### PR TITLE
Client/server correct profiles

### DIFF
--- a/packages/matrix-client-server/src/__testData__/buildUserDB.ts
+++ b/packages/matrix-client-server/src/__testData__/buildUserDB.ts
@@ -37,8 +37,8 @@ const matrixDbQueries = [
   'CREATE TABLE IF NOT EXISTS rooms( room_id TEXT PRIMARY KEY NOT NULL, is_public BOOL, creator TEXT , room_version TEXT, has_auth_chain_index BOOLEAN)',
   'CREATE TABLE IF NOT EXISTS room_tags( user_id TEXT NOT NULL, room_id TEXT NOT NULL, tag TEXT NOT NULL, content TEXT NOT NULL, CONSTRAINT room_tag_uniqueness UNIQUE (user_id, room_id, tag) )',
   'CREATE TABLE IF NOT EXISTS "user_threepids" ( user_id TEXT NOT NULL, medium TEXT NOT NULL, address TEXT NOT NULL, validated_at BIGINT NOT NULL, added_at BIGINT NOT NULL, CONSTRAINT medium_address UNIQUE (medium, address) )',
-  'CREATE TABLE threepid_validation_session (session_id TEXT PRIMARY KEY,medium TEXT NOT NULL,address TEXT NOT NULL,client_secret TEXT NOT NULL,last_send_attempt BIGINT NOT NULL,validated_at BIGINT)',
-  'CREATE TABLE threepid_validation_token (token TEXT PRIMARY KEY,session_id TEXT NOT NULL,next_link TEXT,expires BIGINT NOT NULL)',
+  'CREATE TABLE IF NOT EXISTS threepid_validation_session (session_id TEXT PRIMARY KEY,medium TEXT NOT NULL,address TEXT NOT NULL,client_secret TEXT NOT NULL,last_send_attempt BIGINT NOT NULL,validated_at BIGINT)',
+  'CREATE TABLE IF NOT EXISTS threepid_validation_token (token TEXT PRIMARY KEY,session_id TEXT NOT NULL,next_link TEXT,expires BIGINT NOT NULL)',
   'CREATE TABLE IF NOT EXISTS presence (user_id TEXT NOT NULL, state VARCHAR(20), status_msg TEXT, mtime BIGINT, UNIQUE (user_id))'
 ]
 

--- a/packages/matrix-client-server/src/__testData__/registerConf.json
+++ b/packages/matrix-client-server/src/__testData__/registerConf.json
@@ -10,7 +10,7 @@
   "keys_depth": 5,
   "mail_link_delay": 7200,
   "rate_limiting_window": 10000,
-  "server_name": "matrix.org",
+  "server_name": "example.com",
   "smtp_sender": "yadd@debian.org",
   "smtp_server": "localhost",
   "template_dir": "./templates",

--- a/packages/matrix-client-server/src/devices/changeDevices.ts
+++ b/packages/matrix-client-server/src/devices/changeDevices.ts
@@ -1,3 +1,10 @@
+/*
+This file implements the changeDeviceName functions, which is used to update the display name of a device associated with a user.
+These functions are used to provide device management functionality in the Matrix client server : https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv3devices
+
+TODO : Add checks to ensure that the user has the rigths to change the device name.
+*/
+
 import {
   errMsg,
   type expressAppHandler,
@@ -26,13 +33,17 @@ export const changeDeviceName = (
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(res, schema, obj, clientServer.logger, (obj) => {
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          const _display_name = (obj as changeDeviceNameArgs).display_name
+          const new_display_name = (obj as changeDeviceNameArgs).display_name
 
           clientServer.matrixDb
-            .updateWithConditions('devices', { display_name: _display_name }, [
-              { field: 'device_id', value: deviceId },
-              { field: 'user_id', value: userId }
-            ])
+            .updateWithConditions(
+              'devices',
+              { display_name: new_display_name },
+              [
+                { field: 'device_id', value: deviceId },
+                { field: 'user_id', value: userId }
+              ]
+            )
             .then((rows) => {
               if (rows.length === 0) {
                 send(

--- a/packages/matrix-client-server/src/devices/getDevices.ts
+++ b/packages/matrix-client-server/src/devices/getDevices.ts
@@ -1,3 +1,14 @@
+/*
+This file implements the getDevices and getDeviceInfo functions, which are used to retrieve information about devices associated with a user. 
+The getDevices function returns a list of devices, while the getDeviceInfo function returns information about a specific device. 
+These functions are used to provide device management functionality in the Matrix client server : https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientv3devices
+
+One of the main differences between the implementation in the Twake codebase and the equivalent implementation in the Synapse codebase 
+is that for now we are not updating the last_ip field of a device when it is looked upon by a user (as it is done here).
+
+It can be done by looking up the ip of the client (stored in the user_ips table) and updating the ip field of the device in the devices table.
+*/
+
 import { errMsg, type expressAppHandler, send } from '@twake/utils'
 import type MatrixClientServer from '../index'
 import { type Request } from 'express'

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -31,8 +31,7 @@ beforeAll((done) => {
     database_engine: 'sqlite',
     base_url: 'http://example.com/',
     userdb_engine: 'sqlite',
-    matrix_database_engine: 'sqlite',
-    server_name: 'example.com'
+    matrix_database_engine: 'sqlite'
   }
   if (process.env.TEST_PG === 'yes') {
     conf.database_engine = 'pg'
@@ -124,6 +123,14 @@ describe('Use configuration file', () => {
     expect(response.statusCode).toBe(405)
   })
 
+  it('should return true if provided user is hosted on local server', async () => {
+    expect(clientServer.isMine('@testuser:example.com')).toBe(true)
+  })
+
+  it('should return false if provided user is hosted on remote server', async () => {
+    expect(clientServer.isMine('@testuser:remote.com')).toBe(false)
+  })
+
   describe('/_matrix/client/v3/profile/:userId', () => {
     describe('GET', () => {
       const testUserId = '@testuser:example.com'
@@ -213,7 +220,6 @@ describe('Use configuration file', () => {
           const response = await request(app).get(
             '/_matrix/client/v3/profile/@nonexistentuser:example.com/avatar_url'
           )
-
           expect(response.statusCode).toBe(404)
           expect(response.body.errcode).toBe('M_NOT_FOUND')
           expect(response.body).toHaveProperty('error')
@@ -223,7 +229,6 @@ describe('Use configuration file', () => {
           const response = await request(app).get(
             '/_matrix/client/v3/profile/@incompleteuser:example.com/avatar_url'
           )
-
           expect(response.statusCode).toBe(404)
           expect(response.body.errcode).toBe('M_NOT_FOUND')
           expect(response.body).toHaveProperty('error')
@@ -1112,9 +1117,8 @@ describe('Use configuration file', () => {
           }
         })
 
-        describe('/_matrix/client/v3/profile/{userId}/avatar_url', () => {
+        describe('/_matrix/client/v3/profile/:userId/avatar_url', () => {
           it('should require authentication', async () => {
-            await clientServer.cronTasks?.ready
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', 'Bearer invalidToken')

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -31,7 +31,8 @@ beforeAll((done) => {
     database_engine: 'sqlite',
     base_url: 'http://example.com/',
     userdb_engine: 'sqlite',
-    matrix_database_engine: 'sqlite'
+    matrix_database_engine: 'sqlite',
+    server_name: 'example.com'
   }
   if (process.env.TEST_PG === 'yes') {
     conf.database_engine = 'pg'
@@ -1069,6 +1070,14 @@ describe('Use configuration file', () => {
         const testUserId = '@testuser:example.com'
         beforeAll(async () => {
           try {
+            await clientServer.matrixDb.insert('users', {
+              name: '@testuser2:example.com',
+              admin: 1
+            })
+            await clientServer.matrixDb.insert('users', {
+              name: '@testuser3:example.com',
+              admin: 0
+            })
             await clientServer.matrixDb.insert('profiles', {
               user_id: testUserId,
               displayname: 'Test User',
@@ -1082,6 +1091,16 @@ describe('Use configuration file', () => {
 
         afterAll(async () => {
           try {
+            await clientServer.matrixDb.deleteEqual(
+              'users',
+              'name',
+              '@testuser2:example.com'
+            )
+            await clientServer.matrixDb.deleteEqual(
+              'users',
+              'name',
+              '@testuser3:example.com'
+            )
             await clientServer.matrixDb.deleteEqual(
               'profiles',
               'user_id',
@@ -1103,7 +1122,49 @@ describe('Use configuration file', () => {
             expect(response.statusCode).toBe(401)
           })
 
-          it('should send correct response when updating the avatar_url of an existing user', async () => {
+          it('should return 400 if the target user is on a remote server', async () => {
+            const response = await request(app)
+              .put(
+                `/_matrix/client/v3/profile/@testuser:anotherexample.com/avatar_url`
+              )
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ avatar_url: 'http://example.com/new_avatar.jpg' })
+            expect(response.statusCode).toBe(400)
+          })
+
+          it('should return 403 if the requester is not admin and is not the target user', async () => {
+            const response = await request(app)
+              .put(
+                `/_matrix/client/v3/profile/@testuser2:example.com/avatar_url`
+              )
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ avatar_url: 'http://example.com/new_avatar.jpg' })
+            expect(response.statusCode).toBe(403)
+          })
+
+          it('should return 400 if provided avatar_url is too long', async () => {
+            const response = await request(app)
+              .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ avatar_url: randomString(2049) })
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toHaveProperty('errcode', 'M_INVALID_PARAM')
+          })
+
+          it('should send correct response when requester is admin and target user is on local server', async () => {
+            const response = await request(app)
+              .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
+              .set('Authorization', `Bearer ${validToken2}`)
+              .send({ avatar_url: 'http://example.com/new_avatar.jpg' })
+
+            expect(response.statusCode).toBe(200)
+            expect(response.body).toEqual({})
+          })
+
+          it('should send correct response when requester is target user (on local server)', async () => {
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', `Bearer ${validToken}`)
@@ -1140,10 +1201,42 @@ describe('Use configuration file', () => {
             expect(response.statusCode).toBe(401)
           })
 
-          it('should send correct response when updating the display_name of an existing user', async () => {
+          it('should return 400 if the target user is on a remote server', async () => {
+            const response = await request(app)
+              .put(
+                `/_matrix/client/v3/profile/@testuser:anotherexample.com/displayname`
+              )
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ displayname: 'New name' })
+            expect(response.statusCode).toBe(400)
+          })
+
+          it('should return 403 if the requester is not admin and is not the target user', async () => {
+            const response = await request(app)
+              .put(
+                `/_matrix/client/v3/profile/@testuser2:example.com/displayname`
+              )
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ displayname: 'New name' })
+            expect(response.statusCode).toBe(403)
+          })
+
+          it('should return 400 if provided display_name is too long', async () => {
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/displayname`)
               .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ displayname: randomString(257) })
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toHaveProperty('errcode', 'M_INVALID_PARAM')
+          })
+
+          it('should send correct response when requester is admin and target user is on local server', async () => {
+            const response = await request(app)
+              .put(`/_matrix/client/v3/profile/${testUserId}/displayname`)
+              .set('Authorization', `Bearer ${validToken2}`)
               .send({ displayname: 'New name' })
 
             expect(response.statusCode).toBe(200)

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -384,11 +384,11 @@ describe('Use configuration file', () => {
         expect(registerResponse.statusCode).toBe(200)
         const response = await request(app)
           .get('/_matrix/client/v3/account/whoami')
-          .query({ user_id: '@_irc_bridge_:matrix.org' })
+          .query({ user_id: '@_irc_bridge_:example.com' })
           .set('Authorization', `Bearer ${asToken}`)
           .set('Accept', 'application/json')
         expect(response.statusCode).toBe(200)
-        expect(response.body.user_id).toBe('@_irc_bridge_:matrix.org')
+        expect(response.body.user_id).toBe('@_irc_bridge_:example.com')
       })
       it('should refuse an appservice authentication with a user_id not registered in the appservice', async () => {
         const response = await request(app)
@@ -401,7 +401,7 @@ describe('Use configuration file', () => {
       it('should ensure a normal user cannot access the account of an appservice', async () => {
         const response = await request(app)
           .get('/_matrix/client/v3/account/whoami')
-          .query({ user_id: '@_irc_bridge_:matrix.org' })
+          .query({ user_id: '@_irc_bridge_:example.com' })
           .set('Authorization', `Bearer ${validToken}`)
           .set('Accept', 'application/json')
         expect(response.body).toHaveProperty('user_id', '@testuser:example.com') // not _irc_bridge_ (appservice account)

--- a/packages/matrix-client-server/src/index.ts
+++ b/packages/matrix-client-server/src/index.ts
@@ -123,18 +123,10 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/account/whoami': whoami(this),
             '/_matrix/client/v3/admin/whois': whois(this),
             '/_matrix/client/v3/register': badMethod,
-            '/_matrix/client/v3/profile/:userId': getProfile(
-              this.matrixDb,
-              this.logger
-            ),
-            '/_matrix/client/v3/profile/:userId/avatar_url': getAvatarUrl(
-              this.matrixDb,
-              this.logger
-            ),
-            '/_matrix/client/v3/profile/:userId/displayname': getDisplayname(
-              this.matrixDb,
-              this.logger
-            ),
+            '/_matrix/client/v3/profile/:userId': getProfile(this),
+            '/_matrix/client/v3/profile/:userId/avatar_url': getAvatarUrl(this),
+            '/_matrix/client/v3/profile/:userId/displayname':
+              getDisplayname(this),
             '/_matrix/client/v3/user/:userId/account_data/:type':
               getAccountData(this),
             '/_matrix/client/v3/user/:userId/rooms/:roomId/account_data/:type':
@@ -270,6 +262,12 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
         /* istanbul ignore next */
         .catch(reject)
     })
+  }
+
+  // Class methods that determiens if a user is hosted in the server or in a remote one
+  isMine(userId: string): boolean {
+    const parts = userId.split(':')
+    return parts[1] === this.conf.server_name
   }
 
   cleanJobs(): void {

--- a/packages/matrix-client-server/src/profiles/changeProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/changeProfiles.ts
@@ -1,3 +1,15 @@
+/*
+As done in the Synapse implementation of the Matrix Protocol,
+one user will have the ability to change the displayname and avatar_url of another user if they are an admin,
+if they are changing their own displayname and avatar_url,
+or if the servers congiguration allows it.
+
+Future implementations may include :
+ - the ability to change the displayname and avatar_url of a user while deactivating them
+ - the ability to change the displayname and avatar_url of a user and have it apply to the user's membership events
+ - the ability to change another user's profile if the requester presents one of the target's valid tokens
+*/
+
 import type MatrixClientServer from '../index'
 import { type Request } from 'express'
 import {
@@ -8,8 +20,16 @@ import {
   validateParameters
 } from '@twake/utils'
 
+const MAX_DISPLAYNAME_LEN = 256
+const MAX_AVATAR_URL_LEN = 1000
+
 const schema = {
   avatar_url: true
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const schema_name = {
+  displayname: true
 }
 
 interface changeAvatarUrlArgs {
@@ -23,19 +43,78 @@ export const changeAvatarUrl = (
   clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
+    /* 
+    Sets the avatar_url of a user
+
+    Arguments to take into account :
+      target_user: the user whose avatar_url is to be changed.
+      requester: The user attempting to make this change.
+      newAvatarUrl: The avatar_url to give this user.
+      byAdmin: Whether this change was made by an administrator.
+
+      TO DO : The following arguments are not used in this function, 
+      but are used in the equivalent function in the Synapse codebase:
+        deactivation: Whether this change was made while deactivating the user.
+        propagate: Whether this change also applies to the user's membership events.
+    */
     const userId: string = (req as Request).params.userId
-    clientServer.authenticate(req, res, (data, id) => {
+
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    clientServer.authenticate(req, res, async (token) => {
+      const requesterUserId = token.sub
+      // Check wether requester is admin or not
+      const requester = await clientServer.matrixDb.get('users', ['is_admin'], {
+        name: requesterUserId
+      })
+      const byAdmin = requester[0].is_admin
+
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(res, schema, obj, clientServer.logger, (obj) => {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          const _avatar_url = (obj as changeAvatarUrlArgs).avatar_url
+          const newAvatarUrl = (obj as changeAvatarUrlArgs).avatar_url
+          const targetUserId: string = (req as Request).params.userId
+
+          /*  istanbul ignore if */
+          if (!clientServer.isMine(targetUserId)) {
+            send(
+              res,
+              400,
+              errMsg('unknown', 'Cannot change displayname of a remote user')
+            )
+            return
+          }
+
+          if (byAdmin === 0 && requesterUserId !== targetUserId) {
+            send(
+              res,
+              403,
+              errMsg(
+                'forbidden',
+                'Cannot change displayname of another user when not admin'
+              )
+            )
+            return
+          }
+
+          // TO DO: check if changing displayname is allowed according to config settings
+
+          if (newAvatarUrl.length > MAX_AVATAR_URL_LEN) {
+            send(
+              res,
+              400,
+              errMsg(
+                'invalidParam',
+                `Avatar url too long. Max length is + ${MAX_AVATAR_URL_LEN}`
+              )
+            )
+            return
+          }
 
           clientServer.matrixDb
-            .updateWithConditions('profiles', { avatar_url: _avatar_url }, [
+            .updateWithConditions('profiles', { avatar_url: newAvatarUrl }, [
               { field: 'user_id', value: userId }
             ])
             .then(() => {
-              clientServer.logger.debug('Avatar URL updated')
+              clientServer.logger.debug('AvatarUrl updated')
               send(res, 200, {})
             })
             .catch((e) => {
@@ -50,17 +129,35 @@ export const changeAvatarUrl = (
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const schema_name = {
-  displayname: true
-}
-
 export const changeDisplayname = (
   clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
+    /* 
+    Set the displayname of a user
+
+    Arguments to take into account :
+      target_user: the user whose displayname is to be changed.
+      requester: The user attempting to make this change.
+      newDisplayname: The displayname to give this user.
+      byAdmin: Whether this change was made by an administrator.
+
+      TO DO : The following arguments are not used in this function, 
+      but are used in the equivalent function in the Synapse codebase:
+        deactivation: Whether this change was made while deactivating the user.
+        propagate: Whether this change also applies to the user's membership events.
+    */
     const userId: string = (req as Request).params.userId
-    clientServer.authenticate(req, res, (data, id) => {
+
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    clientServer.authenticate(req, res, async (token) => {
+      const requesterUserId = token.sub
+      // Check wether requester is admin or not
+      const requester = await clientServer.matrixDb.get('users', ['is_admin'], {
+        name: requesterUserId
+      })
+      const byAdmin = requester[0].is_admin
+
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(
           res,
@@ -68,12 +165,51 @@ export const changeDisplayname = (
           obj,
           clientServer.logger,
           (obj) => {
-            const _displayname = (obj as changeDisplaynameArgs).displayname
+            const newDisplayname = (obj as changeDisplaynameArgs).displayname
+            const targetUserId: string = (req as Request).params.userId
+
+            /*  istanbul ignore if */
+            if (!clientServer.isMine(targetUserId)) {
+              send(
+                res,
+                400,
+                errMsg('unknown', 'Cannot change displayname of a remote user')
+              )
+              return
+            }
+
+            if (byAdmin === 0 && requesterUserId !== targetUserId) {
+              send(
+                res,
+                403,
+                errMsg(
+                  'forbidden',
+                  'Cannot change displayname of another user when not admin'
+                )
+              )
+              return
+            }
+
+            // TO DO: check if changing displayname is allowed according to config settings
+
+            if (newDisplayname.length > MAX_DISPLAYNAME_LEN) {
+              send(
+                res,
+                400,
+                errMsg(
+                  'invalidParam',
+                  `Displayname too long. Max length is + ${MAX_DISPLAYNAME_LEN}`
+                )
+              )
+              return
+            }
 
             clientServer.matrixDb
-              .updateWithConditions('profiles', { displayname: _displayname }, [
-                { field: 'user_id', value: userId }
-              ])
+              .updateWithConditions(
+                'profiles',
+                { displayname: newDisplayname },
+                [{ field: 'user_id', value: userId }]
+              )
               .then(() => {
                 clientServer.logger.debug('Displayname updated')
                 send(res, 200, {})

--- a/packages/matrix-client-server/src/profiles/changeProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/changeProfiles.ts
@@ -52,7 +52,7 @@ export const changeAvatarUrl = (
       newAvatarUrl: The avatar_url to give this user.
       byAdmin: Whether this change was made by an administrator.
 
-      TO DO : The following arguments are not used in this function, 
+      TODO : The following arguments are not used in this function, 
       but are used in the equivalent function in the Synapse codebase:
         deactivation: Whether this change was made while deactivating the user.
         propagate: Whether this change also applies to the user's membership events.
@@ -103,7 +103,7 @@ export const changeAvatarUrl = (
             return
           }
 
-          // TO DO: check if changing displayname is allowed according to config settings
+          // TODO: check if changing displayname is allowed according to config settings
 
           if (newAvatarUrl.length > MAX_AVATAR_URL_LEN) {
             send(
@@ -150,14 +150,12 @@ export const changeDisplayname = (
       newDisplayname: The displayname to give this user.
       byAdmin: Whether this change was made by an administrator.
 
-      TO DO : The following arguments are not used in this function, 
+      TODO : The following arguments are not used in this function, 
       but are used in the equivalent function in the Synapse codebase:
         deactivation: Whether this change was made while deactivating the user.
         propagate: Whether this change also applies to the user's membership events.
     */
     const userId: string = (req as Request).params.userId
-
-    console.log('i am here displayname')
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     clientServer.authenticate(req, res, async (token) => {
@@ -165,11 +163,9 @@ export const changeDisplayname = (
       // Check wether requester is admin or not
       let byAdmin = 0
       try {
-        console.log('checking admin')
         const response = await clientServer.matrixDb.get('users', ['admin'], {
           name: requesterUserId
         })
-        console.log('got admin')
         byAdmin = response[0].admin as number
       } catch (e) {
         /* istanbul ignore next */
@@ -177,8 +173,6 @@ export const changeDisplayname = (
         /* istanbul ignore next */
         send(res, 500, errMsg('unknown', 'Error checking admin'))
       }
-
-      console.log('finished checking admin')
 
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(
@@ -212,7 +206,7 @@ export const changeDisplayname = (
               return
             }
 
-            // TO DO: check if changing displayname is allowed according to config settings
+            // TODO: check if changing displayname is allowed according to config settings
 
             if (newDisplayname.length > MAX_DISPLAYNAME_LEN) {
               send(

--- a/packages/matrix-client-server/src/profiles/changeProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/changeProfiles.ts
@@ -62,11 +62,19 @@ export const changeAvatarUrl = (
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     clientServer.authenticate(req, res, async (token) => {
       const requesterUserId = token.sub
-      // Check wether requester is admin or not
-      const requester = await clientServer.matrixDb.get('users', ['is_admin'], {
-        name: requesterUserId
-      })
-      const byAdmin = requester[0].is_admin
+      let byAdmin = 0
+      try {
+        // Check wether requester is admin or not
+        const response = await clientServer.matrixDb.get('users', ['admin'], {
+          name: requesterUserId
+        })
+        byAdmin = response[0].admin as number
+      } catch (e) {
+        /* istanbul ignore next */
+        clientServer.logger.error('Error checking admin:', e)
+        /* istanbul ignore next */
+        send(res, 500, errMsg('unknown', 'Error checking admin'))
+      }
 
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(res, schema, obj, clientServer.logger, (obj) => {
@@ -149,14 +157,28 @@ export const changeDisplayname = (
     */
     const userId: string = (req as Request).params.userId
 
+    console.log('i am here displayname')
+
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     clientServer.authenticate(req, res, async (token) => {
       const requesterUserId = token.sub
       // Check wether requester is admin or not
-      const requester = await clientServer.matrixDb.get('users', ['is_admin'], {
-        name: requesterUserId
-      })
-      const byAdmin = requester[0].is_admin
+      let byAdmin = 0
+      try {
+        console.log('checking admin')
+        const response = await clientServer.matrixDb.get('users', ['admin'], {
+          name: requesterUserId
+        })
+        console.log('got admin')
+        byAdmin = response[0].admin as number
+      } catch (e) {
+        /* istanbul ignore next */
+        clientServer.logger.error('Error checking admin:', e)
+        /* istanbul ignore next */
+        send(res, 500, errMsg('unknown', 'Error checking admin'))
+      }
+
+      console.log('finished checking admin')
 
       jsonContent(req, res, clientServer.logger, (obj) => {
         validateParameters(

--- a/packages/matrix-client-server/src/profiles/getProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/getProfiles.ts
@@ -46,6 +46,7 @@ export const getProfile = (
           })
       } else {
         // TO DO : Have a look on remote server via federation
+        send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))
@@ -75,9 +76,13 @@ export const getAvatarUrl = (
               clientServer.logger.info('User not found')
               send(res, 404, errMsg('notFound', 'User not found'))
             } else {
-              send(res, 200, {
-                avatar_url: rows[0].avatar_url
-              })
+              if (rows[0].avatar_url === null) {
+                send(res, 404, errMsg('notFound', 'Avatar not found'))
+              } else {
+                send(res, 200, {
+                  avatar_url: rows[0].avatar_url
+                })
+              }
             }
           })
           .catch((e) => {
@@ -88,6 +93,7 @@ export const getAvatarUrl = (
           })
       } else {
         // TO DO : Have a look on remote server via federation
+        send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))
@@ -117,9 +123,13 @@ export const getDisplayname = (
               clientServer.logger.info('User not found')
               send(res, 404, errMsg('notFound', 'User not found'))
             } else {
-              send(res, 200, {
-                displayname: rows[0].displayname
-              })
+              if (rows[0].displayname === null) {
+                send(res, 404, errMsg('notFound', 'Displayname not found'))
+              } else {
+                send(res, 200, {
+                  displayname: rows[0].displayname
+                })
+              }
             }
           })
           .catch((e) => {
@@ -130,6 +140,7 @@ export const getDisplayname = (
           })
       } else {
         // TO DO : Have a look on remote server via federation
+        send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))

--- a/packages/matrix-client-server/src/profiles/getProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/getProfiles.ts
@@ -1,11 +1,17 @@
-import type MatrixDBmodified from '../matrixDb'
-import { type TwakeLogger } from '@twake/logger'
+/*
+As specified in the Matrix Protocol, access to the profile information of another user is allowed on the local server,
+and may be allowed on remote servers via federation.
+
+TO DO : implement the ability to access the profile information of another user on a remote server via federation.
+TO DO : implement the ability to close access to the profile information of another user on the local server.
+*/
+
+import type MatrixClientServer from '../'
 import { type Request } from 'express'
 import { errMsg, send, type expressAppHandler } from '@twake/utils'
 
 export const getProfile = (
-  matrixDb: MatrixDBmodified,
-  logger: TwakeLogger
+  clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
     const userId: string = (req as Request).params.userId
@@ -15,45 +21,41 @@ export const getProfile = (
       typeof userId === 'string' &&
       userId.length > 0
     ) {
-      matrixDb
-        .get('profiles', ['displayname', 'avatar_url'], {
-          user_id: userId
-        })
-        .then((rows) => {
-          if (rows.length === 0) {
-            logger.info('Profile not found')
-            send(res, 404, errMsg('notFound', 'Profile not found'))
-          } else {
-            // logger.info('Profile found:', rows[0])
-            send(res, 200, {
-              avatar_url: rows[0].avatar_url,
-              displayname: rows[0].displayname
-            })
-          }
-        })
-        .catch((e) => {
-          /* istanbul ignore next */
-          send(
-            res,
-            403,
-            errMsg(
-              'forbidden',
-              'Profile lookup over federation is disabled on this homeserver'
-            )
-          )
-          /* istanbul ignore next */
-          logger.error('Error querying profiles:', e)
-        })
+      if (clientServer.isMine(userId)) {
+        clientServer.matrixDb
+          .get('profiles', ['displayname', 'avatar_url'], {
+            user_id: userId
+          })
+          .then((rows) => {
+            if (rows.length === 0) {
+              clientServer.logger.info('Profile not found')
+              send(res, 404, errMsg('notFound', 'Profile not found'))
+            } else {
+              // logger.info('Profile found:', rows[0])
+              send(res, 200, {
+                avatar_url: rows[0].avatar_url,
+                displayname: rows[0].displayname
+              })
+            }
+          })
+          .catch((e) => {
+            /* istanbul ignore next */
+            send(res, 500, errMsg('unknown', e))
+            /* istanbul ignore next */
+            clientServer.logger.error('Error querying profiles:', e)
+          })
+      } else {
+        // TO DO : Have a look on remote server via federation
+      }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))
-      logger.debug('No user ID provided')
+      clientServer.logger.debug('No user ID provided')
     }
   }
 }
 
 export const getAvatarUrl = (
-  matrixDb: MatrixDBmodified,
-  logger: TwakeLogger
+  clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
     const userId: string = (req as Request).params.userId
@@ -63,45 +65,39 @@ export const getAvatarUrl = (
       typeof userId === 'string' &&
       userId.length > 0
     ) {
-      matrixDb
-        .get('profiles', ['avatar_url'], {
-          user_id: userId
-        })
-        .then((rows) => {
-          if (rows.length === 0) {
-            logger.info('No avatar found')
-            send(res, 404, errMsg('notFound', 'This user does not exist'))
-          } else {
-            if (rows[0].avatar_url === null) {
-              logger.info('No avatar found')
-              send(
-                res,
-                404,
-                errMsg('notFound', 'No avatar found for this user')
-              )
+      if (clientServer.isMine(userId)) {
+        clientServer.matrixDb
+          .get('profiles', ['avatar_url'], {
+            user_id: userId
+          })
+          .then((rows) => {
+            if (rows.length === 0) {
+              clientServer.logger.info('User not found')
+              send(res, 404, errMsg('notFound', 'User not found'))
             } else {
               send(res, 200, {
                 avatar_url: rows[0].avatar_url
               })
             }
-          }
-        })
-        .catch((e) => {
-          /* istanbul ignore next */
-          logger.error('Error querying profiles:', e)
-          /* istanbul ignore next */
-          send(res, 500, errMsg('unknown', 'Error querying profiles'))
-        })
+          })
+          .catch((e) => {
+            /* istanbul ignore next */
+            send(res, 500, errMsg('unknown', e))
+            /* istanbul ignore next */
+            clientServer.logger.error('Error querying profiles:', e)
+          })
+      } else {
+        // TO DO : Have a look on remote server via federation
+      }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))
-      logger.debug('No user ID provided')
+      clientServer.logger.debug('No user ID provided')
     }
   }
 }
 
 export const getDisplayname = (
-  matrixDb: MatrixDBmodified,
-  logger: TwakeLogger
+  clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
     const userId: string = (req as Request).params.userId
@@ -111,38 +107,33 @@ export const getDisplayname = (
       typeof userId === 'string' &&
       userId.length > 0
     ) {
-      matrixDb
-        .get('profiles', ['displayname'], {
-          user_id: userId
-        })
-        .then((rows) => {
-          if (rows.length === 0) {
-            logger.info('No display_name found')
-            send(res, 404, errMsg('notFound', 'This user does not exist'))
-          } else {
-            if (rows[0].displayname === null) {
-              logger.info('No display_name found')
-              send(
-                res,
-                404,
-                errMsg('notFound', 'No display_name found for this user')
-              )
+      if (clientServer.isMine(userId)) {
+        clientServer.matrixDb
+          .get('profiles', ['displayname'], {
+            user_id: userId
+          })
+          .then((rows) => {
+            if (rows.length === 0) {
+              clientServer.logger.info('User not found')
+              send(res, 404, errMsg('notFound', 'User not found'))
             } else {
               send(res, 200, {
                 displayname: rows[0].displayname
               })
             }
-          }
-        })
-        .catch((e) => {
-          /* istanbul ignore next */
-          logger.error('Error querying profiles:', e)
-          /* istanbul ignore next */
-          send(res, 500, errMsg('unknown', 'Error querying profiles'))
-        })
+          })
+          .catch((e) => {
+            /* istanbul ignore next */
+            send(res, 500, errMsg('unknown', e))
+            /* istanbul ignore next */
+            clientServer.logger.error('Error querying profiles:', e)
+          })
+      } else {
+        // TO DO : Have a look on remote server via federation
+      }
     } else {
       send(res, 400, errMsg('missingParams', 'No user ID provided'))
-      logger.debug('No user ID provided')
+      clientServer.logger.debug('No user ID provided')
     }
   }
 }

--- a/packages/matrix-client-server/src/profiles/getProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/getProfiles.ts
@@ -2,8 +2,8 @@
 As specified in the Matrix Protocol, access to the profile information of another user is allowed on the local server,
 and may be allowed on remote servers via federation.
 
-TO DO : implement the ability to access the profile information of another user on a remote server via federation.
-TO DO : implement the ability to close access to the profile information of another user on the local server.
+TODO : implement the ability to access the profile information of another user on a remote server via federation.
+TODO : implement the ability to close access to the profile information of another user on the local server.
 */
 
 import type MatrixClientServer from '../'
@@ -45,7 +45,7 @@ export const getProfile = (
             clientServer.logger.error('Error querying profiles:', e)
           })
       } else {
-        // TO DO : Have a look on remote server via federation
+        // TODO : Have a look on remote server via federation
         send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {
@@ -92,7 +92,7 @@ export const getAvatarUrl = (
             clientServer.logger.error('Error querying profiles:', e)
           })
       } else {
-        // TO DO : Have a look on remote server via federation
+        // TODO : Have a look on remote server via federation
         send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {
@@ -139,7 +139,7 @@ export const getDisplayname = (
             clientServer.logger.error('Error querying profiles:', e)
           })
       } else {
-        // TO DO : Have a look on remote server via federation
+        // TODO : Have a look on remote server via federation
         send(res, 500, errMsg('unknown', 'Cannot get profile of a remote user'))
       }
     } else {


### PR DESCRIPTION
Corrected the APIs of https://spec.matrix.org/v1.11/client-server-api/#profiles

Added TO DOs to complete when server-server API will be available
Added TO DOs following synapses implementation of matrix Protocol

Test coverage is deliberately incomplete for getProfiles related API to make sure it is not forgotten when server-server is available.