### PR TITLE
Fix Enriched Information not Properly Forwarded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -669,3 +669,4 @@ test-output
 *.db-journal
 
 **/*.last-run.json
+**/nul

--- a/packages/tom-server/src/addressbook-api/controllers/index.ts
+++ b/packages/tom-server/src/addressbook-api/controllers/index.ts
@@ -1,13 +1,17 @@
 import { TwakeLogger } from '@twake/logger'
 import { AuthRequest, TwakeDB } from '../../types'
 import type {
+  Contact,
   EnrichedContact,
   IAddressbookApiController,
   IAddressbookService
 } from '../types'
 import { AddressbookService } from '../services'
 import type { NextFunction, Response } from 'express'
-import type { IUserInfoService } from '../../user-info-api/types'
+import type {
+  IUserInfoService,
+  UserInformation
+} from '../../user-info-api/types'
 
 export default class AddressbookApiController
   implements IAddressbookApiController
@@ -27,12 +31,12 @@ export default class AddressbookApiController
    * Enriches contacts with additional user information from UserInfoService.
    *
    * @param {Contact[]} contacts - Array of contacts to enrich
-   * @param {string} viewer - The viewer's user ID for visibility checks
+   * @param {string?} viewer - The viewer's user ID for visibility checks
    * @returns {Promise<EnrichedContact[]>} Array of enriched contacts
    */
   private async _enrichContacts(
-    contacts: { mxid: string; [key: string]: any }[],
-    viewer: string
+    contacts: Contact[],
+    viewer?: string
   ): Promise<EnrichedContact[]> {
     if (!this.userInfoService || contacts.length === 0) {
       this.logger.debug(
@@ -53,30 +57,33 @@ export default class AddressbookApiController
       )
       const userInfoMap = await this.userInfoService.getBatch(mxids, viewer)
 
-      const enrichedContacts = contacts.map((contact) => {
-        const userInfo = userInfoMap.get(contact.mxid)
-        const enriched: EnrichedContact = { ...contact } as EnrichedContact
+      const enrichedContacts: EnrichedContact[] = contacts.map((contact) => {
+        const userInfo: UserInformation | undefined = userInfoMap.get(
+          contact.mxid
+        )
 
-        if (userInfo) {
-          // Enrichment fields
-          enriched.avatar_url = userInfo.avatar_url || ''
-          enriched.last_name = userInfo.last_name || ''
-          enriched.first_name = userInfo.first_name || ''
-          enriched.emails = userInfo.emails || []
-          enriched.phones = userInfo.phones || []
-          enriched.language = userInfo.language || ''
-          enriched.timezone = userInfo.timezone || ''
-          if (userInfo.workplaceFqdn)
-            enriched.workplaceFqdn = userInfo.workplaceFqdn
+        if (!userInfo) {
+          this.logger.debug(
+            `... mxid=${contact.mxid} no user info found, keeping stored display_name="${contact.display_name}"`
+          )
+          return { ...contact } as EnrichedContact
+        }
 
-          // Deprecated fields for backward compatibility
-          enriched.displayName = userInfo.display_name || ''
-          enriched.cn = userInfo.display_name || ''
-          enriched.sn = userInfo.sn || ''
-          enriched.givenName = userInfo.first_name || ''
-          enriched.givenname = userInfo.first_name || ''
-          enriched.mail = userInfo.emails?.at(0) || ''
-          enriched.mobile = userInfo.phones?.at(0) || ''
+        const displayName =
+          userInfo.display_name || (contact.display_name as string)
+
+        const enriched: EnrichedContact = {
+          ...contact,
+          ...userInfo, // spreads all shared UserEnrichmentFields directly
+          // Override/resolve conflicts and fill defaults
+          display_name: displayName,
+          displayName,
+          cn: displayName,
+          sn: userInfo.sn || '',
+          givenName: userInfo.givenName || userInfo.first_name || '',
+          givenname: userInfo.first_name || '',
+          mail: userInfo.emails?.at(0) || '',
+          mobile: userInfo.phones?.at(0) || ''
         }
 
         return enriched

--- a/packages/tom-server/src/addressbook-api/controllers/index.ts
+++ b/packages/tom-server/src/addressbook-api/controllers/index.ts
@@ -179,12 +179,18 @@ export default class AddressbookApiController
   ): Promise<void> => {
     try {
       const { id } = req.params
+      const viewer = req.userId
+
+      this.logger.debug(
+        `[AddressbookApiController.fetchContact] Fetching contact id=${id} viewer=${viewer}`
+      )
 
       const contact = await this.service.getContact(id)
 
       if (!contact) {
-        this.logger.error('Contact not found')
-
+        this.logger.error(
+          `[AddressbookApiController.fetchContact] Contact not found id=${id}`
+        )
         res.status(404).json({ message: 'Contact not found' })
         return
       }

--- a/packages/tom-server/src/addressbook-api/controllers/index.ts
+++ b/packages/tom-server/src/addressbook-api/controllers/index.ts
@@ -202,7 +202,15 @@ export default class AddressbookApiController
         return
       }
 
-      res.status(200).json(contact)
+      const [enrichedContact] = await this._enrichContacts([contact], viewer)
+
+      this.logger.info(
+        `[AddressbookApiController.fetchContact] Returning contact id=${id} mxid=${
+          enrichedContact.mxid
+        }`
+      )
+
+      res.status(200).json(enrichedContact)
     } catch (error) {
       next(error)
     }

--- a/packages/tom-server/src/addressbook-api/types.ts
+++ b/packages/tom-server/src/addressbook-api/types.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Response, Request } from 'express'
+import type { UserEnrichmentFields } from '../user-info-api/types'
 
 export interface Contact {
   id: string
@@ -35,16 +36,7 @@ export interface AddressbookListResponse {
 }
 
 // Extended contact with enrichment data from UserInfoService
-export interface EnrichedContact extends Contact {
-  // Enrichment fields
-  avatar_url?: string
-  last_name?: string
-  first_name?: string
-  emails?: string[]
-  phones?: string[]
-  language?: string
-  timezone?: string
-  workplaceFqdn?: string
+export interface EnrichedContact extends Contact, UserEnrichmentFields {
   // Deprecated fields for backward compatibility
   displayName?: string
   cn?: string

--- a/packages/tom-server/src/user-info-api/services/index.ts
+++ b/packages/tom-server/src/user-info-api/services/index.ts
@@ -102,7 +102,9 @@ class UserInfoService implements IUserInfoService {
     viewer?: string
   ): Promise<Map<string, UserInformation>> => {
     this.logger.debug(
-      `[UserInfoService].getBatch: Gathering information on ${ids.length} users`
+      `[UserInfoService].getBatch: Gathering information on ${ids.length} user${
+        ids.length > 1 ? 's' : ''
+      }`
     )
 
     const result = new Map<string, UserInformation>()
@@ -321,17 +323,32 @@ class UserInfoService implements IUserInfoService {
 
         // Matrix profile (highest precedence)
         if (matrixRow) {
-          if (matrixRow.displayname)
+          if (matrixRow.displayname) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} display_name source=matrix value="${matrixRow.displayname}"`
+            )
             userInfo.display_name = matrixRow.displayname
-          if (matrixRow.avatar_url) userInfo.avatar_url = matrixRow.avatar_url
+          }
+          if (matrixRow.avatar_url) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} avatar_url source=matrix value="${matrixRow.avatar_url}"`
+            )
+            userInfo.avatar_url = matrixRow.avatar_url
+          }
         }
 
         // Directory (second precedence)
         if (directoryRow) {
           if (!userInfo.display_name && directoryRow.cn) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} display_name source=directory (matrix empty) value="${directoryRow.cn}"`
+            )
             userInfo.display_name = directoryRow.cn as string
           }
           if (directoryRow.sn) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} sn source=directory value="${directoryRow.sn}"`
+            )
             userInfo.sn = directoryRow.sn as string
             userInfo.last_name = directoryRow.sn as string
           }
@@ -339,10 +356,13 @@ class UserInfoService implements IUserInfoService {
             directoryRow.givenname != null ||
             directoryRow.givenName != null
           ) {
-            userInfo.givenName = (directoryRow.givenname ??
+            const givenName = (directoryRow.givenname ??
               directoryRow.givenName) as string
-            userInfo.first_name = (directoryRow.givenname ??
-              directoryRow.givenName) as string
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} givenName source=directory value="${givenName}"`
+            )
+            userInfo.givenName = givenName
+            userInfo.first_name = givenName
           }
           // Apply visibility checks for email/phone
           if (
@@ -351,6 +371,11 @@ class UserInfoService implements IUserInfoService {
               (isIdProfileVisible &&
                 idProfileVisibleFields.includes(ProfileField.Email)))
           ) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} email source=directory value="${String(
+                directoryRow.mail
+              ).replace(/^(.).*(@.+)$/, '$1***$2')}"`
+            )
             userInfo.emails = [directoryRow.mail as string]
           }
           if (
@@ -359,9 +384,17 @@ class UserInfoService implements IUserInfoService {
               (isIdProfileVisible &&
                 idProfileVisibleFields.includes(ProfileField.Phone)))
           ) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} phone source=directory value="${String(
+                directoryRow.mobile
+              ).replace(/^.+(.{4})$/, '***$1')}"`
+            )
             userInfo.phones = [directoryRow.mobile as string]
           }
           if (directoryRow.workplaceFqdn) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} workplaceFqdn source=directory value="${directoryRow.workplaceFqdn}"`
+            )
             userInfo.workplaceFqdn = directoryRow.workplaceFqdn as string
           }
         }
@@ -369,13 +402,22 @@ class UserInfoService implements IUserInfoService {
         // Settings (third precedence)
         if (settingsRow) {
           if (settingsRow.display_name) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} display_name source=settings value="${settingsRow.display_name}"`
+            )
             userInfo.display_name = settingsRow.display_name
           }
           if (settingsRow.last_name) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} sn source=settings value="${settingsRow.last_name}"`
+            )
             userInfo.last_name = settingsRow.last_name
             userInfo.sn = settingsRow.last_name
           }
           if (settingsRow.first_name) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} givenName source=settings value="${settingsRow.first_name}"`
+            )
             userInfo.first_name = settingsRow.first_name
             userInfo.givenName = settingsRow.first_name
           }
@@ -390,8 +432,18 @@ class UserInfoService implements IUserInfoService {
               userInfo.emails &&
               !userInfo.emails.includes(settingsRow.email)
             ) {
+              this.logger.debug(
+                `[UserInfoService].getBatch: mxid=${id} email source=settings value="${String(
+                  settingsRow.email
+                ).replace(/^(.).*(@.+)$/, '$1***$2')}" (appended)`
+              )
               userInfo.emails.push(settingsRow.email)
             } else if (!userInfo.emails) {
+              this.logger.debug(
+                `[UserInfoService].getBatch: mxid=${id} email source=settings value="${String(
+                  settingsRow.email
+                ).replace(/^(.).*(@.+)$/, '$1***$2')}"`
+              )
               userInfo.emails = [settingsRow.email]
             }
           }
@@ -405,17 +457,40 @@ class UserInfoService implements IUserInfoService {
               userInfo.phones &&
               !userInfo.phones.includes(settingsRow.phone)
             ) {
+              this.logger.debug(
+                `[UserInfoService].getBatch: mxid=${id} phone source=settings value="${String(
+                  settingsRow.phone
+                ).replace(/^.+(.{4})$/, '***$1')}" (appended)`
+              )
               userInfo.phones.push(settingsRow.phone)
             } else if (!userInfo.phones) {
+              this.logger.debug(
+                `[UserInfoService].getBatch: mxid=${id} phone source=settings value="${String(
+                  settingsRow.phone
+                ).replace(/^.+(.{4})$/, '***$1')}"`
+              )
               userInfo.phones = [settingsRow.phone]
             }
           }
-          if (settingsRow.language) userInfo.language = settingsRow.language
-          if (settingsRow.timezone) userInfo.timezone = settingsRow.timezone
+          if (settingsRow.language) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} language source=settings value="${settingsRow.language}"`
+            )
+            userInfo.language = settingsRow.language
+          }
+          if (settingsRow.timezone) {
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} timezone source=settings value="${settingsRow.timezone}"`
+            )
+            userInfo.timezone = settingsRow.timezone
+          }
         }
 
         // Addressbook (fourth source) - override display_name if present
         if (addressbookContact?.display_name) {
+          this.logger.debug(
+            `[UserInfoService].getBatch: mxid=${id} display_name source=addressbook (overrides previous) value="${addressbookContact.display_name}"`
+          )
           userInfo.display_name = addressbookContact.display_name
         }
 

--- a/packages/tom-server/src/user-info-api/services/index.ts
+++ b/packages/tom-server/src/user-info-api/services/index.ts
@@ -191,7 +191,7 @@ class UserInfoService implements IUserInfoService {
       const viewerAddressbookPromise = (async () => {
         if (!viewer) return null
         try {
-          const ab = await this.addressBookService.list(viewer)
+          const ab = await this.addressBookService.list(viewer, false) // We only list personal contacts not company provided
           return ab ?? null
         } catch (e) {
           this.logger.warn(

--- a/packages/tom-server/src/user-info-api/tests/controller.test.ts
+++ b/packages/tom-server/src/user-info-api/tests/controller.test.ts
@@ -71,6 +71,7 @@ describe('the user info API controller', () => {
     getMock.mockImplementation(
       async () =>
         ({
+          display_name: 'David',
           givenName: 'David',
           sn: 'Who',
           uid: '@dwho:docker.localhost'
@@ -81,6 +82,7 @@ describe('the user info API controller', () => {
 
     expect(response.status).toEqual(200)
     expect(response.body).toEqual({
+      display_name: 'David',
       givenName: 'David',
       sn: 'Who',
       uid: '@dwho:docker.localhost'

--- a/packages/tom-server/src/user-info-api/tests/service.test.ts
+++ b/packages/tom-server/src/user-info-api/tests/service.test.ts
@@ -4658,7 +4658,11 @@ describe('User Info Service GET with: No feature flags ON', () => {
     afterEach(() => {
       // Verify addressbook service was called when viewer is provided
       if (VIEWER_MXID !== MATRIX_MXID) {
-        expect(addressBookServiceMock.list).toHaveBeenCalledWith(VIEWER_MXID)
+        expect(addressBookServiceMock.list).toHaveBeenCalledTimes(1)
+        expect(addressBookServiceMock.list).toHaveBeenCalledWith(
+          VIEWER_MXID,
+          false
+        )
       }
     })
 
@@ -7345,7 +7349,7 @@ describe('User Info Service getBatch', () => {
 
     // Addressbook should be fetched exactly once
     expect(addressBookServiceMock.list).toHaveBeenCalledTimes(1)
-    expect(addressBookServiceMock.list).toHaveBeenCalledWith(viewerMxid)
+    expect(addressBookServiceMock.list).toHaveBeenCalledWith(viewerMxid, false)
 
     // User1 should have addressbook name override
     expect(result.get(MXID_1)!.display_name).toBe('Addressbook Name for User1')

--- a/packages/tom-server/src/user-info-api/types.ts
+++ b/packages/tom-server/src/user-info-api/types.ts
@@ -18,19 +18,22 @@ export interface IUserInfoService {
   ) => Promise<UserProfileSettingsT | undefined>
 }
 
-export interface UserInformation {
-  uid: string
-  display_name?: string
+export interface UserEnrichmentFields {
+  display_name: string
   avatar_url?: string
-  sn?: string
   last_name?: string
-  givenName?: string
   first_name?: string
   emails?: string[]
   phones?: string[]
   language?: string
   timezone?: string
   workplaceFqdn?: string
+}
+
+export interface UserInformation extends UserEnrichmentFields {
+  uid: string
+  sn?: string
+  givenName?: string
 }
 
 export interface SettingsPayload {


### PR DESCRIPTION
In B2B setup the contact list is sourced from personal contacts and the LDAP. In conjunction with the CS this is an issue as the contact info takes final precedence.

Therefore, the userinfo service is now only querying personal contacts to retrieve only custom names and thus preserving CS in a B2B deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced contact enrichment mechanism that consolidates user information for improved display accuracy across contacts

* **Improvements**
  * Refined handling and merging of contact data from multiple sources with intelligent fallback behavior when information is unavailable
  * Strengthened type definitions for contact enrichment data
  * Improved diagnostic logging for contact retrieval and enrichment operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->