### PR TITLE
fix(cs-bridge): use bot credentials for avatar upload in admin/fallback modes

### DIFF
--- a/packages/common-settings-bridge/src/bridge.test.ts
+++ b/packages/common-settings-bridge/src/bridge.test.ts
@@ -5,7 +5,7 @@ import { Bridge, Logger, Intent } from 'matrix-appservice-bridge'
 import { AMQPConnector } from '@twake/amqp-connector'
 import { Database } from '@twake/db'
 import type { ConsumeMessage, Channel } from 'amqplib'
-import type { BridgeConfig, UserSettings, SettingsPayload } from './types'
+import type { BridgeConfig, StoredUserSettings, SettingsPayload } from './types'
 import { SynapseAdminRetryMode } from './types'
 
 // Mock external dependencies
@@ -296,7 +296,7 @@ describe('CommonSettingsBridge', () => {
       channel: Channel
     ) => Promise<void>
     let mockMessage: ConsumeMessage
-    let mockUserSettings: UserSettings | null
+    let mockUserSettings: StoredUserSettings | null
     let mockPayload: SettingsPayload
 
     beforeEach(async () => {
@@ -467,8 +467,7 @@ describe('CommonSettingsBridge', () => {
       expect(mockProfileUpdater.processChanges).toHaveBeenCalledWith(
         '@user:example.com',
         null,
-        mockPayload,
-        true
+        mockPayload
       )
     })
 
@@ -510,8 +509,7 @@ describe('CommonSettingsBridge', () => {
       expect(mockProfileUpdater.processChanges).toHaveBeenCalledWith(
         '@user:example.com',
         oldPayload,
-        mockPayload,
-        false
+        mockPayload
       )
     })
 

--- a/packages/common-settings-bridge/src/index.test.ts
+++ b/packages/common-settings-bridge/src/index.test.ts
@@ -448,10 +448,11 @@ describe('CommonSettingsBridge - Change Detection', () => {
 
     const existingSettings = {
       matrix_id: '@user:example.com',
-      settings: JSON.stringify({
+      settings: {
+        matrix_id: '@user:example.com',
         display_name: 'Test User',
         avatar: 'mxc://example.com/avatar123'
-      }),
+      },
       version: 1,
       timestamp: Date.now() - 1000,
       request_id: 'old-request'
@@ -477,10 +478,11 @@ describe('CommonSettingsBridge - Change Detection', () => {
 
     const existingSettings = {
       matrix_id: '@user:example.com',
-      settings: JSON.stringify({
+      settings: {
+        matrix_id: '@user:example.com',
         display_name: 'Old Name',
         avatar: 'mxc://example.com/avatar123'
-      }),
+      },
       version: 1,
       timestamp: Date.now() - 1000,
       request_id: 'old-request'

--- a/packages/common-settings-bridge/src/settings-repository.test.ts
+++ b/packages/common-settings-bridge/src/settings-repository.test.ts
@@ -83,7 +83,7 @@ describe('SettingsRepository', () => {
       const payload = createTestPayload()
       const dbRow = {
         matrix_id: '@user:example.com',
-        settings: JSON.stringify(payload),
+        settings: payload, // jsonb returns as object, not string
         version: 1,
         timestamp: 1234567890,
         request_id: 'req-123'

--- a/packages/common-settings-bridge/src/types.ts
+++ b/packages/common-settings-bridge/src/types.ts
@@ -41,8 +41,10 @@ export interface CommonSettingsMessage {
 
 /**
  * Represents user settings as stored in the bridge database.
+ * Named StoredUserSettings to distinguish from the UserSettings type
+ * in the @twake/common-settings package.
  */
-export interface UserSettings {
+export interface StoredUserSettings {
   readonly source?: string
   readonly nickname: string
   readonly request_id: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot-based avatar uploads with automatic fallback when user-based uploads fail or are restricted.
  * Improved avatar resolution and download flows to handle more source types robustly.

* **Bug Fixes**
  * Better error handling and clearer logging for avatar and profile updates.
  * More reliable fallback behavior between user and bot upload paths.

* **Refactor**
  * Simplified profile update API for cleaner integration and changed change-detection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->