### PR TITLE
chore(cs-bridge): adds ssl and vacuumDelay in config

### DIFF
--- a/.compose/cs-bridge/config.yaml
+++ b/.compose/cs-bridge/config.yaml
@@ -20,6 +20,8 @@ database:
   name: "tom_db"
   user: "twake"
   password: "twake_password"
+  ssl: false
+  vacuumDelay: 3600  # 1 hour in seconds
 
 # RabbitMQ Configuration
 # Message queue setup for publishing and consuming settings update events

--- a/packages/common-settings-bridge/config.example.yaml
+++ b/packages/common-settings-bridge/config.example.yaml
@@ -20,6 +20,8 @@ database:
   name: 'tom_db'
   user: 'twake'
   password: 'twake_password'
+  ssl: false
+  vacuumDelay: 3600 # 1 hour in seconds
 
 # RabbitMQ Configuration
 # Message queue setup for publishing and consuming settings update events

--- a/packages/common-settings-bridge/src/bridge.ts
+++ b/packages/common-settings-bridge/src/bridge.ts
@@ -79,7 +79,8 @@ export class CommonSettingsBridge {
       database_name: this.#config.database.name,
       database_user: this.#config.database.user,
       database_password: this.#config.database.password,
-      database_vacuum_delay: 3600
+      ssl: this.#config.database.ssl ?? false,
+      database_vacuum_delay: this.#config.database.vacuumDelay ?? 3600
     }
 
     this.#log.debug(

--- a/packages/common-settings-bridge/src/types.ts
+++ b/packages/common-settings-bridge/src/types.ts
@@ -71,6 +71,8 @@ export interface DatabaseConfig {
   readonly name?: string
   readonly user?: string
   readonly password?: string
+  readonly ssl?: boolean
+  readonly vacuumDelay?: number
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database SSL configuration is now available and user-configurable (default: disabled)
  * Database vacuum delay is now configurable with a 1-hour default value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->