### PR TITLE
fix(token-service): handle cross-origin redirects in SSO token flow

### DIFF
--- a/packages/tom-server/src/utils/services/token-service.test.ts
+++ b/packages/tom-server/src/utils/services/token-service.test.ts
@@ -18,7 +18,8 @@ describe('the Token service', () => {
   }
 
   const configMock = {
-    matrix_server: 'example.com'
+    matrix_server: 'example.com',
+    auth_url: 'https://auth.example.com'
   } as unknown as Config
 
   const tokenService = new TokenService(
@@ -26,6 +27,10 @@ describe('the Token service', () => {
     loggerMock as unknown as TwakeLogger,
     'test'
   )
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
   describe('the getOidcProvider method', () => {
     it('should return the oidc provider', async () => {
@@ -117,7 +122,7 @@ describe('the Token service', () => {
   })
 
   describe('the getOidcRedirectLocation method', () => {
-    it('should return the location and cookies headers from the redirection response', async () => {
+    it('should return the location and cleaned cookies from the redirection response', async () => {
       global.fetch = jest.fn(
         async () =>
           await Promise.resolve({
@@ -125,10 +130,13 @@ describe('the Token service', () => {
               get: (header: string) => {
                 if (header === 'location') {
                   return 'https://auth.example.com/login'
-                } else if (header === 'set-cookie') {
-                  return 'cookie1=value1; cookie2=value2'
                 }
-              }
+                return null
+              },
+              getSetCookie: () => [
+                'session=abc123; Path=/; HttpOnly; Secure',
+                'session_compat=abc123; Path=/; HttpOnly'
+              ]
             }
           } as unknown as Response)
       )
@@ -137,7 +145,33 @@ describe('the Token service', () => {
 
       expect(result).toEqual({
         location: 'https://auth.example.com/login',
-        cookies: 'cookie1=value1; cookie2=value2'
+        cookies: 'session=abc123; session_compat=abc123'
+      })
+    })
+
+    it('should strip cookie attributes and handle a single cookie', async () => {
+      global.fetch = jest.fn(
+        async () =>
+          await Promise.resolve({
+            headers: {
+              get: (header: string) => {
+                if (header === 'location') {
+                  return 'https://auth.example.com/login'
+                }
+                return null
+              },
+              getSetCookie: () => [
+                'token=abc=def==; Domain=.example.com; Path=/; Max-Age=3600; HttpOnly; Secure; SameSite=None'
+              ]
+            }
+          } as unknown as Response)
+      )
+
+      const result = await tokenService.getOidcRedirectLocation('oidc_provider')
+
+      expect(result).toEqual({
+        location: 'https://auth.example.com/login',
+        cookies: 'token=abc=def=='
       })
     })
 
@@ -156,13 +190,13 @@ describe('the Token service', () => {
         async () =>
           await Promise.resolve({
             headers: {
-              get: (headers: string) => {
-                if (headers === 'location') {
+              get: (header: string) => {
+                if (header === 'location') {
                   return 'https://auth.example.com/login'
                 }
-
                 return null
-              }
+              },
+              getSetCookie: () => []
             }
           } as unknown as Response)
       )
@@ -177,13 +211,8 @@ describe('the Token service', () => {
         async () =>
           await Promise.resolve({
             headers: {
-              get: (headers: string) => {
-                if (headers === 'set-cookie') {
-                  return 'cookie1=value1; cookie2=value2'
-                }
-
-                return null
-              }
+              get: () => null,
+              getSetCookie: () => ['session=abc123; Path=/; HttpOnly']
             }
           } as unknown as Response)
       )
@@ -195,30 +224,109 @@ describe('the Token service', () => {
   })
 
   describe('the getLoginToken method', () => {
-    it('should extract the login token from the response body', async () => {
-      global.fetch = jest.fn(
-        async () =>
-          await Promise.resolve({
-            text: async () =>
-              await Promise.resolve(
-                `
-                <div id="something">
-                  <some-random-html>
-                    <a href="https://localhost:9876/?loginToken=123456">continue</a>
-                  </some-random-html>
-                </div>
-                `
-              )
-          } as unknown as Response)
-      )
+    it('should extract the login token from the callback response body', async () => {
+      global.fetch = jest
+        .fn()
+        // Step 1: auth provider returns redirect to Matrix callback
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'https://example.com/_synapse/client/oidc/callback?code=abc&state=xyz'
+                : null
+          }
+        } as unknown as Response)
+        // Step 2: Matrix callback returns HTML with loginToken
+        .mockResolvedValueOnce({
+          headers: { get: () => null },
+          text: async () =>
+            '<a href="https://localhost:9876/?loginToken=123456">continue</a>'
+        } as unknown as Response)
 
       const result = await tokenService.getLoginToken(
-        'oidc_provider',
-        'session-cookie',
-        'auth-cookie'
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
       )
 
       expect(result).toBe('123456')
+      // Step 1: only auth cookie sent to auth provider
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://auth.example.com/authorize',
+        { headers: { Cookie: 'lemonldap=xyz' }, redirect: 'manual' }
+      )
+      // Step 2: only session cookies sent to Matrix callback
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/_synapse/client/oidc/callback?code=abc&state=xyz',
+        { headers: { Cookie: 'session=abc123' }, redirect: 'manual' }
+      )
+    })
+
+    it('should extract the login token from the callback redirect URL', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'https://example.com/_synapse/client/oidc/callback?code=abc'
+                : null
+          }
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'http://localhost:9876/?loginToken=token-from-redirect'
+                : null
+          },
+          text: async () => '<html>no token here</html>'
+        } as unknown as Response)
+
+      const result = await tokenService.getLoginToken(
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
+      )
+
+      expect(result).toBe('token-from-redirect')
+    })
+
+    it('should return null if callback URL origin does not match Matrix server', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        headers: {
+          get: (header: string) =>
+            header === 'location'
+              ? 'https://evil.example.com/_synapse/client/oidc/callback?code=abc'
+              : null
+        }
+      } as unknown as Response)
+
+      const result = await tokenService.getLoginToken(
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
+      )
+
+      expect(result).toBeNull()
+      // Should NOT have made the second fetch
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return null if auth provider does not redirect', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        headers: { get: () => null }
+      } as unknown as Response)
+
+      const result = await tokenService.getLoginToken(
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
+      )
+
+      expect(result).toBeNull()
     })
 
     it('should return null if something wrong happens', async () => {
@@ -227,29 +335,87 @@ describe('the Token service', () => {
       )
 
       const result = await tokenService.getLoginToken(
-        'oidc_provider',
-        'session-cookie',
-        'auth-cookie'
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
       )
 
       expect(result).toBeNull()
     })
 
-    it("should return null if the response body didn't include a loginToken", async () => {
-      global.fetch = jest.fn(
-        async () =>
-          await Promise.resolve({
-            text: async () =>
-              await Promise.resolve(
-                '<a href="https://localhost:9876/">continue</a>'
-              )
-          } as unknown as Response)
-      )
+    it("should return null if the callback response didn't include a loginToken", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'https://example.com/_synapse/client/oidc/callback?code=abc'
+                : null
+          }
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          headers: { get: () => null },
+          text: async () => '<a href="https://localhost:9876/">continue</a>'
+        } as unknown as Response)
 
       const result = await tokenService.getLoginToken(
-        'oidc_provider',
-        'session-cookie',
-        'auth-cookie'
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('should fall through to body when redirect URL has no loginToken', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'https://example.com/_synapse/client/oidc/callback?code=abc'
+                : null
+          }
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'http://localhost:9876/?other=param'
+                : null
+          },
+          text: async () =>
+            '<a href="http://localhost:9876/?loginToken=from-body">continue</a>'
+        } as unknown as Response)
+
+      const result = await tokenService.getLoginToken(
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
+      )
+
+      expect(result).toBe('from-body')
+    })
+
+    it('should return null if the Matrix callback request fails', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          headers: {
+            get: (header: string) =>
+              header === 'location'
+                ? 'https://example.com/_synapse/client/oidc/callback?code=abc'
+                : null
+          }
+        } as unknown as Response)
+        .mockRejectedValueOnce(new Error('connection refused'))
+
+      const result = await tokenService.getLoginToken(
+        'https://auth.example.com/authorize',
+        'session=abc123',
+        'lemonldap=xyz'
       )
 
       expect(result).toBeNull()
@@ -332,6 +498,132 @@ describe('the Token service', () => {
       )
 
       const result = await tokenService.requestAccessToken('loginToken')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('the getAuthCookie method', () => {
+    it('should return a cleaned cookie from the auth provider response', async () => {
+      global.fetch = jest
+        .fn()
+        // First call: _getAuthProviderLoginToken
+        .mockResolvedValueOnce({
+          json: async () => ({ token: 'csrf_token_123' })
+        } as unknown as Response)
+        // Second call: POST credentials
+        .mockResolvedValueOnce({
+          headers: {
+            getSetCookie: () => [
+              'lemonldap=session_id_abc; domain=.example.com; path=/; HttpOnly=1; SameSite=Lax'
+            ]
+          }
+        } as unknown as Response)
+
+      const result = await tokenService.getAuthCookie(
+        'admin@example.com',
+        'password'
+      )
+
+      expect(result).toBe('lemonldap=session_id_abc')
+    })
+
+    it('should return null if the auth provider does not return a token', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        json: async () => ({})
+      } as unknown as Response)
+
+      const result = await tokenService.getAuthCookie(
+        'admin@example.com',
+        'password'
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null if the auth provider does not set cookies', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ token: 'csrf_token_123' })
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          headers: { getSetCookie: () => [] }
+        } as unknown as Response)
+
+      const result = await tokenService.getAuthCookie(
+        'admin@example.com',
+        'password'
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('should POST credentials with the CSRF token from the auth provider', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          json: async () => ({ token: 'csrf_token_123' })
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          headers: {
+            getSetCookie: () => ['lemonldap=abc; path=/']
+          }
+        } as unknown as Response)
+
+      await tokenService.getAuthCookie('admin@example.com', 'secret')
+
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://auth.example.com',
+        {
+          method: 'POST',
+          headers: { Accept: 'application/json' },
+          body: new URLSearchParams({
+            user: 'admin@example.com',
+            password: 'secret',
+            token: 'csrf_token_123'
+          })
+        }
+      )
+    })
+  })
+
+  describe('the getAccessTokenWithCreds method', () => {
+    it('should return the access token using auth cookie and SSO flow', async () => {
+      jest
+        .spyOn(tokenService, 'getAuthCookie')
+        .mockResolvedValue('lemonldap=session_abc')
+      jest
+        .spyOn(tokenService, 'getAccessTokenWithCookie')
+        .mockResolvedValue('access_token_xyz')
+
+      const result = await tokenService.getAccessTokenWithCreds('admin', 'pass')
+
+      expect(result).toBe('access_token_xyz')
+      expect(tokenService.getAuthCookie).toHaveBeenCalledWith('admin', 'pass')
+      expect(tokenService.getAccessTokenWithCookie).toHaveBeenCalledWith(
+        'lemonldap=session_abc'
+      )
+    })
+
+    it('should return null if auth cookie acquisition fails', async () => {
+      jest.spyOn(tokenService, 'getAuthCookie').mockResolvedValue(null)
+
+      const result = await tokenService.getAccessTokenWithCreds('admin', 'pass')
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null if SSO token exchange fails', async () => {
+      jest
+        .spyOn(tokenService, 'getAuthCookie')
+        .mockResolvedValue('lemonldap=session_abc')
+      jest
+        .spyOn(tokenService, 'getAccessTokenWithCookie')
+        .mockResolvedValue(null)
+
+      const result = await tokenService.getAccessTokenWithCreds('admin', 'pass')
 
       expect(result).toBeNull()
     })

--- a/packages/tom-server/src/utils/services/token-service.ts
+++ b/packages/tom-server/src/utils/services/token-service.ts
@@ -212,13 +212,13 @@ export default class TokenService implements ITokenService {
       )
 
       const location = response.headers.get('location')
-      const cookies = response.headers.get('set-cookie')
+      const cookies = this.extractCookies(response)
 
       if (location === null) {
         throw new Error('No location found in the response')
       }
 
-      if (cookies === null) {
+      if (cookies.length === 0) {
         throw new Error('No session cookies found in the response')
       }
 
@@ -232,13 +232,14 @@ export default class TokenService implements ITokenService {
   /**
    * Fetches the login token using SSO
    *
-   * @param {string} location - The location to fetch the login token from.
-   * @param {string} sessionCookies - The session cookies to be used for authentication.
-   * @param {string} authCookie - The auth cookie to be used for authentication ( ex lemonldap ).
+   * The redirect chain crosses origins (auth provider → Matrix), so we must
+   * handle redirects manually to send the right cookies to each server.
+   * Node.js fetch strips cookies on cross-origin redirects.
+   *
+   * @param {string} location - The auth provider URL to initiate the login flow.
+   * @param {string} sessionCookies - The Matrix session cookies for the OIDC callback.
+   * @param {string} authCookie - The auth cookie for the auth provider (e.g. lemonldap).
    * @returns {Promise<string | null>} The login token or null if an error occurs.
-   * @memberof QRCodeTokenService
-   * @example
-   * const loginToken = await getLoginToken(location, sessionCookies, authCookie);
    */
   getLoginToken = async (
     location: string,
@@ -246,13 +247,50 @@ export default class TokenService implements ITokenService {
     authCookie: string
   ): Promise<string | null> => {
     try {
-      const response = await fetch(location, {
+      // Step 1: Visit auth provider with auth cookie only (manual redirect)
+      const authResponse = await fetch(location, {
         headers: {
-          Cookie: `${sessionCookies}; ${authCookie}`
-        }
+          Cookie: authCookie
+        },
+        redirect: 'manual'
       })
 
-      const responseText = await response.text()
+      const callbackUrl = authResponse.headers.get('location')
+      await authResponse.body?.cancel()
+
+      if (callbackUrl === null) {
+        throw new Error('No callback URL in auth provider response')
+      }
+
+      const matrixOrigin = new URL(this.matrixUrl).origin
+
+      if (new URL(callbackUrl).origin !== matrixOrigin) {
+        throw new Error('Unexpected callback origin: expected Matrix server')
+      }
+
+      // Step 2: Follow callback to Matrix with session cookies
+      const callbackResponse = await fetch(callbackUrl, {
+        headers: {
+          Cookie: sessionCookies
+        },
+        redirect: 'manual'
+      })
+
+      // Check redirect URL (Synapse may redirect to redirectUrl?loginToken=xxx)
+      const redirectLocation = callbackResponse.headers.get('location')
+
+      if (redirectLocation !== null) {
+        const url = new URL(redirectLocation)
+        const loginToken = url.searchParams.get('loginToken')
+
+        if (loginToken !== null) {
+          await callbackResponse.body?.cancel()
+          return loginToken
+        }
+      }
+
+      // Check body (Synapse may return HTML with embedded loginToken)
+      const responseText = await callbackResponse.text()
       const loginTokenMatch = responseText.match(/loginToken=(.+?)['"]/)
 
       if (loginTokenMatch === null) {
@@ -294,9 +332,9 @@ export default class TokenService implements ITokenService {
         body: new URLSearchParams({ user, password, token })
       })
 
-      const cookie = response.headers.get('set-cookie')
+      const cookie = this.extractCookies(response)
 
-      if (!cookie) {
+      if (cookie.length === 0) {
         throw new Error('No auth cookie found in the response')
       }
 
@@ -305,6 +343,19 @@ export default class TokenService implements ITokenService {
       this.logger.error('Failed to fetch auth cookie', { error })
       return null
     }
+  }
+
+  /**
+   * Extracts cookie name=value pairs from a response's Set-Cookie headers.
+   * Strips cookie attributes (Domain, Path, HttpOnly, etc.) and joins
+   * multiple cookies with '; ' for use in a Cookie request header.
+   */
+  private extractCookies = (response: Response): string => {
+    return response.headers
+      .getSetCookie()
+      .map((cookie) => cookie.split(';')[0].trim())
+      .filter((cookie) => cookie.length > 0)
+      .join('; ')
   }
 
   /**


### PR DESCRIPTION
Closes #339

The `/_twake/admin/deactivate-user/:id` endpoint returns a 500 because the admin token acquisition flow silently fails mid-way through the SSO dance.

Node.js `fetch` strips the `Cookie` header on cross-origin redirects. The SSO chain goes auth provider → Matrix callback, crossing origins — so the OIDC session cookie set by Synapse never makes it back to Synapse. It rejects the callback with a 400, no `loginToken` is produced, and the whole flow returns null.

The fix splits `getLoginToken` into two explicit fetch calls with `redirect: 'manual'`, sending each cookie to the right server. It also switches from `headers.get('set-cookie')` (which joins multiple cookies with `,` and includes attributes like `Domain`/`Path`/`HttpOnly`) to `headers.getSetCookie()` with attribute stripping, so the `Cookie` header actually contains valid `name=value` pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for OIDC authentication flows, including multi-step redirects, cookie handling, and token exchange scenarios
  * Added tests for edge cases and error conditions in authentication processes

* **Refactor**
  * Improved cookie extraction logic from authentication responses
  * Updated cross-origin redirect handling in authentication flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->