### PR TITLE
fix(tom): handles missing property and uses LDAP_FILTER when fetching contacts

### DIFF
--- a/.compose/ldap/ldif/base_ldap_users.ldif
+++ b/.compose/ldap/ldif/base_ldap_users.ldif
@@ -10,6 +10,12 @@ objectClass: top
 objectClass: organizationalUnit
 ou: users
 
+dn: cn=readers,ou=users,dc=docker,dc=localhost
+objectclass: groupOfNames
+member: uid=dwho,ou=users,dc=docker,dc=localhost
+member: uid=rtyler,ou=users,dc=docker,dc=localhost
+cn: readers
+
 dn: uid=dwho,ou=users,dc=docker,dc=localhost
 objectClass: inetOrgPerson
 uid: dwho

--- a/packages/tom-server/src/identity-server/lookup/_search.ts
+++ b/packages/tom-server/src/identity-server/lookup/_search.ts
@@ -222,6 +222,31 @@ const _search = async (
             )
             send(res, 200, { matches: [], inactive_matches: [] })
           } else {
+            // Filter rows to ensure each element has a 'uid' property
+            const filteredRows = rows.filter((row) => {
+              const toBeKept =
+                row && typeof row.uid === 'string' && row.uid.length > 0
+              if (!toBeKept)
+                logger.warn(
+                  `[_search] Following element from userDB is invalid: ${JSON.stringify(
+                    row
+                  )}`
+                )
+              return toBeKept
+            })
+            logger.debug(
+              '[_search] Filtered rows to include only elements with a valid UID.',
+              {
+                originalRowCount: rows.length,
+                filteredRowCount: filteredRows.length
+              }
+            )
+            if (rows.length != filteredRows.length)
+              logger.warn(
+                '[_search] Invalid elements found after fetching user registry, PLEASE VERIFY YOUR LDAP_FILTER!'
+              )
+            rows = filteredRows // Reassign rows to the filtered array
+
             const start = data.offset ?? 0
             const end = start + (data.limit ?? 30)
             logger.debug('[_search] Applying pagination to userDB rows.', {


### PR DESCRIPTION
When triggering `/_twake/identity/v1/lookup/match` with `ADDITIONAL_FEATURES` enabled the server will fetch data from the `User DB`. If the returned values do not contain a `uid` filed then the following error is triggred.

```sh
2025-07-24 10:41:39.726	
SILLY | 2025-07-24T08:41:39.726Z | [_search] Exiting search request handler (userDb error).
2025-07-24 10:41:39.724	
ERROR | 2025-07-24T08:41:39.723Z | Autocompletion error Cannot read properties of undefined (reading 'match') | CONTEXT: userDb_query_or_initial_processing
2025-07-24 10:41:39.723	
ERROR | 2025-07-24T08:41:39.723Z | [_search] Error during userDB query or initial result processing. | ERROR: TypeError: Cannot read properties of undefined (reading 'match')
2025-07-24 10:41:39.722	
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-07-24 10:41:39.722	
    at file:///usr/src/app/packages/tom-server/src/identity-server/lookup/_search.ts:240:31
2025-07-24 10:41:39.722	
    at Array.map (<anonymous>)
2025-07-24 10:41:39.722	
    at map (file:///usr/src/app/packages/tom-server/src/identity-server/lookup/_search.ts:242:22)
2025-07-24 10:41:39.722	
    at toMatrixId (file:///usr/src/app/packages/utils/src/utils.ts:143:18)
2025-07-24 10:41:39.722	
TypeError: Cannot read properties of undefined (reading 'match')
2025-07-24 10:41:39.718	
{"cn":"readers"}
2025-07-24 10:41:39.716	
DEBUG | 2025-07-24T08:41:39.716Z | [_search] UserDB rows after slicing. | NUMBEROFUSERROWSAFTERSLICE: 13
```

This is also happening because the LDAP `_get` function is not using the configured `LDAP_FILTER` that should be set to only fetch properly formed `inetOrgPerson`.