### PR TITLE
✨ Parse cron job service env flag

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -79,7 +79,7 @@ const twakeChatConf = {
 let conf = {
   ...appServerConf,
   additional_features: process.env.ADDITIONAL_FEATURES || false,
-  cron_service: process.env.CRON_SERVICE ?? true,
+  cron_service: _parseBooleanEnv(process.env.CRON_SERVICE, false),
   database_engine: process.env.DATABASE_ENGINE,
   database_host: process.env.DATABASE_HOST,
   database_name: process.env.DATABASE_NAME,


### PR DESCRIPTION
Using the existing helper to properly handle the CRON_SERVICE env flag.