### PR TITLE
🔀 Updated routing for create room internal on dev

### DIFF
--- a/.compose/examples/tom+fed+chat+admin.pgsql+ldap.yml
+++ b/.compose/examples/tom+fed+chat+admin.pgsql+ldap.yml
@@ -136,6 +136,7 @@ services:
       # - LDAP_USER=uid=tom,dc=docker,dc=localhost  ## Local LDAP is fully readable
       # - LDAP_PASSWORD=T0m_p@Ss                    ## Local LDAP is fully readable
 
+      - MATRIX_INTERNAL_HOST=http://synapse:8008
       - MATRIX_SERVER=matrix.docker.localhost
       - MATRIX_DATABASE_ENGINE=pg
       - MATRIX_DATABASE_HOST=pgsql

--- a/.compose/examples/tom+fed+chat+admin.sqlite.yml
+++ b/.compose/examples/tom+fed+chat+admin.sqlite.yml
@@ -86,6 +86,7 @@ services:
       - USERDB_ENGINE=sqlite
       - USERDB_HOST=/opt/lemon/db/lemon.db
 
+      - MATRIX_INTERNAL_HOST=http://synapse:8008
       - MATRIX_SERVER=matrix.docker.localhost
       - MATRIX_DATABASE_ENGINE=sqlite
       - MATRIX_DATABASE_HOST=/opt/synapse/db/homeserver.db

--- a/.compose/examples/tom+fed+chat.pgsql+ldap.yml
+++ b/.compose/examples/tom+fed+chat.pgsql+ldap.yml
@@ -136,7 +136,7 @@ services:
       # - LDAP_USER=uid=tom,dc=docker,dc=localhost  ## Local LDAP is fully readable
       # - LDAP_PASSWORD=T0m_p@Ss                    ## Local LDAP is fully readable
 
-      - MATRIX_SERVER=matrix.docker.localhost
+      - MATRIX_SERVER=http://synapse:8008
       - MATRIX_DATABASE_ENGINE=pg
       - MATRIX_DATABASE_HOST=pgsql
       - MATRIX_DATABASE_NAME=synapse

--- a/.compose/examples/tom+fed+chat.pgsql+ldap.yml
+++ b/.compose/examples/tom+fed+chat.pgsql+ldap.yml
@@ -136,7 +136,8 @@ services:
       # - LDAP_USER=uid=tom,dc=docker,dc=localhost  ## Local LDAP is fully readable
       # - LDAP_PASSWORD=T0m_p@Ss                    ## Local LDAP is fully readable
 
-      - MATRIX_SERVER=http://synapse:8008
+      - MATRIX_INTERNAL_HOST=http://synapse:8008
+      - MATRIX_SERVER=matrix.docker.localhost
       - MATRIX_DATABASE_ENGINE=pg
       - MATRIX_DATABASE_HOST=pgsql
       - MATRIX_DATABASE_NAME=synapse

--- a/.compose/examples/tom+fed+chat.sqlite.yml
+++ b/.compose/examples/tom+fed+chat.sqlite.yml
@@ -86,6 +86,7 @@ services:
       - USERDB_ENGINE=sqlite
       - USERDB_HOST=/opt/lemon/db/lemon.db
 
+      - MATRIX_INTERNAL_HOST=http://synapse:8008
       - MATRIX_SERVER=matrix.docker.localhost
       - MATRIX_DATABASE_ENGINE=sqlite
       - MATRIX_DATABASE_HOST=/opt/synapse/db/homeserver.db

--- a/.compose/haproxy/haproxy.tom+fed+chat+admin.cfg
+++ b/.compose/haproxy/haproxy.tom+fed+chat+admin.cfg
@@ -24,9 +24,13 @@ frontend http-in
    acl is_synapse_matrix path_beg -i /_matrix
    acl is_synapse_synapse path_beg -i /_synapse
    acl is_well-known path_beg -i /.well-known/matrix
+   acl is_create_room path_beg -i /_matrix/client/v3/createRoom
 
    # If it's asking for the well_known endpoint
    use_backend tom if is_matrix is_well-known
+   # If it's asking for the create room endpoint
+   use_backend tom if is_matrix is_create_room
+
 
    # If asking a synapse endpoint
    #use_backend %[lua.path_to_worker] if is_matrix is_synapse_matrix || is_matrix is_synapse_synapse

--- a/.compose/haproxy/haproxy.tom+fed+chat.cfg
+++ b/.compose/haproxy/haproxy.tom+fed+chat.cfg
@@ -24,9 +24,12 @@ frontend http-in
    acl is_synapse_matrix path_beg -i /_matrix
    acl is_synapse_synapse path_beg -i /_synapse
    acl is_well-known path_beg -i /.well-known/matrix
+   acl is_create_room path_beg -i /_matrix/client/v3/createRoom
 
    # If it's asking for the well_known endpoint
    use_backend tom if is_matrix is_well-known
+   # If it's asking for the create room endpoint
+   use_backend tom if is_matrix is_create_room
 
    # If asking a synapse endpoint
    #use_backend %[lua.path_to_worker] if is_matrix is_synapse_matrix || is_matrix is_synapse_synapse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - USERDB_ENGINE=sqlite
       - USERDB_HOST=/opt/lemon/db/lemon.db
 
+      - MATRIX_INTERNAL_HOST=http://synapse:8008
       - MATRIX_SERVER=matrix.docker.localhost
       - MATRIX_DATABASE_ENGINE=sqlite
       - MATRIX_DATABASE_HOST=/opt/synapse/db/homeserver.db


### PR DESCRIPTION
For local development, requests to the /_matrix/client/v3/createRoom endpoint are now redirected to the tom server.