### PR TITLE
Client server capabilities

### DIFF
--- a/packages/matrix-client-server/src/capabilities/getCapabilities.ts
+++ b/packages/matrix-client-server/src/capabilities/getCapabilities.ts
@@ -7,22 +7,22 @@
  * To be effectively taken into account, the concerned API's should check the capabilities to ensure it can be used.
  *
  * For reference, look at how the capabilities are checked in the `changeDisplayname` function. ( ../profiles/changeProfiles.ts )
+ *
+ * TODO : Implement the `m.room_versions` capabilities
+ * TODO : Implement capability checks in the concerned API's for changing password and 3pid changes
  */
 
 import type MatrixClientServer from '../index'
 import { errMsg, send, type expressAppHandler } from '@twake/utils'
 
-export const getCapabilities = (
+const getCapabilities = (
   clientServer: MatrixClientServer
 ): expressAppHandler => {
   return (req, res) => {
-    clientServer.authenticate(req, res, (token) => {
-      const requesterUserId = token.sub
-      // TODO : Check if the requester has the rights to get the capabilities
-
-      let capabilities: Record<string, any>
+    clientServer.authenticate(req, res, (data) => {
+      let _capabilities: Record<string, any>
       try {
-        capabilities = {
+        _capabilities = {
           //       "m.room_versions": {
           //           "default": self.config.server.default_room_version.identifier,
           //           "available": {
@@ -47,15 +47,19 @@ export const getCapabilities = (
           }
         }
       } catch (e) {
+        /* istanbul ignore next */
         send(
           res,
           500,
           errMsg('unknown', 'Error getting capabilities'),
           clientServer.logger
         )
+        /* istanbul ignore next */
         return
       }
-      send(res, 200, JSON.stringify(capabilities), clientServer.logger)
+      send(res, 200, { capabilities: _capabilities }, clientServer.logger)
     })
   }
 }
+
+export default getCapabilities

--- a/packages/matrix-client-server/src/capabilities/getCapabilities.ts
+++ b/packages/matrix-client-server/src/capabilities/getCapabilities.ts
@@ -1,0 +1,61 @@
+/**
+ * Implements the Capabilities negotiation of the Matrix Protocol (Client-Server)
+ *  cf https://spec.matrix.org/latest/client-server-api/#capabilities-negotiation
+ *
+ * The capabilities will be stored in the server's configuration file.
+ *
+ * To be effectively taken into account, the concerned API's should check the capabilities to ensure it can be used.
+ *
+ * For reference, look at how the capabilities are checked in the `changeDisplayname` function. ( ../profiles/changeProfiles.ts )
+ */
+
+import type MatrixClientServer from '../index'
+import { errMsg, send, type expressAppHandler } from '@twake/utils'
+
+export const getCapabilities = (
+  clientServer: MatrixClientServer
+): expressAppHandler => {
+  return (req, res) => {
+    clientServer.authenticate(req, res, (token) => {
+      const requesterUserId = token.sub
+      // TODO : Check if the requester has the rights to get the capabilities
+
+      let capabilities: Record<string, any>
+      try {
+        capabilities = {
+          //       "m.room_versions": {
+          //           "default": self.config.server.default_room_version.identifier,
+          //           "available": {
+          //               v.identifier: v.disposition
+          //               for v in KNOWN_ROOM_VERSIONS.values()
+          //           },
+          //   },
+          'm.change_password': {
+            enabled:
+              clientServer.conf.capabilities.enable_change_password ?? true
+          },
+          'm.set_displayname': {
+            enabled:
+              clientServer.conf.capabilities.enable_set_displayname ?? true
+          },
+          'm.set_avatar_url': {
+            enabled:
+              clientServer.conf.capabilities.enable_set_avatar_url ?? true
+          },
+          'm.3pid_changes': {
+            enabled: clientServer.conf.capabilities.enable_3pid_changes ?? true
+          }
+        }
+      } catch (e) {
+        send(
+          res,
+          500,
+          errMsg('unknown', 'Error getting capabilities'),
+          clientServer.logger
+        )
+        return
+      }
+      send(res, 200, JSON.stringify(capabilities), clientServer.logger)
+    })
+  }
+}

--- a/packages/matrix-client-server/src/config.json
+++ b/packages/matrix-client-server/src/config.json
@@ -1,7 +1,25 @@
 {
   "additional_features": false,
+  "application_services": [
+    {
+      "id": "test",
+      "hs_token": "hsTokenTestwdakZQunWWNe3DZitAerw9aNqJ2a6HVp0sJtg7qTJWXcHnBjgN0NL",
+      "as_token": "as_token_test",
+      "url": "http://localhost:3000",
+      "sender_localpart": "sender_localpart_test",
+      "namespaces": {
+        "users": [
+          {
+            "exclusive": false,
+            "regex": "@_irc_bridge_.*"
+          }
+        ]
+      }
+    }
+  ],
   "base_url": "",
   "cache_engine": "",
+  "capabilities": {},
   "cron_service": true,
   "database_engine": "sqlite",
   "database_host": "./tokens.db",
@@ -14,6 +32,7 @@
   "hashes_rate_limit": 100,
   "invitation_server_name": "matrix.to",
   "is_federated_identity_service": false,
+  "is_registration_enabled": true,
   "key_delay": 3600,
   "keys_depth": 5,
   "ldap_base": "",
@@ -22,37 +41,6 @@
   "ldap_uri": "",
   "ldap_user": "",
   "ldapjs_opts": {},
-  "mail_link_delay": 7200,
-  "matrix_server": "localhost",
-  "matrix_database_engine": "sqlite",
-  "matrix_database_host": "./matrix.db",
-  "matrix_database_name": null,
-  "matrix_database_password": null,
-  "matrix_database_ssl": false,
-  "matrix_database_user": null,
-  "pepperCron": "0 0 * * *",
-  "policies": null,
-  "rate_limiting_window": 600000,
-  "rate_limiting_nb_requests": 100,
-  "redis_uri": "",
-  "server_name": "localhost",
-  "smtp_password": "",
-  "smtp_tls": true,
-  "smtp_user": "",
-  "smtp_verify_certificate": true,
-  "smtp_sender": "",
-  "smtp_server": "localhost",
-  "smtp_port": 25,
-  "trust_x_forwarded_for": false,
-  "update_federated_identity_hashes_cron": "3 3 3 * * *",
-  "update_users_cron": "*/10 * * * *",
-  "userdb_engine": "sqlite",
-  "userdb_host": "./tokens.db",
-  "userdb_name": "",
-  "userdb_password": "",
-  "userdb_ssl": false,
-  "userdb_user": "",
-  "template_dir": "./templates",
   "login_flows": {
     "flows": [
       {
@@ -73,23 +61,36 @@
       }
     ]
   },
-  "application_services": [
-    {
-      "id": "test",
-      "hs_token": "hsTokenTestwdakZQunWWNe3DZitAerw9aNqJ2a6HVp0sJtg7qTJWXcHnBjgN0NL",
-      "as_token": "as_token_test",
-      "url": "http://localhost:3000",
-      "sender_localpart": "sender_localpart_test",
-      "namespaces": {
-        "users": [
-          {
-            "exclusive": false,
-            "regex": "@_irc_bridge_.*"
-          }
-        ]
-      }
-    }
-  ],
+  "mail_link_delay": 7200,
+  "matrix_server": "localhost",
+  "matrix_database_engine": "sqlite",
+  "matrix_database_host": "./matrix.db",
+  "matrix_database_name": null,
+  "matrix_database_password": null,
+  "matrix_database_ssl": false,
+  "matrix_database_user": null,
+  "pepperCron": "0 0 * * *",
+  "policies": null,
+  "rate_limiting_window": 600000,
+  "rate_limiting_nb_requests": 100,
+  "redis_uri": "",
+  "server_name": "localhost",
   "sms_folder": "./src/__testData__/sms",
-  "is_registration_enabled": true
+  "smtp_password": "",
+  "smtp_tls": true,
+  "smtp_user": "",
+  "smtp_verify_certificate": true,
+  "smtp_sender": "",
+  "smtp_server": "localhost",
+  "smtp_port": 25,
+  "template_dir": "./templates",
+  "trust_x_forwarded_for": false,
+  "update_federated_identity_hashes_cron": "3 3 3 * * *",
+  "update_users_cron": "*/10 * * * *",
+  "userdb_engine": "sqlite",
+  "userdb_host": "./tokens.db",
+  "userdb_name": "",
+  "userdb_password": "",
+  "userdb_ssl": false,
+  "userdb_user": ""
 }

--- a/packages/matrix-client-server/src/index.test.ts
+++ b/packages/matrix-client-server/src/index.test.ts
@@ -1217,7 +1217,22 @@ describe('Use configuration file', () => {
             expect(response.statusCode).toBe(403)
           })
 
+          it('should return 403 if the requester is not admin and the config does not allow changing avatar_url', async () => {
+            clientServer.conf.capabilities.enable_set_avatar_url = false
+
+            const response = await request(app)
+              .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ avatar_url: 'http://example.com/new_avatar.jpg' })
+            expect(response.statusCode).toBe(403)
+            expect(response.body).toHaveProperty('errcode', 'M_FORBIDDEN')
+
+            clientServer.conf.capabilities.enable_set_avatar_url = true
+          })
+
           it('should return 400 if provided avatar_url is too long', async () => {
+            clientServer.conf.capabilities.enable_set_avatar_url = true
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', `Bearer ${validToken}`)
@@ -1228,6 +1243,7 @@ describe('Use configuration file', () => {
           })
 
           it('should send correct response when requester is admin and target user is on local server', async () => {
+            clientServer.conf.capabilities.enable_set_avatar_url = true
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', `Bearer ${validToken2}`)
@@ -1238,6 +1254,7 @@ describe('Use configuration file', () => {
           })
 
           it('should send correct response when requester is target user (on local server)', async () => {
+            clientServer.conf.capabilities.enable_set_avatar_url = true
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', `Bearer ${validToken}`)
@@ -1248,6 +1265,7 @@ describe('Use configuration file', () => {
           })
 
           it('should correctly update the avatar_url of an existing user', async () => {
+            clientServer.conf.capabilities.enable_set_avatar_url = undefined
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/avatar_url`)
               .set('Authorization', `Bearer ${validToken}`)
@@ -1296,6 +1314,20 @@ describe('Use configuration file', () => {
             expect(response.statusCode).toBe(403)
           })
 
+          it('should return 403 if the requester is not admin and the config does not allow changing display_name', async () => {
+            clientServer.conf.capabilities.enable_set_displayname = false
+
+            const response = await request(app)
+              .put(`/_matrix/client/v3/profile/${testUserId}/displayname`)
+              .set('Authorization', `Bearer ${validToken}`)
+              .set('Accept', 'application/json')
+              .send({ displayname: 'New name' })
+            expect(response.statusCode).toBe(403)
+            expect(response.body).toHaveProperty('errcode', 'M_FORBIDDEN')
+
+            clientServer.conf.capabilities.enable_set_displayname = true
+          })
+
           it('should return 400 if provided display_name is too long', async () => {
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/displayname`)
@@ -1317,6 +1349,7 @@ describe('Use configuration file', () => {
           })
 
           it('should correctly update the display_name of an existing user', async () => {
+            clientServer.conf.capabilities.enable_set_displayname = undefined
             const response = await request(app)
               .put(`/_matrix/client/v3/profile/${testUserId}/displayname`)
               .set('Authorization', `Bearer ${validToken}`)
@@ -1743,6 +1776,99 @@ describe('Use configuration file', () => {
             error: 'Room not found'
           })
         })
+      })
+    })
+
+    describe('/_matrix/client/v3/capabilities', () => {
+      it('should require authentication', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', 'Bearer invalid_token')
+          .set('Accept', 'application/json')
+        expect(response.statusCode).toBe(401)
+      })
+
+      it('should return the capabilities of the server', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+
+        expect(response.status).toBe(200)
+        expect(response.body).toHaveProperty('capabilities')
+        // expect(response.body.capabilities).toHaveProperty('m.room_versions')
+        expect(response.body.capabilities).toHaveProperty(['m.change_password'])
+        expect(response.body.capabilities).toHaveProperty(['m.set_displayname'])
+        expect(response.body.capabilities).toHaveProperty(['m.set_avatar_url'])
+        expect(response.body.capabilities).toHaveProperty(['m.3pid_changes'])
+      })
+
+      it('should return rigth format for m.change_password capability', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+
+        expect(response.status).toBe(200)
+        expect(response.body.capabilities).toHaveProperty(['m.change_password'])
+        expect(response.body.capabilities['m.change_password']).toHaveProperty(
+          'enabled'
+        )
+        const numKeyValuePairs = Object.keys(
+          response.body.capabilities['m.change_password']
+        ).length
+        expect(numKeyValuePairs).toBe(1)
+      })
+
+      it('should return rigth format for m.set_displayname capability', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+
+        expect(response.status).toBe(200)
+        expect(response.body.capabilities).toHaveProperty(['m.set_displayname'])
+        expect(response.body.capabilities['m.set_displayname']).toHaveProperty(
+          'enabled'
+        )
+        const numKeyValuePairs = Object.keys(
+          response.body.capabilities['m.set_displayname']
+        ).length
+        expect(numKeyValuePairs).toBe(1)
+      })
+
+      it('should return rigth format for m.set_avatar_url capability', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+
+        expect(response.status).toBe(200)
+        expect(response.body.capabilities).toHaveProperty(['m.set_avatar_url'])
+        expect(response.body.capabilities['m.set_avatar_url']).toHaveProperty(
+          'enabled'
+        )
+        const numKeyValuePairs = Object.keys(
+          response.body.capabilities['m.set_avatar_url']
+        ).length
+        expect(numKeyValuePairs).toBe(1)
+      })
+
+      it('should return rigth format for m.3pid_changes capability', async () => {
+        const response = await request(app)
+          .get('/_matrix/client/v3/capabilities')
+          .set('Authorization', `Bearer ${validToken}`)
+          .set('Accept', 'application/json')
+
+        expect(response.status).toBe(200)
+        expect(response.body.capabilities).toHaveProperty(['m.3pid_changes'])
+        expect(response.body.capabilities['m.3pid_changes']).toHaveProperty(
+          'enabled'
+        )
+        const numKeyValuePairs = Object.keys(
+          response.body.capabilities['m.3pid_changes']
+        ).length
+        expect(numKeyValuePairs).toBe(1)
       })
     })
   })

--- a/packages/matrix-client-server/src/index.ts
+++ b/packages/matrix-client-server/src/index.ts
@@ -67,6 +67,7 @@ import getRoomState from './rooms/roomId/getState'
 import getRoomStateEvent, {
   getRoomStateEventNoStatekey
 } from './rooms/roomId/getStateEvent'
+import getCapabilities from './capabilities/getCapabilities'
 
 const tables = {
   ui_auth_sessions: 'session_id TEXT NOT NULL, stage_type TEXT NOT NULL'
@@ -177,7 +178,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey':
               getRoomStateEvent(this),
             '/_matrix/client/v3/rooms/:roomId/state/:eventType':
-              getRoomStateEventNoStatekey(this)
+              getRoomStateEventNoStatekey(this),
+            '/_matrix/client/v3/capabilities': getCapabilities(this)
           }
           this.api.post = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -226,7 +228,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/rooms/:roomId/state': badMethod,
             '/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey':
               badMethod,
-            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod
+            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod,
+            '/_matrix/client/v3/capabilities': badMethod
           }
           this.api.put = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -274,7 +277,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/rooms/:roomId/state': badMethod,
             '/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey':
               badMethod,
-            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod
+            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod,
+            '/_matrix/client/v3/capabilities': badMethod
           }
           this.api.delete = {
             '/_matrix/client/v3/account/whoami': badMethod,
@@ -312,7 +316,8 @@ export default class MatrixClientServer extends MatrixIdentityServer<clientDbCol
             '/_matrix/client/v3/rooms/:roomId/state': badMethod,
             '/_matrix/client/v3/rooms/:roomId/state/:eventType/:stateKey':
               badMethod,
-            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod
+            '/_matrix/client/v3/rooms/:roomId/state/:eventType': badMethod,
+            '/_matrix/client/v3/capabilities': badMethod
           }
           resolve(true)
         })

--- a/packages/matrix-client-server/src/profiles/changeProfiles.ts
+++ b/packages/matrix-client-server/src/profiles/changeProfiles.ts
@@ -112,7 +112,20 @@ export const changeAvatarUrl = (
             return
           }
 
-          // TODO: check if changing displayname is allowed according to config settings
+          const allowed =
+            clientServer.conf.capabilities.enable_set_avatar_url ?? true
+          if (byAdmin === 0 && !allowed) {
+            send(
+              res,
+              403,
+              errMsg(
+                'forbidden',
+                'Cannot change avatar_url as not allowed by server'
+              ),
+              clientServer.logger
+            )
+            return
+          }
 
           if (newAvatarUrl.length > MAX_AVATAR_URL_LEN) {
             send(
@@ -226,7 +239,20 @@ export const changeDisplayname = (
               return
             }
 
-            // TODO: check if changing displayname is allowed according to config settings
+            const allowed =
+              clientServer.conf.capabilities.enable_set_displayname ?? true
+            if (byAdmin === 0 && !allowed) {
+              send(
+                res,
+                403,
+                errMsg(
+                  'forbidden',
+                  'Cannot change displayname as not allowed by server'
+                ),
+                clientServer.logger
+              )
+              return
+            }
 
             if (newDisplayname.length > MAX_DISPLAYNAME_LEN) {
               send(

--- a/packages/matrix-client-server/src/types.ts
+++ b/packages/matrix-client-server/src/types.ts
@@ -11,6 +11,7 @@ export type Config = MIdentityServerConfig & {
   application_services: AppServiceRegistration[]
   sms_folder: string
   is_registration_enabled: boolean
+  capabilities: Capabilities
 }
 
 export type DbGetResult = Array<
@@ -384,4 +385,13 @@ interface Namespaces {
 interface Namespace {
   exclusive: boolean
   regex: string
+}
+
+/* https://spec.matrix.org/latest/client-server-api/#capabilities-negotiation */
+
+interface Capabilities {
+  enable_set_displayname?: boolean
+  enable_set_avatar_url?: boolean
+  enable_3pid_changes?: boolean
+  enable_change_password?: boolean
 }


### PR DESCRIPTION
Implements the Capabilities negotiation of the Matrix Protocol (Client-Server)
   cf https://spec.matrix.org/latest/client-server-api/#capabilities-negotiation

In line with the work done, I've modified the respective profile change APIs to take account of these additions.

 TODO : Implement the `m.room_versions` capabilities <- requires the  GET /_matrix/client/versions  API
 TODO : Implement capability checks in the concerned API's for changing password and 3pid changes

(These TODOs are naturally listed in the code itself)