### PR TITLE
🐛 Get or create user address book when listing or adding a contact

### DIFF
--- a/packages/tom-server/src/addressbook-api/services/index.ts
+++ b/packages/tom-server/src/addressbook-api/services/index.ts
@@ -269,12 +269,11 @@ export class AddressbookService implements IAddressbookService {
     if (userAddressbook == null) {
       this.logger.info('Addressbook not found, creating one')
       userAddressbook = await this._createUserAddressBook(owner)
-    }
-
-    // Throw an error is we couldn't get or create an addressbook
-    if (userAddressbook == null) {
-      this.logger.error('Failed to get or create addressbook')
-      throw new Error('Failed to get or create addressbook')
+      // Throw an error is we couldn't get or create an addressbook
+      if (userAddressbook == null) {
+        this.logger.error('Failed to get or create addressbook')
+        throw new Error('Failed to get or create addressbook')
+      }
     }
 
     return userAddressbook

--- a/packages/tom-server/src/addressbook-api/services/index.ts
+++ b/packages/tom-server/src/addressbook-api/services/index.ts
@@ -270,14 +270,16 @@ export class AddressbookService implements IAddressbookService {
       try {
         this.logger.info('Addressbook not found, creating one')
         userAddressbook = await this._createUserAddressBook(owner)
-        if (userAddressbook == null) {
-          this.logger.error('Failed to create addressbook')
-          throw new Error('Failed to create addressbook')
-        }
       } catch (error) {
         this.logger.error('Failed to create user addressbook', { error })
         throw error
       }
+    }
+
+    // Throw an error is we couldn't get or create an addressbook
+    if (userAddressbook == null) {
+      this.logger.error('Failed to get or create addressbook')
+      throw new Error('Failed to get or create addressbook')
     }
 
     return userAddressbook

--- a/packages/tom-server/src/addressbook-api/services/index.ts
+++ b/packages/tom-server/src/addressbook-api/services/index.ts
@@ -267,13 +267,8 @@ export class AddressbookService implements IAddressbookService {
 
     // Create if it doesn’t exist
     if (userAddressbook == null) {
-      try {
-        this.logger.info('Addressbook not found, creating one')
-        userAddressbook = await this._createUserAddressBook(owner)
-      } catch (error) {
-        this.logger.error('Failed to create user addressbook', { error })
-        throw error
-      }
+      this.logger.info('Addressbook not found, creating one')
+      userAddressbook = await this._createUserAddressBook(owner)
     }
 
     // Throw an error is we couldn't get or create an addressbook

--- a/packages/tom-server/src/addressbook-api/tests/controller.test.ts
+++ b/packages/tom-server/src/addressbook-api/tests/controller.test.ts
@@ -17,9 +17,11 @@ const dbMock = {
 }
 
 const loggerMock = {
-  info: jest.fn(),
   error: jest.fn(),
-  warn: jest.fn()
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  silly: jest.fn()
 }
 
 const authenticatorMock = jest

--- a/packages/tom-server/src/addressbook-api/tests/service.test.ts
+++ b/packages/tom-server/src/addressbook-api/tests/service.test.ts
@@ -13,9 +13,11 @@ const dbMock = {
 }
 
 const loggerMock = {
-  info: jest.fn(),
   error: jest.fn(),
-  warn: jest.fn()
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  silly: jest.fn()
 }
 
 afterEach(() => {

--- a/packages/tom-server/src/identity-server/index.ts
+++ b/packages/tom-server/src/identity-server/index.ts
@@ -32,145 +32,143 @@ export default class TwakeIdentityServer extends MatrixIdentityServer<twakeDbCol
     this.ready = new Promise((resolve, reject) => {
       superReady
         .then(async () => {
-           // Extend API
-            /**
-             * @openapi
-             * '/_twake/identity/v1/lookup/match':
-             *  post:
-             *    tags:
-             *    - Identity server
-             *    description: Looks up the Organization User IDs which match value sent
-             *    requestBody:
-             *      description: Object containing detail for the search and the returned data
-             *      required: true
-             *      content:
-             *        application/json:
-             *          schema:
-             *            type: object
-             *            properties:
-             *              scope:
-             *                type: array
-             *                items:
-             *                  type: string
-             *                  description: List of fields to search in (uid, mail,...)
-             *              fields:
-             *                type: array
-             *                items:
-             *                  type: string
-             *                  description: List of fields to return for matching users (uid, mail, mobile, displayName, givenName, cn, sn)
-             *              val:
-             *                type: string
-             *                description: Optional value to search
-             *              limit:
-             *                type: integer
-             *                description:  Optional max number of result to return (default 30)
-             *              offset:
-             *                type: integer
-             *                description: Optional offset for pagination
-             *            required:
-             *              - scope
-             *              - fields
-             *          example:
-             *            scope: [mail, uid]
-             *            fields: [uid, displayName, sn, givenName, mobile]
-             *            val: rtyler
-             *            limit: 3
-             *    responses:
-             *      200:
-             *        description: Success
-             *        content:
-             *          application/json:
-             *            schema:
-             *              type: object
-             *              properties:
-             *                matches:
-             *                  type: array
-             *                  items:
-             *                    type: object
-             *                    properties:
-             *                      address:
-             *                        type: string
-             *                        description: Matrix address
-             *                      uid:
-             *                        type: string
-             *                        description: id of a matching user
-             *                      mail:
-             *                        type: string
-             *                        description: email address of a matching user
-             *                  description: List of users that match
-             *            example:
-             *              matches: [{uid: dwho, mail: dwho@badwolf.com}]
-             *      401:
-             *        $ref: '#/components/responses/Unauthorized'
-             *      400:
-             *        $ref: '#/components/responses/BadRequest'
-             *
-             * '/_twake/identity/v1/lookup/diff':
-             *  post:
-             *    tags:
-             *    - Identity server
-             *    description: Looks up the Organization User IDs updated since X
-             *    requestBody:
-             *      description: Object containing the timestamp
-             *      required: true
-             *      content:
-             *        application/json:
-             *          schema:
-             *            type: object
-             *            properties:
-             *              since:
-             *                type: integer
-             *                description: timestamp
-             *              fields:
-             *                type: array
-             *                items:
-             *                  type: string
-             *                  description: List of fields to return for matching users
-             *              limit:
-             *                type: integer
-             *                description:  Optional max number of result to return (default 30)
-             *              offset:
-             *                type: integer
-             *                description: Optional offset for pagination
-             *          example:
-             *            since: 1685074279
-             *            fields: [uid, mail]
-             *            limit: 3
-             *    responses:
-             *      200:
-             *        description: Success
-             *        content:
-             *          application/json:
-             *            schema:
-             *              type: object
-             *              properties:
-             *                matches:
-             *                  type: array
-             *                  items:
-             *                    type: object
-             *                    properties:
-             *                      address:
-             *                        type: string
-             *                        description: Matrix address
-             *                      timestamp:
-             *                        type: integer
-             *                        description: current server timestamp
-             *                      uid:
-             *                        type: string
-             *                        description: id of a matching user
-             *                      mail:
-             *                        type: string
-             *                        description: email address of a matching user
-             *                  description: List of users that match
-             *            example:
-             *              matches: [{uid: dwho, mail: dwho@badwolf.com}]
-             */
-            this.api.post['/_twake/identity/v1/lookup/match'] =
-              await autocompletion(this, this.logger)
-          if (
-            this.conf.additional_features === true 
-          ) {
-             this.api.post['/_twake/identity/v1/lookup/diff'] = diff(
+          // Extend API
+          /**
+           * @openapi
+           * '/_twake/identity/v1/lookup/match':
+           *  post:
+           *    tags:
+           *    - Identity server
+           *    description: Looks up the Organization User IDs which match value sent
+           *    requestBody:
+           *      description: Object containing detail for the search and the returned data
+           *      required: true
+           *      content:
+           *        application/json:
+           *          schema:
+           *            type: object
+           *            properties:
+           *              scope:
+           *                type: array
+           *                items:
+           *                  type: string
+           *                  description: List of fields to search in (uid, mail,...)
+           *              fields:
+           *                type: array
+           *                items:
+           *                  type: string
+           *                  description: List of fields to return for matching users (uid, mail, mobile, displayName, givenName, cn, sn)
+           *              val:
+           *                type: string
+           *                description: Optional value to search
+           *              limit:
+           *                type: integer
+           *                description:  Optional max number of result to return (default 30)
+           *              offset:
+           *                type: integer
+           *                description: Optional offset for pagination
+           *            required:
+           *              - scope
+           *              - fields
+           *          example:
+           *            scope: [mail, uid]
+           *            fields: [uid, displayName, sn, givenName, mobile]
+           *            val: rtyler
+           *            limit: 3
+           *    responses:
+           *      200:
+           *        description: Success
+           *        content:
+           *          application/json:
+           *            schema:
+           *              type: object
+           *              properties:
+           *                matches:
+           *                  type: array
+           *                  items:
+           *                    type: object
+           *                    properties:
+           *                      address:
+           *                        type: string
+           *                        description: Matrix address
+           *                      uid:
+           *                        type: string
+           *                        description: id of a matching user
+           *                      mail:
+           *                        type: string
+           *                        description: email address of a matching user
+           *                  description: List of users that match
+           *            example:
+           *              matches: [{uid: dwho, mail: dwho@badwolf.com}]
+           *      401:
+           *        $ref: '#/components/responses/Unauthorized'
+           *      400:
+           *        $ref: '#/components/responses/BadRequest'
+           *
+           * '/_twake/identity/v1/lookup/diff':
+           *  post:
+           *    tags:
+           *    - Identity server
+           *    description: Looks up the Organization User IDs updated since X
+           *    requestBody:
+           *      description: Object containing the timestamp
+           *      required: true
+           *      content:
+           *        application/json:
+           *          schema:
+           *            type: object
+           *            properties:
+           *              since:
+           *                type: integer
+           *                description: timestamp
+           *              fields:
+           *                type: array
+           *                items:
+           *                  type: string
+           *                  description: List of fields to return for matching users
+           *              limit:
+           *                type: integer
+           *                description:  Optional max number of result to return (default 30)
+           *              offset:
+           *                type: integer
+           *                description: Optional offset for pagination
+           *          example:
+           *            since: 1685074279
+           *            fields: [uid, mail]
+           *            limit: 3
+           *    responses:
+           *      200:
+           *        description: Success
+           *        content:
+           *          application/json:
+           *            schema:
+           *              type: object
+           *              properties:
+           *                matches:
+           *                  type: array
+           *                  items:
+           *                    type: object
+           *                    properties:
+           *                      address:
+           *                        type: string
+           *                        description: Matrix address
+           *                      timestamp:
+           *                        type: integer
+           *                        description: current server timestamp
+           *                      uid:
+           *                        type: string
+           *                        description: id of a matching user
+           *                      mail:
+           *                        type: string
+           *                        description: email address of a matching user
+           *                  description: List of users that match
+           *            example:
+           *              matches: [{uid: dwho, mail: dwho@badwolf.com}]
+           */
+          this.api.post['/_twake/identity/v1/lookup/match'] =
+            await autocompletion(this, this.logger)
+          if (this.conf.additional_features === true) {
+            this.api.post['/_twake/identity/v1/lookup/diff'] = diff(
               this,
               this.logger
             )

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -4,6 +4,7 @@ import { type Response } from 'express'
 import type http from 'http'
 import type TwakeIdentityServer from '..'
 import { AddressbookService } from '../../addressbook-api/services'
+import { type Contact } from '../../addressbook-api/types'
 
 type SearchFunction = (
   res: Response | http.ServerResponse,
@@ -60,8 +61,12 @@ const _search = async (
     if (!error) {
       const owner = data.owner ?? '';
       const addressBookService = new AddressbookService(idServer.db, logger)
-      let { contacts } = await addressBookService.list(owner)
-      logger.info(`Found ${contacts.length} contacts in addressbook for owner ${owner}`);
+      let contacts: Contact[] = [];
+
+      if (owner.length !== 0) {
+        ({ contacts } = await addressBookService.list(owner));
+        logger.info(`Found ${contacts.length} contacts in addressbook for owner ${owner}`);
+      }
 
       const val = data.val?.toLowerCase() ?? ''
       const normalizedScope = scope.map((f) =>

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -35,45 +35,101 @@ const _search = async (
   idServer: TwakeIdentityServer,
   logger: TwakeLogger
 ): Promise<SearchFunction> => {
+  logger.debug('[_search] Initializing search function factory.')
+
   return async (res, data) => {
-    const sendError = (e: string): void => {
+    logger.info('[_search] Incoming search request.', {
+      queryData: JSON.stringify(data)
+    })
+
+    const sendError = (e: string, context?: string): void => {
       /* istanbul ignore next */
-      logger.error('Autocompletion error', e)
+      logger.error('Autocompletion error', {
+        message: e,
+        context: context || 'unknown'
+      })
       /* istanbul ignore next */
       send(res, 500, errMsg('unknown', e))
     }
+
     let fields = data.fields
     let scope = data.scope
+
+    logger.debug('[_search] Initial fields and scope.', {
+      initialFields: fields,
+      initialScope: scope
+    })
+
     /* istanbul ignore if */
-    if (fields == null) fields = []
+    if (fields == null) {
+      fields = []
+      logger.debug('[_search] Fields were null, initialized to empty array.')
+    }
     /* istanbul ignore if */
-    if (typeof scope !== 'object') scope = [scope]
+    if (typeof scope !== 'object' || !Array.isArray(scope)) {
+      // Added Array.isArray check for robustness
+      scope = [scope as string] // Cast to string as it could be a single string from original type
+      logger.debug(
+        '[_search] Scope was not an array, initialized to single-element array.',
+        { newScope: scope }
+      )
+    }
+
     let error = false
     fields.forEach((v) => {
       /* istanbul ignore next */
-      if (!SearchFields.has(v)) error = true
+      if (!SearchFields.has(v)) {
+        error = true
+        logger.warn('[_search] Invalid field detected.', { field: v })
+      }
     })
     scope.forEach((v) => {
       /* istanbul ignore next */
-      if (!SearchFields.has(v)) error = true
+      if (!SearchFields.has(v)) {
+        error = true
+        logger.warn('[_search] Invalid scope value detected.', {
+          scopeValue: v
+        })
+      }
     })
+
     /* istanbul ignore else */
     if (!error) {
-      const owner = data.owner ?? '';
-      const addressBookService = new AddressbookService(idServer.db, logger)
-      let contacts: Contact[] = [];
+      logger.debug('[_search] Input fields and scope validated successfully.')
+      const owner = data.owner ?? ''
+      let contacts: Contact[] // Declare contacts without immediate initialization
+
+      logger.debug(
+        '[_search] Attempting to fetch contacts from address book.',
+        { owner: data.owner ?? 'no-owner-provided' }
+      )
 
       if (owner.length !== 0) {
-        ({ contacts } = await addressBookService.list(owner));
-        logger.info(`Found ${contacts.length} contacts in addressbook for owner ${owner}`);
+        const addressBookService = new AddressbookService(idServer.db, logger)
+        const result = await addressBookService.list(owner) // Call and get the result
+        contacts = result.contacts // Assign directly
+        logger.info('[_search] Contacts fetched from address book.', {
+          numberOfContacts: contacts.length
+        })
+      } else {
+        contacts = [] // Initialize to empty if owner is empty, and skip service call
+        logger.debug('[_search] Owner is empty, skipping address book fetch.')
       }
 
       const val = data.val?.toLowerCase() ?? ''
       const normalizedScope = scope.map((f) =>
         f === 'matrixAddress' ? 'uid' : f
       )
+      logger.debug('[_search] Normalized scope and search value.', {
+        normalizedScope,
+        searchValue: val
+      })
 
       if (val.length > 0) {
+        logger.debug('[_search] Filtering contacts based on search value.', {
+          valueToFilter: val
+        })
+        const initialContactCount = contacts.length
         contacts = contacts.filter((contact) =>
           normalizedScope.some((field) => {
             const fieldVal = (() => {
@@ -90,62 +146,136 @@ const _search = async (
                   return ''
               }
             })()
-            return fieldVal?.toLowerCase().includes(val)
+            const match = fieldVal?.toLowerCase().includes(val)
+            if (match) {
+              logger.silly('[_search] Contact matched filter criteria.', {
+                contactMxid: contact.mxid,
+                field,
+                fieldVal,
+                val
+              })
+            }
+            return match
           })
         )
+        logger.debug('[_search] Contacts filtered.', {
+          initialContactCount,
+          contactsAfterFilter: contacts.length
+        })
       }
 
       const contactMap = new Map<string, any>()
       for (const contact of contacts) {
         const uid = contact.mxid?.replace(/^@(.*?):.*/, '$1')
-        if (uid.length > 0) {
+        if (uid && uid.length > 0) {
+          // Ensure uid is valid before adding to map
           contactMap.set(uid, {
             uid,
             cn: contact.display_name,
             address: contact.mxid
           })
+          logger.silly('[_search] Added contact to map.', {
+            uid,
+            displayName: contact.display_name
+          })
+        } else {
+          logger.warn('[_search] Skipping contact due to invalid UID.', {
+            contactMxid: contact.mxid
+          })
         }
       }
+      logger.debug('[_search] Contact map populated.', {
+        contactMapSize: contactMap.size
+      })
+
       const _fields = fields.includes('uid') ? fields : [...fields, 'uid']
       const _scope = scope.map((f) => (f === 'matrixAddress' ? 'uid' : f))
       const value = data.val?.replace(/^@(.*?):(?:.*)$/, '$1')
+
+      logger.debug('[_search] Preparing userDB query parameters.', {
+        queryFields: _fields,
+        queryScope: _scope,
+        queryValue: value,
+        additionalFeaturesEnabled: idServer.conf.additional_features
+      })
+
       const request =
-        (idServer.conf.additional_features === true)
+        process.env.ADDITIONAL_FEATURES === 'true' ||
+        (idServer.conf.additional_features as boolean)
           ? typeof value === 'string' && value.length > 0
             ? idServer.userDB.match('users', _fields, _scope, value, _fields[0])
             : idServer.userDB.getAll('users', _fields, _fields[0])
           : Promise.resolve([])
+
+      logger.info('[_search] UserDB query initiated.')
+
       request
         .then((rows) => {
+          logger.debug('[_search] Received rows from userDB.', {
+            numberOfUserRows: rows.length
+          })
+
           if (rows.length === 0 && contactMap.size === 0) {
             /* istanbul ignore next */
+            logger.info(
+              '[_search] No matches found from userDB or contactMap. Sending empty response.'
+            )
             send(res, 200, { matches: [], inactive_matches: [] })
           } else {
             const start = data.offset ?? 0
             const end = start + (data.limit ?? 30)
+            logger.debug('[_search] Applying pagination to userDB rows.', {
+              start,
+              end,
+              totalRowsBeforeSlice: rows.length
+            })
             rows = rows.slice(start, end)
+            logger.debug('[_search] UserDB rows after slicing.', {
+              numberOfUserRowsAfterSlice: rows.length
+            })
+
             const mUid = rows.map((v) => {
               return toMatrixId(v.uid as string, idServer.conf.server_name)
             })
+            logger.debug('[_search] Prepared Matrix UIDs for matrixDb query.', {
+              matrixUidsCount: mUid.length
+            })
+
             /**
              * For the record, this can be replaced by a call to
              * <matrix server>/_matrix/app/v1/users/{userId}
              *
              * See https://spec.matrix.org/v1.6/application-service-api/#get_matrixappv1usersuserid
              */
+            logger.info(
+              '[_search] Initiating matrixDb query to get user presence.'
+            )
             idServer.matrixDb
               .get('users', ['*'], { name: mUid })
               .then((matrixRows) => {
+                logger.debug('[_search] Received rows from matrixDb.', {
+                  numberOfMatrixRows: matrixRows.length
+                })
                 const mUids: Record<string, true> = {}
                 const matches: typeof rows = []
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 const inactive_matches: typeof rows = []
 
                 for (const mrow of matrixRows) {
-                  mUids[
-                    (mrow.name as string).replace(/^@(.*?):(?:.*)$/, '$1')
-                  ] = true
+                  const uidFromMatrix = (mrow.name as string).replace(
+                    /^@(.*?):(?:.*)$/,
+                    '$1'
+                  )
+                  mUids[uidFromMatrix] = true
+                  logger.silly(
+                    '[_search] Processed Matrix user from matrixDb.',
+                    { matrixUid: uidFromMatrix }
+                  )
                 }
+                logger.debug(
+                  '[_search] Populated Matrix UIDs map for active users.',
+                  { activeMatrixUsersCount: Object.keys(mUids).length }
+                )
 
                 for (const row of rows) {
                   row.address = toMatrixId(
@@ -157,32 +287,84 @@ const _search = async (
 
                   if (contactMap.has(uid)) {
                     row.cn = contactMap.get(uid).cn // Update display name from addressbook
+                    logger.silly(
+                      '[_search] Updated display name from contact map for UID.',
+                      { uid, newCn: row.cn }
+                    )
                     contactMap.delete(uid)
                   }
 
                   if (mUids[uid]) {
                     matches.push(row)
+                    logger.silly('[_search] Added user to active matches.', {
+                      uid
+                    })
                   } else {
                     inactive_matches.push(row)
+                    logger.silly('[_search] Added user to inactive matches.', {
+                      uid
+                    })
                   }
                 }
 
                 // Merge remaining contacts from Map into matches
                 for (const contact of contactMap.values()) {
                   matches.push(contact)
+                  logger.silly(
+                    '[_search] Merged remaining contact from map into matches.',
+                    { contactUid: contact.uid }
+                  )
                 }
+
+                logger.info('[_search] Final search results compiled.', {
+                  activeMatchesCount: matches.length,
+                  inactiveMatchesCount: inactive_matches.length
+                })
 
                 send(res, 200, {
                   matches,
                   inactive_matches
                 })
+                logger.silly(
+                  '[_search] Exiting search request handler (success).'
+                )
               })
-              .catch(sendError)
+              .catch((e) => {
+                logger.error(
+                  '[_search] Error during matrixDb query or result processing.',
+                  { error: e }
+                )
+                sendError(
+                  e instanceof Error ? e.message : String(e),
+                  'matrixDb_query_or_processing'
+                )
+                logger.silly(
+                  '[_search] Exiting search request handler (matrixDb error).'
+                )
+              })
           }
         })
-        .catch(sendError)
+        .catch((e) => {
+          logger.error(
+            '[_search] Error during userDB query or initial result processing.',
+            { error: e }
+          )
+          sendError(
+            e instanceof Error ? e.message : String(e),
+            'userDb_query_or_initial_processing'
+          )
+          logger.silly(
+            '[_search] Exiting search request handler (userDb error).'
+          )
+        })
     } else {
+      logger.warn(
+        '[_search] Invalid parameters detected. Sending 400 response.'
+      )
       send(res, 400, errMsg('invalidParam'))
+      logger.silly(
+        '[_search] Exiting search request handler (invalid parameters).'
+      )
     }
   }
 }

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -58,8 +58,10 @@ const _search = async (
     })
     /* istanbul ignore else */
     if (!error) {
+      const owner = data.owner ?? '';
       const addressBookService = new AddressbookService(idServer.db, logger)
-      let { contacts } = await addressBookService.list(data.owner ?? '')
+      let { contacts } = await addressBookService.list(owner)
+      logger.info(`Found ${contacts.length} contacts in addressbook for owner ${owner}`);
 
       const val = data.val?.toLowerCase() ?? ''
       const normalizedScope = scope.map((f) =>

--- a/packages/tom-server/src/index.ts
+++ b/packages/tom-server/src/index.ts
@@ -60,9 +60,7 @@ export default class TwakeServer {
     this.ready = new Promise<boolean>((resolve, reject) => {
       this._initServer(confDesc)
         .then(() => {
-          if (
-            this.conf.additional_features === true
-          ) {
+          if (this.conf.additional_features === true) {
             const appServiceApi = new AppServiceAPI(this, confDesc, this.logger)
             this.endpoints.use(appServiceApi.router.routes)
           }
@@ -177,7 +175,11 @@ export default class TwakeServer {
       this.logger
     )
 
-    const matrixClientApi = MatrixclientApi(this.conf, this.idServer.authenticate, this.logger)
+    const matrixClientApi = MatrixclientApi(
+      this.conf,
+      this.idServer.authenticate,
+      this.logger
+    )
 
     this.endpoints.use(privateNoteApi)
     this.endpoints.use(mutualRoolsApi)

--- a/packages/tom-server/src/matrix-api/client/createRoom/routes/index.ts
+++ b/packages/tom-server/src/matrix-api/client/createRoom/routes/index.ts
@@ -15,7 +15,11 @@ import authMiddleware from '../../../../utils/middlewares/auth.middleware'
  * @param {TwakeLogger} defaultLogger
  * @returns {Router}
  */
-export default (config: Config, authenticator: AuthenticationFunction, defaultLogger?: TwakeLogger): Router => {
+export default (
+  config: Config,
+  authenticator: AuthenticationFunction,
+  defaultLogger?: TwakeLogger
+): Router => {
   const logger = defaultLogger ?? getLogger(config as unknown as LoggerConfig)
   const router = Router()
   const controller = new CreateRoomController(config, logger)

--- a/packages/tom-server/src/matrix-api/client/createRoom/tests/controller.test.ts
+++ b/packages/tom-server/src/matrix-api/client/createRoom/tests/controller.test.ts
@@ -1,7 +1,12 @@
 import express, { type NextFunction } from 'express'
 import bodyParser from 'body-parser'
 import { TwakeLogger } from '@twake/logger'
-import type { AuthenticationFunction, AuthRequest, Config, CreateRoomPayload } from '../../../../types'
+import type {
+  AuthenticationFunction,
+  AuthRequest,
+  Config,
+  CreateRoomPayload
+} from '../../../../types'
 import router from '../routes'
 import supertest from 'supertest'
 
@@ -45,7 +50,7 @@ const mockAuthenticationFunction: AuthenticationFunction = (
 ) => {
   // Attach mock user ID on the request object
   // Must cast req as any because it's typed as IncomingMessage | Request
-  (req as any).userId = '@user:server.com'
+  ;(req as any).userId = '@user:server.com'
 
   const mockTokenContent = {
     user_id: '@user:server.com',

--- a/packages/tom-server/src/types.ts
+++ b/packages/tom-server/src/types.ts
@@ -272,7 +272,7 @@ export interface PowerLevelEventContent {
     'm.room.history_visibility': number
     'm.room.power_levels': number
     'm.room.encryption': number
-  },
+  }
   users?: Record<string, number>
   creator_becomes?: number
 }


### PR DESCRIPTION
When listing a user address book, make sure it exists first or create it with `_getOrCreateUserAddressBook` helper method. A refactored portion of `addContacts` was affected by this bug fix.