### PR TITLE
feat(common-settings): make dead letter optional

### DIFF
--- a/packages/tom-server/src/config.json
+++ b/packages/tom-server/src/config.json
@@ -272,9 +272,7 @@
       "enabled": false,
       "queue": "settings.queue",
       "routingKey": "settings.routing.key",
-      "exchange": "exchange.exchange",
-      "deadLetterExchange": "settings.dead.letter.exchange",
-      "deadLetterRoutingKey": "settings.dead.letter.routing.key"
+      "exchange": "exchange.exchange"
     },
     "matrix_profile_updates_allowed": true
   }

--- a/packages/tom-server/src/types.ts
+++ b/packages/tom-server/src/types.ts
@@ -70,8 +70,8 @@ export type Config = MConfig &
         exchange: string
         queue: string
         routingKey: string
-        deadLetterExchange: string
-        deadLetterRoutingKey: string
+        deadLetterExchange?: string
+        deadLetterRoutingKey?: string
       }
       matrix_profile_updates_allowed: boolean
     }

--- a/server.mjs
+++ b/server.mjs
@@ -59,11 +59,9 @@ const featuresConf = {
     exchange:
       process.env.FEATURE_COMMON_SETTINGS_EXCHANGE || 'settings.exchange',
     deadLetterExchange:
-      process.env.FEATURE_COMMON_SETTINGS_DEAD_LETTER_EXCHANGE ||
-      'settings.dead.letter.exchange',
+      process.env.FEATURE_COMMON_SETTINGS_DEAD_LETTER_EXCHANGE,
     deadLetterRoutingKey:
-      process.env.FEATURE_COMMON_SETTINGS_DEAD_LETTER_ROUTING_KEY ||
-      'settings.dead.letter.routing.key'
+      process.env.FEATURE_COMMON_SETTINGS_DEAD_LETTER_ROUTING_KEY
   },
   matrix_profile_updates_allowed: _parseBooleanEnv(
     process.env.FEATURE_MATRIX_PROFILE_UPDATES_ALLOWED,


### PR DESCRIPTION
Makes the dead letter optional by removing the default values.