### PR TITLE
feat : added endpoints to get/put a user's presence state

### DIFF
--- a/packages/matrix-client-server/src/__testData__/buildUserDB.ts
+++ b/packages/matrix-client-server/src/__testData__/buildUserDB.ts
@@ -36,6 +36,7 @@ const matrixDbQueries = [
   'CREATE TABLE IF NOT EXISTS room_aliases( room_alias TEXT NOT NULL, room_id TEXT NOT NULL, creator TEXT, UNIQUE (room_alias) )',
   'CREATE TABLE IF NOT EXISTS rooms( room_id TEXT PRIMARY KEY NOT NULL, is_public BOOL, creator TEXT , room_version TEXT, has_auth_chain_index BOOLEAN)',
   'CREATE TABLE IF NOT EXISTS room_tags( user_id TEXT NOT NULL, room_id TEXT NOT NULL, tag TEXT NOT NULL, content TEXT NOT NULL, CONSTRAINT room_tag_uniqueness UNIQUE (user_id, room_id, tag) )',
+  'CREATE TABLE IF NOT EXISTS presence (user_id TEXT NOT NULL, state VARCHAR(20), status_msg TEXT, mtime BIGINT, UNIQUE (user_id))'
 ]
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/matrix-client-server/src/__testData__/presenceConf.json
+++ b/packages/matrix-client-server/src/__testData__/presenceConf.json
@@ -1,0 +1,50 @@
+{
+  "cron_service": false,
+  "database_engine": "sqlite",
+  "database_host": "./src/__testData__/testPresence.db",
+  "matrix_database_engine": "sqlite",
+  "matrix_database_host": "./src/__testData__/testMatrixPresence.db",
+  "database_vacuum_delay": 7200,
+  "is_federated_identity_service": false,
+  "key_delay": 3600,
+  "keys_depth": 5,
+  "mail_link_delay": 7200,
+  "rate_limiting_window": 10000,
+  "server_name": "matrix.org",
+  "smtp_sender": "yadd@debian.org",
+  "smtp_server": "localhost",
+  "template_dir": "./templates",
+  "userdb_engine": "sqlite",
+  "userdb_host": "./src/__testData__/testPresence.db",
+  "flows": [
+    {
+      "stages": ["m.login.dummy"]
+    },
+    {
+      "stages": ["m.login.password", "m.login.registration_token"]
+    },
+    {
+      "stages": ["m.login.terms", "m.login.password"]
+    },
+    {
+      "stages": ["m.login.registration_token", "m.login.dummy"]
+    }
+  ],
+  "params": {
+    "m.login.terms": {
+      "policies": {
+        "terms_of_service": {
+          "version": "1.2",
+          "en": {
+            "name": "Terms of Service",
+            "url": "https://example.org/somewhere/terms-1.2-en.html"
+          },
+          "fr": {
+            "name": "Conditions d'utilisation",
+            "url": "https://example.org/somewhere/terms-1.2-fr.html"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/matrix-client-server/src/index.ts
+++ b/packages/matrix-client-server/src/index.ts
@@ -48,6 +48,8 @@ import {
 } from './rooms/room_information/room_visibilty'
 import { getRoomAliases } from './rooms/room_information/room_aliases'
 import getTimestampToEvent from './rooms/roomId/getTimestampToEvent'
+import getStatus from './presence/getStatus'
+import putStatus from './presence/putStatus'
 
 const tables = {
   ui_auth_sessions: 'session_id TEXT NOT NULL, stage_type TEXT NOT NULL'
@@ -143,7 +145,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
               getRoomVisibility(this),
             '/_matrix/client/v3/rooms/:roomId/aliases': getRoomAliases(this),
             '/_matrix/client/v3/rooms/:roomId/timestamp_to_event':
-              getTimestampToEvent(this)
+              getTimestampToEvent(this),
+            '/_matrix/client/v3/presence/:userId/status': getStatus(this)
           }
           this.api.post = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -163,7 +166,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/joined_rooms': badMethod,
             '/_matrix/client/v3/directory/list/room/:roomId': badMethod,
             '/_matrix/client/v3/rooms/{roomId}/aliases': badMethod,
-            '/_matrix/client/v3/user/:roomId/timestamp_to_event': badMethod
+            '/_matrix/client/v3/user/:roomId/timestamp_to_event': badMethod,
+            '/_matrix/client/v3/presence/:userId/status': badMethod
           }
           this.api.put = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -189,7 +193,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/directory/list/room/:roomId':
               setRoomVisibility(this),
             '/_matrix/client/v3/rooms/{roomId}/aliases': badMethod,
-            '/_matrix/client/v3/user/:roomId/timestamp_to_event': badMethod
+            '/_matrix/client/v3/user/:roomId/timestamp_to_event': badMethod,
+            '/_matrix/client/v3/presence/:userId/status': putStatus(this)
           }
           this.api.delete = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -205,7 +210,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
               removeUserRoomTag(this),
             '/_matrix/client/v3/joined_rooms': badMethod,
             '/_matrix/client/v3/directory/list/room/:roomId': badMethod,
-            '/_matrix/client/v3/rooms/{roomId}/aliases': badMethod
+            '/_matrix/client/v3/rooms/{roomId}/aliases': badMethod,
+            '/_matrix/client/v3/presence/:userId/status': badMethod
           }
           resolve(true)
         })

--- a/packages/matrix-client-server/src/matrixDb/index.ts
+++ b/packages/matrix-client-server/src/matrixDb/index.ts
@@ -28,6 +28,7 @@ export type Collections =
   | 'registration_tokens'
   | 'account_data'
   | 'devices'
+  | 'presence'
 
 type sqlComparaisonOperator = '=' | '!=' | '>' | '<' | '>=' | '<=' | '<>'
 interface ISQLCondition {

--- a/packages/matrix-client-server/src/presence/getStatus.ts
+++ b/packages/matrix-client-server/src/presence/getStatus.ts
@@ -1,0 +1,50 @@
+import type MatrixClientServer from '..'
+import { errMsg, type expressAppHandler, send, epoch } from '@twake/utils'
+
+const matrixIdRegex = /^@[0-9a-zA-Z._=-]+:[0-9a-zA-Z.-]+$/
+
+// TODO : Handle error 403 where the user isn't allowed to see this user's presence status, may have to do with the "users_to_send_full_presence_to" table in the matrixDb
+const getStatus = (clientServer: MatrixClientServer): expressAppHandler => {
+  return (req, res) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const userId: string = req.params.userId as string
+    if (!matrixIdRegex.test(userId)) {
+      clientServer.logger.warn('Invalid user ID')
+      send(res, 400, errMsg('invalidParam'))
+    } else {
+      clientServer.authenticate(req, res, (data, id) => {
+        clientServer.matrixDb
+          .get('presence', ['state', 'mtime', 'state', 'status_msg'], {
+            user_id: userId
+          })
+          .then((rows) => {
+            if (rows.length === 0) {
+              send(res, 404, {
+                errcode: 'M_UNKNOWN',
+                error:
+                  'There is no presence state for this user. This user may not exist or isn’t exposing presence information to you.'
+              })
+            } else {
+              send(res, 200, {
+                currently_active: rows[0].state === 'online',
+                last_active_ts: epoch() - (rows[0].mtime as number), // TODO : Check if mtime corresponds to last_active_ts, not clear in the spec
+                state: rows[0].state,
+                status_msg: rows[0].status_msg
+              })
+            }
+          })
+          .catch((e) => {
+            // istanbul ignore next
+            clientServer.logger.error(
+              "Error retrieving user's presence state",
+              e
+            )
+            // istanbul ignore next
+            send(res, 500, errMsg('unknown'))
+          })
+      })
+    }
+  }
+}
+export default getStatus

--- a/packages/matrix-client-server/src/presence/getStatus.ts
+++ b/packages/matrix-client-server/src/presence/getStatus.ts
@@ -20,6 +20,7 @@ const getStatus = (clientServer: MatrixClientServer): expressAppHandler => {
           })
           .then((rows) => {
             if (rows.length === 0) {
+              clientServer.logger.error('No presence state for this user')
               send(res, 404, {
                 errcode: 'M_UNKNOWN',
                 error:

--- a/packages/matrix-client-server/src/presence/presence.test.ts
+++ b/packages/matrix-client-server/src/presence/presence.test.ts
@@ -1,0 +1,197 @@
+import fs from 'fs'
+import request from 'supertest'
+import express from 'express'
+import ClientServer from '../index'
+import { buildMatrixDb, buildUserDB } from '../__testData__/buildUserDB'
+import { type Config } from '../types'
+import defaultConfig from '../__testData__/presenceConf.json'
+import { getLogger, type TwakeLogger } from '@twake/logger'
+import { randomString } from '@twake/crypto'
+
+process.env.TWAKE_CLIENT_SERVER_CONF = './src/__testData__/presenceConf.json'
+jest.mock('node-fetch', () => jest.fn())
+
+let conf: Config
+let clientServer: ClientServer
+let app: express.Application
+
+const logger: TwakeLogger = getLogger()
+
+beforeAll((done) => {
+  // @ts-expect-error TS doesn't understand that the config is valid
+  conf = {
+    ...defaultConfig,
+    cron_service: false,
+    database_engine: 'sqlite',
+    base_url: 'http://example.com/',
+    userdb_engine: 'sqlite',
+    matrix_database_engine: 'sqlite'
+  }
+  if (process.env.TEST_PG === 'yes') {
+    conf.database_engine = 'pg'
+    conf.userdb_engine = 'pg'
+    conf.database_host = process.env.PG_HOST ?? 'localhost'
+    conf.database_user = process.env.PG_USER ?? 'twake'
+    conf.database_password = process.env.PG_PASSWORD ?? 'twake'
+    conf.database_name = process.env.PG_DATABASE ?? 'test'
+  }
+  buildUserDB(conf)
+    .then(() => {
+      buildMatrixDb(conf)
+        .then(() => {
+          done()
+        })
+        .catch((e) => {
+          logger.error('Error while building matrix db:', e)
+          done(e)
+        })
+    })
+    .catch((e) => {
+      logger.error('Error while building user db:', e)
+      done(e)
+    })
+})
+
+afterAll(() => {
+  fs.unlinkSync('src/__testData__/testPresence.db')
+  fs.unlinkSync('src/__testData__/testMatrixPresence.db')
+})
+
+describe('Use configuration file', () => {
+  beforeAll((done) => {
+    clientServer = new ClientServer()
+    app = express()
+    clientServer.ready
+      .then(() => {
+        Object.keys(clientServer.api.get).forEach((k) => {
+          app.get(k, clientServer.api.get[k])
+        })
+        Object.keys(clientServer.api.post).forEach((k) => {
+          app.post(k, clientServer.api.post[k])
+        })
+        Object.keys(clientServer.api.put).forEach((k) => {
+          app.put(k, clientServer.api.put[k])
+        })
+        Object.keys(clientServer.api.delete).forEach((k) => {
+          app.delete(k, clientServer.api.delete[k])
+        })
+        done()
+      })
+      .catch((e) => {
+        done(e)
+      })
+  })
+
+  afterAll(() => {
+    clientServer.cleanJobs()
+  })
+
+  let validToken: string
+  let validToken2: string
+  let validToken3: string
+  describe('Endpoints with authentication', () => {
+    beforeAll(async () => {
+      validToken = randomString(64)
+      validToken2 = randomString(64)
+      validToken3 = randomString(64)
+      try {
+        await clientServer.matrixDb.insert('user_ips', {
+          user_id: '@testuser:example.com',
+          device_id: 'testdevice',
+          access_token: validToken,
+          ip: '127.0.0.1',
+          user_agent: 'curl/7.31.0-DEV',
+          last_seen: 1411996332123
+        })
+
+        await clientServer.matrixDb.insert('user_ips', {
+          user_id: '@testuser2:example.com',
+          device_id: 'testdevice2',
+          access_token: validToken2,
+          ip: '137.0.0.1',
+          user_agent: 'curl/7.31.0-DEV',
+          last_seen: 1411996332123
+        })
+
+        await clientServer.matrixDb.insert('user_ips', {
+          user_id: '@testuser3:example.com',
+          device_id: 'testdevice3',
+          access_token: validToken3,
+          ip: '147.0.0.1',
+          user_agent: 'curl/7.31.0-DEV',
+          last_seen: 1411996332123
+        })
+      } catch (e) {
+        logger.error('Error creating tokens for authentification', e)
+      }
+    })
+    describe('/_matrix/client/v3/presence/:userId/status', () => {
+      describe('GET', () => {
+        it('should return the presence state of a user', async () => {
+          await clientServer.matrixDb.insert('presence', {
+            user_id: '@testuser:example.com',
+            state: 'online',
+            status_msg: 'I am online',
+            mtime: Date.now()
+          })
+          const response = await request(app)
+            .get('/_matrix/client/v3/presence/@testuser:example.com/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+          expect(response.statusCode).toBe(200)
+          expect(response.body).toHaveProperty('currently_active', true)
+          expect(response.body).toHaveProperty('last_active_ts')
+          expect(response.body).toHaveProperty('state', 'online')
+          expect(response.body).toHaveProperty('status_msg', 'I am online')
+        })
+        it('should reject a request made to an uknown user', async () => {
+          const response = await request(app)
+            .get('/_matrix/client/v3/presence/@unknownuser:example.com/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+          expect(response.statusCode).toBe(404)
+        })
+        it('should reject a request with a userId that does not match the regex', async () => {
+          const response = await request(app)
+            .get('/_matrix/client/v3/presence/invalidUserId/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+          expect(response.statusCode).toBe(400)
+        })
+      })
+      describe('PUT', () => {
+        it('should set the presence state of a user', async () => {
+          const response = await request(app)
+            .put('/_matrix/client/v3/presence/@testuser:example.com/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+            .send({ presence: 'offline', status_msg: 'I am offline' })
+          expect(response.statusCode).toBe(200)
+          const presence = await clientServer.matrixDb.get(
+            'presence',
+            ['state', 'status_msg'],
+            { user_id: '@testuser:example.com' }
+          )
+          expect(presence).toHaveLength(1)
+          expect(presence[0].state).toBe('offline')
+          expect(presence[0].status_msg).toBe('I am offline')
+        })
+        it('should reject a request to set the presence state of another user', async () => {
+          const response = await request(app)
+            .put('/_matrix/client/v3/presence/@anotheruser:example.com/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+            .send({ presence: 'offline', status_msg: 'I am offline' })
+          expect(response.statusCode).toBe(403)
+        })
+        it('should reject a request with a userId that does not match the regex', async () => {
+          const response = await request(app)
+            .put('/_matrix/client/v3/presence/invalidUserId/status')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('Accept', 'application/json')
+          expect(response.statusCode).toBe(400)
+        })
+      })
+    })
+  })
+})

--- a/packages/matrix-client-server/src/presence/putStatus.ts
+++ b/packages/matrix-client-server/src/presence/putStatus.ts
@@ -1,0 +1,70 @@
+import type MatrixClientServer from '..'
+import {
+  jsonContent,
+  validateParameters,
+  errMsg,
+  type expressAppHandler,
+  send
+} from '@twake/utils'
+
+interface PutRequestBody {
+  presence: string
+  status_msg: string
+}
+
+const schema = {
+  presence: true,
+  status_msg: false
+}
+
+const matrixIdRegex = /^@[0-9a-zA-Z._=-]+:[0-9a-zA-Z.-]+$/
+
+// NB : Maybe the function should update the presence_stream table of the matrixDB,
+// TODO : reread the code after implementing streams-related endpoints
+const putStatus = (clientServer: MatrixClientServer): expressAppHandler => {
+  return (req, res) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const userId: string = req.params.userId as string
+    if (!matrixIdRegex.test(userId)) {
+      clientServer.logger.warn('Invalid user ID')
+      send(res, 400, errMsg('invalidParam'))
+    } else {
+      clientServer.authenticate(req, res, (data, id) => {
+        jsonContent(req, res, clientServer.logger, (obj) => {
+          validateParameters(res, schema, obj, clientServer.logger, (obj) => {
+            if (data.sub !== userId) {
+              clientServer.logger.warn(
+                'You cannot set the presence state of another user'
+              )
+              send(res, 403, errMsg('forbidden'))
+              return
+            }
+            clientServer.matrixDb
+              .updateWithConditions(
+                'presence',
+                {
+                  state: (obj as PutRequestBody).presence,
+                  status_msg: (obj as PutRequestBody).status_msg
+                },
+                [{ field: 'user_id', value: userId }]
+              )
+              .then(() => {
+                send(res, 200, {})
+              })
+              .catch((e) => {
+                // istanbul ignore next
+                clientServer.logger.error(
+                  "Error updating user's presence state",
+                  e
+                )
+                // istanbul ignore next
+                send(res, 500, errMsg('unknown'))
+              })
+          })
+        })
+      })
+    }
+  }
+}
+export default putStatus


### PR DESCRIPTION
Added endpoints from the spec : https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv3presenceuseridstatus
and https://spec.matrix.org/v1.11/client-server-api/#put_matrixclientv3presenceuseridstatus 

They still need completion after implementing streams related endpoints.