### PR TITLE
feat : added a strict version of validateParameters 

### DIFF
--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -14,6 +14,9 @@ export const errCodes = {
   // The request contained one or more invalid parameters.
   invalidParam: 'M_INVALID_PARAM',
 
+  // The request contained unsupported additional parameters.
+  unknownParam: 'M_UNKNOWN_PARAM',
+
   // The session has not been validated.
   sessionNotValidated: 'M_SESSION_NOT_VALIDATED',
 

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -15,7 +15,7 @@ export const errCodes = {
   invalidParam: 'M_INVALID_PARAM',
 
   // The request contained unsupported additional parameters.
-  unknownParam: 'M_UNKNOWN_PARAM',
+  unknownParam: 'UNKNOWN_PARAM',
 
   // The session has not been validated.
   sessionNotValidated: 'M_SESSION_NOT_VALIDATED',


### PR DESCRIPTION
validateParametersStrict do not accept additional parameters and sends an error with new type : UNKNOWN_PARAM. Useful for post apis to avoid inserting unverified data in the db.