### PR TITLE
Client server handle application services

### DIFF
--- a/packages/matrix-client-server/src/__testData__/matrixDbTestConf.json
+++ b/packages/matrix-client-server/src/__testData__/matrixDbTestConf.json
@@ -16,5 +16,22 @@
   "userdb_engine": "sqlite",
   "userdb_host": "./src/__testData__/test.db",
   "matrix_database_engine": "sqlite",
-  "matrix_database_host": "./src/__testData__/testMatrix.db"
+  "matrix_database_host": "./src/__testData__/testMatrix.db",
+  "application_services": [
+    {
+      "id": "test",
+      "hs_token": "hsTokenTestwdakZQunWWNe3DZitAerw9aNqJ2a6HVp0sJtg7qTJWXcHnBjgN0NL",
+      "as_token": "as_token_test",
+      "url": "http://localhost:3000",
+      "sender_localpart": "sender_localpart_test",
+      "namespaces": {
+        "users": [
+          {
+            "exclusive": false,
+            "regex": "@_irc_bridge_.*"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/matrix-client-server/src/__testData__/registerConf.json
+++ b/packages/matrix-client-server/src/__testData__/registerConf.json
@@ -46,5 +46,22 @@
         }
       }
     }
-  }
+  },
+  "application_services": [
+    {
+      "id": "test",
+      "hs_token": "hsTokenTestwdakZQunWWNe3DZitAerw9aNqJ2a6HVp0sJtg7qTJWXcHnBjgN0NL",
+      "as_token": "as_token_test",
+      "url": "http://localhost:3000",
+      "sender_localpart": "sender_localpart_test",
+      "namespaces": {
+        "users": [
+          {
+            "exclusive": false,
+            "regex": "@_irc_bridge_.*"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/matrix-client-server/src/account/whoami.ts
+++ b/packages/matrix-client-server/src/account/whoami.ts
@@ -13,17 +13,6 @@ const whoami = (clientServer: MatrixClientServer): expressAppHandler => {
       clientServer.matrixDb
         .get('users', ['name', 'is_guest'], { name: data.sub })
         .then((rows) => {
-          if (rows.length === 0) {
-            // istanbul ignore next // TODO : Test this after implementing /register endpoint
-            send(
-              res,
-              403,
-              errMsg(
-                'forbidden',
-                'The appservice cannot masquerade as the user or has not registered them.'
-              )
-            )
-          }
           const isGuest = rows[0].is_guest !== 0
           const body: responseBody = { user_id: data.sub, is_guest: isGuest }
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/matrix-client-server/src/account/whoami.ts
+++ b/packages/matrix-client-server/src/account/whoami.ts
@@ -13,6 +13,10 @@ const whoami = (clientServer: MatrixClientServer): expressAppHandler => {
       clientServer.matrixDb
         .get('users', ['name', 'is_guest'], { name: data.sub })
         .then((rows) => {
+          if (rows.length === 0) {
+            // istanbul ignore next // might remove the istanbul ignore if an endpoint other than /register modifies the users table
+            send(res, 403, errMsg('invalidUsername'))
+          }
           const isGuest = rows[0].is_guest !== 0
           const body: responseBody = { user_id: data.sub, is_guest: isGuest }
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/matrix-client-server/src/config.json
+++ b/packages/matrix-client-server/src/config.json
@@ -82,5 +82,22 @@
         }
       }
     }
-  }
+  },
+  "application_services": [
+    {
+      "id": "test",
+      "hs_token": "hsTokenTestwdakZQunWWNe3DZitAerw9aNqJ2a6HVp0sJtg7qTJWXcHnBjgN0NL",
+      "as_token": "as_token_test",
+      "url": "http://localhost:3000",
+      "sender_localpart": "sender_localpart_test",
+      "namespaces": {
+        "users": [
+          {
+            "exclusive": false,
+            "regex": "@_irc_bridge_.*"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -303,6 +303,7 @@ describe('Use configuration file', () => {
       }
     })
     describe('/_matrix/client/v3/account/whoami', () => {
+      let asToken: string
       it('should reject missing token (', async () => {
         const response = await request(app)
           .get('/_matrix/client/v3/account/whoami')
@@ -344,6 +345,39 @@ describe('Use configuration file', () => {
           .set('Authorization', `Bearer ${validToken}`)
           .set('Accept', 'application/json')
         expect(response.statusCode).toBe(200)
+      })
+      it('should accept a valid appservice authentication', async () => {
+        asToken = conf.application_services[0].as_token
+        const registerResponse = await request(app)
+          .post('/_matrix/client/v3/register')
+          .query({ kind: 'user' })
+          .send({
+            auth: {
+              type: 'm.login.application_service',
+              username: '_irc_bridge_'
+            },
+            username: '_irc_bridge_'
+          })
+          .set('Authorization', `Bearer ${asToken}`)
+          .set('User-Agent', 'curl/7.31.0-DEV')
+          .set('X-Forwarded-For', '127.10.00')
+          .set('Accept', 'application/json')
+        expect(registerResponse.statusCode).toBe(200)
+        const response = await request(app)
+          .get('/_matrix/client/v3/account/whoami')
+          .query({ user_id: '@_irc_bridge_:matrix.org' })
+          .set('Authorization', `Bearer ${asToken}`)
+          .set('Accept', 'application/json')
+        expect(response.statusCode).toBe(200)
+        expect(response.body.user_id).toBe('@_irc_bridge_:matrix.org')
+      })
+      it('should refuse an appservice authentication with a user_id not registered in the appservice', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/account/whoami')
+          .query({ user_id: '@testuser:example.com' })
+          .set('Authorization', `Bearer ${asToken}`)
+          .set('Accept', 'application/json')
+        expect(response.statusCode).toBe(403)
       })
     })
 
@@ -484,6 +518,54 @@ describe('Use configuration file', () => {
           expect(response.statusCode).toBe(401)
           expect(response.body).toHaveProperty('error')
           expect(response.body).toHaveProperty('errcode')
+        })
+        it('should refuse autenticating an appservice without a token', async () => {
+          const response = await request(app)
+            .post('/_matrix/client/v3/register')
+            .set('User-Agent', 'curl/7.31.0-DEV')
+            .query({ kind: 'user' })
+            .send({
+              auth: {
+                type: 'm.login.application_service',
+                username: '_irc_bridge_'
+              }
+            })
+          expect(response.statusCode).toBe(401)
+          expect(response.body).toHaveProperty('error')
+          expect(response.body).toHaveProperty('errcode', 'M_MISSING_TOKEN')
+        })
+        it('should refuse authenticating an appservice with the wrong token', async () => {
+          const response = await request(app)
+            .post('/_matrix/client/v3/register')
+            .set('User-Agent', 'curl/7.31.0-DEV')
+            .set('Authorization', `Bearer wrongToken`)
+            .query({ kind: 'user' })
+            .send({
+              auth: {
+                type: 'm.login.application_service',
+                username: '_irc_bridge_'
+              }
+            })
+          expect(response.statusCode).toBe(401)
+          expect(response.body).toHaveProperty('error')
+          expect(response.body).toHaveProperty('errcode', 'M_UNKNOWN_TOKEN')
+        })
+        it('should refuse authenticating an appservice with a username it has not registered', async () => {
+          const asToken = conf.application_services[0].as_token
+          const response = await request(app)
+            .post('/_matrix/client/v3/register')
+            .set('User-Agent', 'curl/7.31.0-DEV')
+            .set('Authorization', `Bearer ${asToken}`)
+            .query({ kind: 'user' })
+            .send({
+              auth: {
+                type: 'm.login.application_service',
+                username: 'invalidUser'
+              }
+            })
+          expect(response.statusCode).toBe(401)
+          expect(response.body).toHaveProperty('error')
+          expect(response.body).toHaveProperty('errcode', 'M_INVALID_USERNAME')
         })
         it('should validate an authentication after the user has accepted the terms', async () => {
           const response = await request(app)
@@ -654,6 +736,19 @@ describe('Use configuration file', () => {
         expect(response.body).toHaveProperty('error')
         expect(response.body).toHaveProperty('errcode', 'M_USER_IN_USE')
       })
+      it('should refuse a request without User Agent', async () => {
+        const response = await request(app)
+          .post('/_matrix/client/v3/register')
+          .set('X-Forwarded-For', '203.0.113.195')
+          .query({ kind: 'user' })
+          .send({
+            username: 'newuser',
+            auth: { type: 'm.login.dummy', session: randomString(20) }
+          })
+        expect(response.statusCode).toBe(400)
+        expect(response.body).toHaveProperty('error')
+        expect(response.body).toHaveProperty('errcode', 'M_MISSING_PARAMS')
+      })
     })
     describe('/_matrix/client/v3/user/{userId}/account_data/{type}', () => {
       it('should reject invalid userId', async () => {
@@ -812,7 +907,6 @@ describe('Use configuration file', () => {
           )
           .set('Authorization', `Bearer ${validToken}`)
           .set('Accept', 'application/json')
-        console.log(response.body)
         expect(response.statusCode).toBe(404)
         expect(response.body).toHaveProperty('errcode', 'M_NOT_FOUND')
       })
@@ -823,7 +917,6 @@ describe('Use configuration file', () => {
           )
           .set('Authorization', `Bearer ${validToken}`)
           .set('Accept', 'application/json')
-        console.log(response.body)
         expect(response.statusCode).toBe(403)
         expect(response.body).toHaveProperty('errcode', 'M_FORBIDDEN')
       })
@@ -841,7 +934,6 @@ describe('Use configuration file', () => {
           )
           .set('Authorization', `Bearer ${validToken}`)
           .set('Accept', 'application/json')
-        console.log(response.body)
         expect(response.statusCode).toBe(200)
         expect(response.body['m.room.message']).toBe('test content')
       })

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -379,6 +379,14 @@ describe('Use configuration file', () => {
           .set('Accept', 'application/json')
         expect(response.statusCode).toBe(403)
       })
+      it('should ensure a normal user cannot access the account of an appservice', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/account/whoami')
+          .query({ user_id: '@_irc_bridge_:matrix.org' })
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+        expect(response.body).toHaveProperty('user_id', '@testuser:example.com') // not _irc_bridge_ (appservice account)
+      })
     })
 
     describe('/_matrix/client/v3/admin/whois', () => {
@@ -754,19 +762,21 @@ describe('Use configuration file', () => {
         expect(response.body).toHaveProperty('error')
         expect(response.body).toHaveProperty('errcode', 'M_USER_IN_USE')
       })
-      it('should refuse a request without User Agent', async () => {
-        const response = await request(app)
-          .post('/_matrix/client/v3/register')
-          .set('X-Forwarded-For', '203.0.113.195')
-          .query({ kind: 'user' })
-          .send({
-            username: 'newuser',
-            auth: { type: 'm.login.dummy', session: randomString(20) }
-          })
-        expect(response.statusCode).toBe(400)
-        expect(response.body).toHaveProperty('error')
-        expect(response.body).toHaveProperty('errcode', 'M_MISSING_PARAMS')
-      })
+      // The following test might be necessary but spec is unclear so it is commented out for now
+
+      // it('should refuse a request without User Agent', async () => {
+      //   const response = await request(app)
+      //     .post('/_matrix/client/v3/register')
+      //     .set('X-Forwarded-For', '203.0.113.195')
+      //     .query({ kind: 'user' })
+      //     .send({
+      //       username: 'newuser',
+      //       auth: { type: 'm.login.dummy', session: randomString(20) }
+      //     })
+      //   expect(response.statusCode).toBe(400)
+      //   expect(response.body).toHaveProperty('error')
+      //   expect(response.body).toHaveProperty('errcode', 'M_MISSING_PARAMS')
+      // })
     })
     describe('/_matrix/client/v3/user/{userId}/account_data/{type}', () => {
       it('should reject invalid userId', async () => {

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -550,7 +550,7 @@ describe('Use configuration file', () => {
           expect(response.body).toHaveProperty('error')
           expect(response.body).toHaveProperty('errcode', 'M_UNKNOWN_TOKEN')
         })
-        it('should refuse authenticating an appservice with a username it has not registered', async () => {
+        it('should refuse authenticating an appservice with a username that is too long', async () => {
           const asToken = conf.application_services[0].as_token
           const response = await request(app)
             .post('/_matrix/client/v3/register')
@@ -561,6 +561,23 @@ describe('Use configuration file', () => {
               auth: {
                 type: 'm.login.application_service',
                 username: 'invalidUser'
+              }
+            })
+          expect(response.statusCode).toBe(401)
+          expect(response.body).toHaveProperty('error')
+          expect(response.body).toHaveProperty('errcode', 'M_INVALID_USERNAME')
+        })
+        it('should refuse authenticating an appservice with a username it has not registered', async () => {
+          const asToken = conf.application_services[0].as_token
+          const response = await request(app)
+            .post('/_matrix/client/v3/register')
+            .set('User-Agent', 'curl/7.31.0-DEV')
+            .set('Authorization', `Bearer ${asToken}`)
+            .query({ kind: 'user' })
+            .send({
+              auth: {
+                type: 'm.login.application_service',
+                username: 'user'
               }
             })
           expect(response.statusCode).toBe(401)
@@ -692,6 +709,7 @@ describe('Use configuration file', () => {
             },
             username: '@localhost:example.com'
           })
+        console.log(response.body)
         expect(response.statusCode).toBe(400)
         expect(response.body).toHaveProperty('error')
         expect(response.body).toHaveProperty('errcode', 'M_INVALID_USERNAME')

--- a/packages/matrix-client-server/src/index.ts
+++ b/packages/matrix-client-server/src/index.ts
@@ -90,7 +90,7 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
       serverConf,
       this.logger
     )
-    this.authenticate = Authenticate(this.matrixDb, this.logger)
+    this.authenticate = Authenticate(this.matrixDb, this.logger, this.conf)
     this.ready = new Promise((resolve, reject) => {
       this.ready
         .then(() => {

--- a/packages/matrix-client-server/src/register.ts
+++ b/packages/matrix-client-server/src/register.ts
@@ -5,51 +5,106 @@ import {
   errMsg,
   type expressAppHandler,
   send,
-  epoch
+  epoch,
+  toMatrixId
 } from '@twake/utils'
 import { type AuthenticationData } from './types'
 import { randomString } from '@twake/crypto'
 import type MatrixClientServer from '.'
+import { type DbGetResult } from '@twake/matrix-identity-server'
+import type { ServerResponse } from 'http'
+import type e from 'express'
 
-interface parameters {
+interface Parameters {
   kind: 'guest' | 'user'
   guest_access_token?: string // If a guest wants to upgrade his account, from spec : https://spec.matrix.org/v1.11/client-server-api/#guest-access
 }
 
 interface registerRequestBody {
-  auth: AuthenticationData
-  device_id: string
-  inhibit_login: boolean
-  initial_device_display_name: string
-  password: string
-  refresh_token: boolean
-  username: string
+  auth?: AuthenticationData
+  device_id?: string
+  inhibit_login?: boolean
+  initial_device_display_name?: string
+  password?: string
+  refresh_token?: boolean
+  username?: string
 }
 
 const localPartRe = /^[a-z0-9._=/+-]+$/
 
+const createUser = (
+  otherPromise: Promise<DbGetResult>,
+  clientServer: MatrixClientServer,
+  userId: string,
+  accessToken: string,
+  deviceId: string,
+  ip: string,
+  userAgent: string,
+  body: registerRequestBody,
+  res: e.Response | ServerResponse,
+  kind: string
+): void => {
+  const userPromise = clientServer.matrixDb.insert('users', {
+    name: userId,
+    creation_ts: epoch(),
+    is_guest: kind === 'guest' ? 1 : 0,
+    user_type: kind,
+    shadow_banned: 0
+  })
+  const userIpPromise = clientServer.matrixDb.insert('user_ips', {
+    user_id: userId,
+    access_token: accessToken,
+    device_id: deviceId,
+    ip,
+    user_agent: userAgent,
+    last_seen: epoch()
+  })
+  Promise.all([otherPromise, userPromise, userIpPromise])
+    .then(() => {
+      if (body.inhibit_login) {
+        send(res, 200, { user_id: userId })
+      } else {
+        send(res, 200, {
+          access_token: accessToken,
+          device_id: deviceId,
+          user_id: userId,
+          expires_in_ms: 60000 // Arbitrary value, should probably be defined in the server config
+        })
+      }
+    })
+    .catch((e) => {
+      // istanbul ignore next
+      clientServer.logger.error('Error while registering a user', e)
+      // istanbul ignore next
+      send(res, 500, {
+        error: 'Error while registering a user'
+      })
+    })
+}
+
 const register = (clientServer: MatrixClientServer): expressAppHandler => {
   return (req, res) => {
     // @ts-expect-error req.query exists
-    const prms = req.query as parameters
-
-    if (prms.kind === 'user') {
+    const parameters = req.query as Parameters
+    // @ts-expect-error req.headers exists
+    const ip = req.headers['x-forwarded-for'] ?? req.ip
+    const accessToken = randomString(64)
+    if (!req.headers['user-agent']) {
+      clientServer.logger.error('Missing User-Agent header')
+      send(res, 400, errMsg('missingParams'))
+      return
+    }
+    const userAgent = req.headers['user-agent']
+    if (parameters.kind === 'user') {
       clientServer.uiauthenticate(req, res, (obj) => {
         const body = obj as unknown as registerRequestBody
-        // @ts-expect-error req.headers exists
-        const ip = req.headers['x-forwarded-for'] ?? req.ip
-        const accessToken = randomString(64)
-        const userAgent = req.headers['user-agent']
-
-        const deviceId = body.device_id ? body.device_id : randomString(20) // Length chosen arbitrarily
-        const username = body.username ? body.username : randomString(9) // Length chosen to match the localpart restrictions for a Matrix userId
-        const userId = `@${username}:${clientServer.conf.server_name}`
-
+        const deviceId = body.device_id ?? randomString(20) // Length chosen arbitrarily
+        const username = body.username ?? randomString(9) // Length chosen to match the localpart restrictions for a Matrix userId
+        const userId = toMatrixId(username, clientServer.conf.server_name)
         if (!localPartRe.test(username)) {
           send(res, 400, errMsg('invalidUsername'))
           return
         }
-
         clientServer.matrixDb
           .get('users', ['name'], {
             name: userId
@@ -63,32 +118,12 @@ const register = (clientServer: MatrixClientServer): expressAppHandler => {
                   device_id: deviceId
                 })
                 .then((deviceRows) => {
-                  const userPromise = clientServer.matrixDb.insert('users', {
-                    name: userId,
-                    creation_ts: epoch(),
-                    is_guest: 0,
-                    user_type: 'user',
-                    shadow_banned: 0
-                  })
-                  const userIpPromise = clientServer.matrixDb.insert(
-                    'user_ips',
-                    {
-                      user_id: userId,
-                      access_token: accessToken,
-                      device_id: deviceId,
-                      ip,
-                      user_agent: userAgent as string,
-                      last_seen: epoch()
-                    }
-                  )
                   let initial_device_display_name
                   if (deviceRows.length > 0) {
                     // TODO : Refresh access tokens using refresh tokens and invalidate the previous access_token associated with the device
                   } else {
                     initial_device_display_name =
-                      body.initial_device_display_name
-                        ? body.initial_device_display_name
-                        : randomString(20) // Length chosen arbitrarily
+                      body.initial_device_display_name ?? randomString(20) // Length chosen arbitrarily
                     const newDevicePromise = clientServer.matrixDb.insert(
                       'devices',
                       {
@@ -97,33 +132,21 @@ const register = (clientServer: MatrixClientServer): expressAppHandler => {
                         display_name: initial_device_display_name,
                         last_seen: epoch(),
                         ip,
-                        user_agent: userAgent as string
+                        user_agent: userAgent
                       }
                     )
-                    Promise.all([newDevicePromise, userPromise, userIpPromise])
-                      .then(() => {
-                        if (body.inhibit_login) {
-                          send(res, 200, { user_id: userId })
-                        } else {
-                          send(res, 200, {
-                            access_token: accessToken,
-                            device_id: deviceId,
-                            user_id: userId,
-                            expires_in_ms: 60000 // Arbitrary value, should probably be defined in the server config
-                          })
-                        }
-                      })
-                      .catch((e) => {
-                        // istanbul ignore next
-                        clientServer.logger.error(
-                          'Error while registering a user',
-                          e
-                        )
-                        // istanbul ignore next
-                        send(res, 500, {
-                          error: 'Error while registering a user'
-                        })
-                      })
+                    createUser(
+                      newDevicePromise,
+                      clientServer,
+                      userId,
+                      accessToken,
+                      deviceId,
+                      ip,
+                      userAgent,
+                      body,
+                      res,
+                      'user'
+                    )
                   }
                 })
                 .catch((e) => {
@@ -150,65 +173,32 @@ const register = (clientServer: MatrixClientServer): expressAppHandler => {
     } else {
       jsonContent(req, res, clientServer.logger, (obj) => {
         const body = obj as unknown as registerRequestBody
-        // @ts-expect-error req.headers exists
-        const ip = req.headers['x-forwarded-for'] ?? req.ip
-        const accessToken = randomString(64)
-        const userAgent = req.headers['user-agent']
-
         const deviceId = randomString(20) // Length chosen arbitrarily
         const username = randomString(9) // Length chosen to match the localpart restrictions for a Matrix userId
-
         const initial_device_display_name = body.initial_device_display_name
           ? body.initial_device_display_name
           : randomString(20) // Length chosen arbitrarily
 
         const devicePromise = clientServer.matrixDb.insert('devices', {
-          user_id: `@${username}:${clientServer.conf.server_name}`,
+          user_id: toMatrixId(username, clientServer.conf.server_name),
           device_id: deviceId,
           display_name: initial_device_display_name,
           last_seen: epoch(),
           ip,
-          user_agent: userAgent as string
+          user_agent: userAgent
         })
-
-        const userPromise = clientServer.matrixDb.insert('users', {
-          name: `@${username}:${clientServer.conf.server_name}`,
-          creation_ts: epoch(),
-          is_guest: 1,
-          user_type: 'guest',
-          shadow_banned: 0
-        })
-
-        const userIpPromise = clientServer.matrixDb.insert('user_ips', {
-          user_id: `@${username}:${clientServer.conf.server_name}`,
-          access_token: accessToken,
-          device_id: deviceId,
+        createUser(
+          devicePromise,
+          clientServer,
+          toMatrixId(username, clientServer.conf.server_name),
+          accessToken,
+          deviceId,
           ip,
-          user_agent: userAgent as string,
-          last_seen: epoch()
-        })
-
-        Promise.all([devicePromise, userPromise, userIpPromise])
-          .then(() => {
-            if (body.inhibit_login) {
-              send(res, 200, {
-                user_id: `@${username}:${clientServer.conf.server_name}`
-              })
-            } else {
-              send(res, 200, {
-                access_token: accessToken,
-                device_id: deviceId,
-                user_id: `@${username}:${clientServer.conf.server_name}`,
-                expires_in_ms: 60000 // Arbitrary value, should probably be defined in the server config
-              })
-            }
-          })
-          .catch((e) => {
-            // istanbul ignore next
-            clientServer.logger.error('Error while registering a guest', e)
-            // istanbul ignore next
-            send(res, 500, { error: 'Error while registering a guest' })
-          })
+          userAgent,
+          body,
+          res,
+          'guest'
+        )
       })
     }
   }

--- a/packages/matrix-client-server/src/register.ts
+++ b/packages/matrix-client-server/src/register.ts
@@ -87,12 +87,10 @@ const register = (clientServer: MatrixClientServer): expressAppHandler => {
     // @ts-expect-error req.headers exists
     const ip = req.headers['x-forwarded-for'] ?? req.ip
     const accessToken = randomString(64)
-    if (!req.headers['user-agent']) {
-      clientServer.logger.error('Missing User-Agent header')
-      send(res, 400, errMsg('missingParams'))
-      return
+    let userAgent = 'undefined'
+    if (req.headers['user-agent']) {
+      userAgent = req.headers['user-agent']
     }
-    const userAgent = req.headers['user-agent']
     if (parameters.kind === 'user') {
       clientServer.uiauthenticate(req, res, (obj) => {
         const body = obj as unknown as registerRequestBody

--- a/packages/matrix-client-server/src/register.ts
+++ b/packages/matrix-client-server/src/register.ts
@@ -30,8 +30,6 @@ interface registerRequestBody {
   username?: string
 }
 
-const localPartRe = /^[a-z0-9._=/+-]+$/
-
 const createUser = (
   otherPromise: Promise<DbGetResult>,
   clientServer: MatrixClientServer,
@@ -101,10 +99,6 @@ const register = (clientServer: MatrixClientServer): expressAppHandler => {
         const deviceId = body.device_id ?? randomString(20) // Length chosen arbitrarily
         const username = body.username ?? randomString(9) // Length chosen to match the localpart restrictions for a Matrix userId
         const userId = toMatrixId(username, clientServer.conf.server_name)
-        if (!localPartRe.test(username)) {
-          send(res, 400, errMsg('invalidUsername'))
-          return
-        }
         clientServer.matrixDb
           .get('users', ['name'], {
             name: userId

--- a/packages/matrix-client-server/src/types.ts
+++ b/packages/matrix-client-server/src/types.ts
@@ -5,10 +5,12 @@ import {
 } from '@twake/matrix-identity-server'
 import { type Policies } from '@twake/matrix-identity-server/dist/terms'
 
+// TODO : Put Policies in types.ts of matrix-identity-server to export it in the @twake/matrix-identity-server module and not in the dist/terms
 export type Config = MIdentityServerConfig & {
   flows: flowContent
   params: Record<string, { policies: Policies }> // For now, only Terms registration gives additional parameters in the request body so the params have this type.
   // If another authentication type returns additional parameters, Policies needs to be changed to a more general type
+  application_services: AppServiceRegistration[]
 }
 
 export type DbGetResult = Array<
@@ -16,7 +18,7 @@ export type DbGetResult = Array<
 >
 
 export interface ClientEvent {
-  content: { [key: string]: any }
+  content: Record<string, any>
   event_id: string
   origin_server_ts: number
   room_id: string
@@ -32,7 +34,7 @@ export interface EventContent {
   join_authorised_via_users_server?: boolean
   membership: string
   reason?: string
-  third_party_invite?: { [key: string]: any }
+  third_party_invite?: Record<string, any>
 }
 
 export interface EventFilter {
@@ -81,19 +83,9 @@ export interface signed {
 export interface UnsignedData {
   age?: number
   membership?: string
-  prev_content?: { [key: string]: any }
+  prev_content?: Record<string, any>
   redacted_because?: ClientEvent
   transaction_id?: string
-}
-
-export interface LocalMediaRepository {
-  media_id: string
-  media_length: string
-  user_id: string
-}
-
-export interface MatrixUser {
-  name: string
 }
 
 export interface UserQuota {
@@ -139,6 +131,7 @@ export type AuthenticationTypes =
   | 'm.login.dummy'
   | 'm.login.registration_token'
   | 'm.login.terms'
+  | 'm.login.application_service'
 
 interface PasswordAuth {
   type: 'm.login.password'
@@ -194,6 +187,11 @@ interface TermsAuth {
   session: string
 }
 
+interface ApplicationServiceAuth {
+  type: 'm.login.application_service'
+  username: string
+}
+
 export type AuthenticationData =
   | PasswordAuth
   | EmailAuth
@@ -202,9 +200,33 @@ export type AuthenticationData =
   | DummyAuth
   | TokenAuth
   | TermsAuth
+  | ApplicationServiceAuth
 
 export type flowContent = stagesContent[]
 
 interface stagesContent {
   stages: AuthenticationTypes[]
+}
+
+// https://spec.matrix.org/v1.11/application-service-api/#registration
+export interface AppServiceRegistration {
+  as_token: string
+  hs_token: string
+  id: string
+  namespaces: Namespaces
+  protocols?: string[]
+  rate_limited?: boolean
+  sender_localpart: string
+  url: string
+}
+
+interface Namespaces {
+  alias?: Namespace[]
+  rooms?: Namespace[]
+  users?: Namespace[]
+}
+
+interface Namespace {
+  exclusive: boolean
+  regex: string
 }

--- a/packages/matrix-client-server/src/utils/userInteractiveAuthentication.ts
+++ b/packages/matrix-client-server/src/utils/userInteractiveAuthentication.ts
@@ -229,7 +229,7 @@ const UiAuthenticate = (
                       e
                     )
                     // istanbul ignore next
-                    send(res, 400, errMsg('unknown'))
+                    send(res, 400, e)
                   })
               })
               .catch((e) => {
@@ -239,7 +239,7 @@ const UiAuthenticate = (
                   e
                 )
                 // istanbul ignore next
-                send(res, 400, errMsg('unknown'))
+                send(res, 400, e)
               })
           })
           .catch((e) => {
@@ -275,7 +275,7 @@ const UiAuthenticate = (
                   e
                 )
                 // istanbul ignore next
-                send(res, 400, errMsg('unknown'))
+                send(res, 400, e)
               })
           })
       }

--- a/packages/matrix-identity-server/src/cron/changePepper.ts
+++ b/packages/matrix-identity-server/src/cron/changePepper.ts
@@ -9,6 +9,7 @@ import updateHash, { type UpdatableFields } from '../lookup/updateHash'
 import MatrixDB from '../matrixDb'
 import { type Config, type DbGetResult } from '../types'
 import type UserDB from '../userdb'
+import { toMatrixId } from '@twake/utils'
 
 export const dbFieldsToHash = ['mobile', 'mail']
 
@@ -137,7 +138,7 @@ const updateHashes = <T extends string = never>(
                   db,
                   logger,
                   rows.reduce((res, row) => {
-                    res[`@${row.uid as string}:${conf.server_name}`] = {
+                    res[toMatrixId(row.uid as string,conf.server_name)] = {
                       email: row.mail as string,
                       phone: row.mobile as string,
                       active: isMatrixDbAvailable ? (row.active as number) : 1

--- a/packages/matrix-identity-server/src/cron/changePepper.ts
+++ b/packages/matrix-identity-server/src/cron/changePepper.ts
@@ -138,7 +138,7 @@ const updateHashes = <T extends string = never>(
                   db,
                   logger,
                   rows.reduce((res, row) => {
-                    res[toMatrixId(row.uid as string,conf.server_name)] = {
+                    res[toMatrixId(row.uid as string, conf.server_name)] = {
                       email: row.mail as string,
                       phone: row.mobile as string,
                       active: isMatrixDbAvailable ? (row.active as number) : 1

--- a/packages/matrix-identity-server/src/cron/update-federated-identity-hashes.ts
+++ b/packages/matrix-identity-server/src/cron/update-federated-identity-hashes.ts
@@ -9,6 +9,7 @@ import {
 import { type Config } from '../types'
 import type UserDB from '../userdb'
 import { dbFieldsToHash, filter } from './changePepper'
+import { toMatrixId } from '@twake/utils'
 
 interface HashDetails {
   algorithms: string[]
@@ -140,7 +141,7 @@ export default async (
       logger
     )
   ).reduce<UpdatableFields>((acc, row) => {
-    acc[`@${row.uid as string}:${conf.server_name}`] = {
+    acc[toMatrixId(row.uid as string, conf.server_name)] = {
       email: row.mail as string,
       phone: row.mobile as string,
       active: isMatrixDbAvailable ? (row.active as number) : 1

--- a/packages/matrix-identity-server/src/cron/updateUsers.ts
+++ b/packages/matrix-identity-server/src/cron/updateUsers.ts
@@ -88,7 +88,7 @@ const updateUsers = async <T extends string = never>(
   const timestamp = epoch()
   users.forEach((user) => {
     const uid = user.uid as string
-    const matrixAddress = toMatrixId(uid,conf.server_name)
+    const matrixAddress = toMatrixId(uid, conf.server_name)
     const pos = knownUids.indexOf(uid)
     const isMatrixUser = matrixUsers.includes(uid)
     const data = {
@@ -150,7 +150,8 @@ const updateUsers = async <T extends string = never>(
   const seen: Record<string, boolean> = {}
   knownUids.forEach((uid, i) => {
     if (!uids.includes(uid)) {
-      if (!seen[uid]) updates.push(setInactive(toMatrixId(uid,conf.server_name)))
+      if (!seen[uid])
+        updates.push(setInactive(toMatrixId(uid, conf.server_name)))
       seen[uid] = true
     }
   })

--- a/packages/matrix-identity-server/src/cron/updateUsers.ts
+++ b/packages/matrix-identity-server/src/cron/updateUsers.ts
@@ -4,7 +4,7 @@ import updateHash, { type UpdatableFields } from '../lookup/updateHash'
 import MatrixDB from '../matrixDb'
 import { type Config, type DbGetResult } from '../types'
 import type UserDB from '../userdb'
-import { epoch } from '@twake/utils'
+import { epoch, toMatrixId } from '@twake/utils'
 
 /**
  * updateUsers is a cron task that reads users from UserDB and find which of
@@ -88,7 +88,7 @@ const updateUsers = async <T extends string = never>(
   const timestamp = epoch()
   users.forEach((user) => {
     const uid = user.uid as string
-    const matrixAddress = `@${uid}:${conf.server_name}`
+    const matrixAddress = toMatrixId(uid,conf.server_name)
     const pos = knownUids.indexOf(uid)
     const isMatrixUser = matrixUsers.includes(uid)
     const data = {
@@ -150,7 +150,7 @@ const updateUsers = async <T extends string = never>(
   const seen: Record<string, boolean> = {}
   knownUids.forEach((uid, i) => {
     if (!uids.includes(uid)) {
-      if (!seen[uid]) updates.push(setInactive(`@${uid}:${conf.server_name}`))
+      if (!seen[uid]) updates.push(setInactive(toMatrixId(uid,conf.server_name)))
       seen[uid] = true
     }
   })

--- a/packages/tom-server/src/application-server/controllers/room.ts
+++ b/packages/tom-server/src/application-server/controllers/room.ts
@@ -11,6 +11,7 @@ import type TwakeApplicationServer from '..'
 import type TwakeServer from '../..'
 import { type TwakeDB, allMatrixErrorCodes } from '../../types'
 import { TwakeRoom } from '../models/room'
+import { toMatrixId } from '@twake/utils'
 const { intersection } = lodash
 
 const domainRe =
@@ -35,7 +36,10 @@ export const createRoom = (
       if (!hostnameRe.test(twakeServer.conf.matrix_server)) {
         throw Error('Bad matrix_server_name')
       }
-      const appServiceMatrixId = `@${appServer.appServiceRegistration.senderLocalpart}:${twakeServer.conf.server_name}`
+      const appServiceMatrixId = toMatrixId(
+        appServer.appServiceRegistration.senderLocalpart,
+        twakeServer.conf.server_name
+      )
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const roomAliasName = `_twake_${req.body.aliasName}`
       const rooms = await twakeServer.matrixDb.get('room_aliases', undefined, {
@@ -132,11 +136,11 @@ export const createRoom = (
         twakeServer.matrixDb.getAll('users', ['name'])
       ])
 
-      const ldapUsersIds = ldapUsers.map(
-        (user) =>
-          `@${user[twakeServer.conf.ldap_uid_field as string] as string}:${
-            twakeServer.conf.server_name
-          }`
+      const ldapUsersIds = ldapUsers.map((user) =>
+        toMatrixId(
+          user[twakeServer.conf.ldap_uid_field as string] as string,
+          twakeServer.conf.server_name
+        )
       )
       const matrixUsersIds = matrixUsers.map((user) => user.name as string)
 

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -1,5 +1,5 @@
 import { type TwakeLogger } from '@twake/logger'
-import { errMsg, send } from '@twake/utils'
+import { errMsg, send, toMatrixId } from '@twake/utils'
 import { type Response } from 'express'
 import type http from 'http'
 import type TwakeIdentityServer from '..'
@@ -70,7 +70,7 @@ const _search = (
             const end = start + (data.limit ?? 30)
             rows = rows.slice(start, end)
             const mUid = rows.map((v) => {
-              return `@${v.uid as string}:${idServer.conf.server_name}`
+              return toMatrixId(v.uid as string, idServer.conf.server_name)
             })
             /**
              * For the record, this can be replaced by a call to
@@ -92,9 +92,7 @@ const _search = (
                   ] = true
                 })
                 rows.forEach((row) => {
-                  row.address = `@${row.uid as string}:${
-                    idServer.conf.server_name
-                  }`
+                  row.address = toMatrixId(row.uid as string, idServer.conf.server_name)
                   if (mUids[row.uid as string]) {
                     matches.push(row)
                   } else {

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -92,7 +92,10 @@ const _search = (
                   ] = true
                 })
                 rows.forEach((row) => {
-                  row.address = toMatrixId(row.uid as string, idServer.conf.server_name)
+                  row.address = toMatrixId(
+                    row.uid as string,
+                    idServer.conf.server_name
+                  )
                   if (mUids[row.uid as string]) {
                     matches.push(row)
                   } else {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,14 +19,19 @@
     {
       "name": "Xavier Guimard",
       "email": "yadd@debian.org"
-    }, {
+    },
+    {
       "name": "Mathias Perez",
       "email": "mathias.perez.2022@polytechnique.org"
-    },{
+    },
+    {
       "name": "Hippolyte Wallaert",
       "email": "hippolyte.wallaert.2022@polytechnique.org"
+    },
+    {
+      "name": "Amine Chraibi",
+      "email": "amine.chraibi.2022@polytechnique.org"
     }
-
   ],
   "type": "module",
   "exports": {

--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -1,5 +1,3 @@
 import config from '../../rollup-template.js'
 
-export default config(['express', "@twake/logger"])
-
-
+export default config(['express', '@twake/logger'])

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -6,7 +6,8 @@ import {
   jsonContent,
   validateParameters,
   epoch,
-  toMatrixId
+  toMatrixId,
+  errMsg
 } from './index'
 import { type TwakeLogger } from '@twake/logger'
 
@@ -181,9 +182,9 @@ describe('Utility Functions', () => {
       expect(toMatrixId('localpart', 'server')).toBe('@localpart:server')
     })
     it('should throw an error for an invalid localpart', () => {
-      expect(() => toMatrixId('invalid localpart', 'example.com')).toThrow(
-        'Invalid localpart'
-      )
+      expect(() =>
+        toMatrixId('invalid localpart', 'example.com')
+      ).toThrowError()
     })
   })
 })

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -6,8 +6,7 @@ import {
   jsonContent,
   validateParameters,
   epoch,
-  toMatrixId,
-  errMsg
+  toMatrixId
 } from './index'
 import { type TwakeLogger } from '@twake/logger'
 

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -1,7 +1,13 @@
 import { type Request, type Response } from 'express'
 import type http from 'http'
 import querystring from 'querystring'
-import { send, jsonContent, validateParameters, epoch } from './index'
+import {
+  send,
+  jsonContent,
+  validateParameters,
+  epoch,
+  toMatrixId
+} from './index'
 import { type TwakeLogger } from '@twake/logger'
 
 describe('Utility Functions', () => {
@@ -167,6 +173,17 @@ describe('Utility Functions', () => {
       jest.spyOn(Date, 'now').mockReturnValue(now)
 
       expect(epoch()).toBe(now)
+    })
+  })
+
+  describe('toMatrixId', () => {
+    it('should return a Matrix ID', () => {
+      expect(toMatrixId('localpart', 'server')).toBe('@localpart:server')
+    })
+    it('should throw an error for an invalid localpart', () => {
+      expect(() => toMatrixId('invalid localpart', 'example.com')).toThrow(
+        'Invalid localpart'
+      )
     })
   })
 })

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -126,7 +126,8 @@ export const epoch = (): number => {
 export const toMatrixId = (localpart: string, serverName: string): string => {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!localpart.match(/^[a-z0-9_\-\.=/]+$/)) {
-    throw new Error('Invalid localpart')
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
+    throw errMsg('invalidUsername')
   }
   return `@${localpart}:${serverName}`
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -122,3 +122,11 @@ export const validateParameters: validateParametersType = (
 export const epoch = (): number => {
   return Date.now()
 }
+
+export const toMatrixId = (localpart: string, serverName: string): string => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (!localpart.match(/^[a-z0-9_\-\.=/]+$/)) {
+    throw new Error('Invalid localpart')
+  }
+  return `@${localpart}:${serverName}`
+}


### PR DESCRIPTION
Added Application Service handling for registration and authentication : https://spec.matrix.org/v1.11/application-service-api/#server-admin-style-permissions 
https://spec.matrix.org/v1.11/application-service-api/#registration

Added method in utils package to convert localpart to matrixId format. Refactored the code for register but is still not finalized. Finalized /whoami to comply with spec. 