### PR TITLE
✨ add Invitation API toggle based on feature flag

### DIFF
--- a/packages/tom-server/src/invitation-api/routes/index.ts
+++ b/packages/tom-server/src/invitation-api/routes/index.ts
@@ -24,10 +24,11 @@ export default (
   const router = Router()
   const authenticate = authMiddleware(authenticator, logger)
   const controller = new InvitationApiController(db, logger, config)
-  const middleware = new invitationApiMiddleware(db, logger)
+  const middleware = new invitationApiMiddleware(db, logger, config)
   const cookieAuthMiddleware = new CookieAuthenticator(config, logger)
 
   router.use(bodyParser.json())
+  router.use(middleware.checkFeatureEnabled)
 
   /**
    * @openapi

--- a/packages/tom-server/src/invitation-api/routes/index.ts
+++ b/packages/tom-server/src/invitation-api/routes/index.ts
@@ -28,7 +28,7 @@ export default (
   const cookieAuthMiddleware = new CookieAuthenticator(config, logger)
 
   router.use(bodyParser.json())
-  router.use(middleware.checkFeatureEnabled)
+  router.use(PATH, middleware.checkFeatureEnabled)
 
   /**
    * @openapi

--- a/packages/tom-server/src/invitation-api/tests/controller.test.ts
+++ b/packages/tom-server/src/invitation-api/tests/controller.test.ts
@@ -46,7 +46,8 @@ jest.mock('../middlewares/index.ts', () => {
       checkInvitation: passiveMiddlewareMock,
       rateLimitInvitations: passiveMiddlewareMock,
       checkInvitationOwnership: passiveMiddlewareMock,
-      checkGenerateInvitationLinkPayload: passiveMiddlewareMock
+      checkGenerateInvitationLinkPayload: passiveMiddlewareMock,
+      checkFeatureEnabled: passiveMiddlewareMock
     }
   }
 })

--- a/packages/tom-server/src/invitation-api/tests/routes.test.ts
+++ b/packages/tom-server/src/invitation-api/tests/routes.test.ts
@@ -34,7 +34,10 @@ const idServer = new IdServer(
     rate_limiting_window: 5000,
     rate_limiting_nb_requests: 10,
     template_dir: './templates',
-    userdb_host: './tokens.db'
+    userdb_host: './tokens.db',
+    twake_chat: {
+      enable_invitations: true
+    }
   } as unknown as ConfigDescription,
   mockLogger as TwakeLogger
 )
@@ -51,7 +54,8 @@ jest.mock('../middlewares', () => {
       checkInvitation: middlewareSpy,
       rateLimitInvitations: middlewareSpy,
       checkInvitationOwnership: middlewareSpy,
-      checkGenerateInvitationLinkPayload: middlewareSpy
+      checkGenerateInvitationLinkPayload: middlewareSpy,
+      checkFeatureEnabled: middlewareSpy
     }
   }
 })

--- a/packages/tom-server/src/invitation-api/tests/routes.test.ts
+++ b/packages/tom-server/src/invitation-api/tests/routes.test.ts
@@ -55,7 +55,9 @@ jest.mock('../middlewares', () => {
       rateLimitInvitations: middlewareSpy,
       checkInvitationOwnership: middlewareSpy,
       checkGenerateInvitationLinkPayload: middlewareSpy,
-      checkFeatureEnabled: middlewareSpy
+      checkFeatureEnabled: jest.fn().mockImplementation((_req, _res, next) => {
+        next()
+      })
     }
   }
 })


### PR DESCRIPTION
Enable the invitations API based on the config key in `twake_chat.enable_invitations`.

This same config is mirrored in the `well-known` response in the `app.twake.chat` section under the `enable_invitations` key.

This feature is toggled by the `TCHAT_ENABLE_INVITATIONS` environment variable

## Poc

### invitations are disabled

![image](https://github.com/user-attachments/assets/d6445a21-5636-4bbc-9b2e-0885bbe0402f)

### invitations are enabled

![image](https://github.com/user-attachments/assets/6e03aa7a-3a34-463b-974d-a62ba044979e)



closes #231