### PR TITLE
AMQP-Connector - Just a BiomeJS Pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/supertest": "^2.0.12",
         "@types/validator": "^13.11.7",
         "concurrently": "^9.2.1",
+        "cross-env": "^10.1.0",
         "docker-compose": "^0.24.3",
         "jest": "^29.5.0",
         "js-nacl": "^1.4.0",
@@ -902,6 +903,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
@@ -6369,6 +6377,24 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/supertest": "^2.0.12",
     "@types/validator": "^13.11.7",
     "concurrently": "^9.2.1",
+    "cross-env": "^10.1.0",
     "docker-compose": "^0.24.3",
     "jest": "^29.5.0",
     "js-nacl": "^1.4.0",

--- a/packages/amqp-connector/jest.config.js
+++ b/packages/amqp-connector/jest.config.js
@@ -1,5 +1,5 @@
-import jestConfigBase from '../../jest-base.config.js'
+import jestConfigBase from "../../jest-base.config.js";
 
 export default {
-  ...jestConfigBase
-}
+  ...jestConfigBase,
+};

--- a/packages/amqp-connector/package.json
+++ b/packages/amqp-connector/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "test": "LOG_TRANSPORTS=File LOG_FILE=/dev/null jest",
+    "test": "cross-env LOG_TRANSPORTS=File LOG_FILE=/dev/null jest",
     "check": "biome check ."
   },
   "author": [

--- a/packages/amqp-connector/rollup.config.js
+++ b/packages/amqp-connector/rollup.config.js
@@ -1,3 +1,3 @@
-import config from '../../rollup-template.js'
+import config from "../../rollup-template.js";
 
-export default config([])
+export default config([]);

--- a/packages/amqp-connector/src/errors.ts
+++ b/packages/amqp-connector/src/errors.ts
@@ -5,8 +5,8 @@
  */
 export class AMQPConnectorError extends Error {
   constructor(message: string) {
-    super(message)
-    this.name = 'AMQPConnectorError'
+    super(message);
+    this.name = "AMQPConnectorError";
   }
 }
 
@@ -17,8 +17,8 @@ export class AMQPConnectorError extends Error {
  */
 export class ExchangeNotSpecifiedError extends AMQPConnectorError {
   constructor() {
-    super('Exchange must be specified')
-    this.name = 'ExchangeNotSpecifiedError'
+    super("Exchange must be specified");
+    this.name = "ExchangeNotSpecifiedError";
   }
 }
 
@@ -29,8 +29,8 @@ export class ExchangeNotSpecifiedError extends AMQPConnectorError {
  */
 export class QueueNotSpecifiedError extends AMQPConnectorError {
   constructor() {
-    super('Queue must be specified')
-    this.name = 'QueueNotSpecifiedError'
+    super("Queue must be specified");
+    this.name = "QueueNotSpecifiedError";
   }
 }
 /**
@@ -40,7 +40,7 @@ export class QueueNotSpecifiedError extends AMQPConnectorError {
  */
 export class MessageHandlerNotProvidedError extends AMQPConnectorError {
   constructor() {
-    super('Message handler must be provided')
-    this.name = 'MessageHandlerNotProvidedError'
+    super("Message handler must be provided");
+    this.name = "MessageHandlerNotProvidedError";
   }
 }

--- a/packages/amqp-connector/src/index.test.ts
+++ b/packages/amqp-connector/src/index.test.ts
@@ -1,23 +1,19 @@
 /* eslint-disable @typescript-eslint/promise-function-async */
-import amqplib from 'amqplib'
-import { AMQPConnector, ConnectionState } from '.'
-import {
-  QueueNotSpecifiedError,
-  MessageHandlerNotProvidedError,
-  ExchangeNotSpecifiedError
-} from './errors'
+import amqplib from "amqplib";
+import { AMQPConnector, ConnectionState } from ".";
+import { ExchangeNotSpecifiedError, MessageHandlerNotProvidedError, QueueNotSpecifiedError } from "./errors";
 
-jest.mock('amqplib')
+jest.mock("amqplib");
 
-describe('AMQPConnector', () => {
-  const mockConsume = jest.fn()
-  const mockAck = jest.fn()
-  const mockNack = jest.fn()
-  const mockCancel = jest.fn(() => Promise.resolve())
-  const mockAssertExchange = jest.fn(() => Promise.resolve())
-  const mockAssertQueue = jest.fn(() => Promise.resolve())
-  const mockBindQueue = jest.fn(() => Promise.resolve())
-  const mockChannelOn = jest.fn()
+describe("AMQPConnector", () => {
+  const mockConsume = jest.fn();
+  const mockAck = jest.fn();
+  const mockNack = jest.fn();
+  const mockCancel = jest.fn(() => Promise.resolve());
+  const mockAssertExchange = jest.fn(() => Promise.resolve());
+  const mockAssertQueue = jest.fn(() => Promise.resolve());
+  const mockBindQueue = jest.fn(() => Promise.resolve());
+  const mockChannelOn = jest.fn();
   const mockChannel = {
     assertExchange: mockAssertExchange,
     assertQueue: mockAssertQueue,
@@ -27,178 +23,169 @@ describe('AMQPConnector', () => {
     nack: mockNack,
     cancel: mockCancel,
     close: jest.fn(() => Promise.resolve()),
-    on: mockChannelOn
-  }
+    on: mockChannelOn,
+  };
 
-  const mockCreateChannel = jest.fn(() => Promise.resolve(mockChannel))
-  const mockCloseConnection = jest.fn(() => Promise.resolve())
-  const mockConnectionOn = jest.fn()
+  const mockCreateChannel = jest.fn(() => Promise.resolve(mockChannel));
+  const mockCloseConnection = jest.fn(() => Promise.resolve());
+  const mockConnectionOn = jest.fn();
   const mockConnect = jest.fn(() =>
     Promise.resolve({
       createChannel: mockCreateChannel,
       close: mockCloseConnection,
-      on: mockConnectionOn
-    })
-  )
+      on: mockConnectionOn,
+    }),
+  );
 
   beforeAll(() => {
-    ;(amqplib.connect as jest.Mock).mockImplementation(mockConnect)
-  })
+    (amqplib.connect as jest.Mock).mockImplementation(mockConnect);
+  });
 
   beforeEach(() => {
-    jest.clearAllMocks()
-    mockConsume.mockImplementation(() =>
-      Promise.resolve({ consumerTag: 'test-tag' })
-    )
-  })
+    jest.clearAllMocks();
+    mockConsume.mockImplementation(() => Promise.resolve({ consumerTag: "test-tag" }));
+  });
 
-  it('should throw an error if exchange is not specified', async () => {
-    await expect(new AMQPConnector().build()).rejects.toThrow(
-      ExchangeNotSpecifiedError
-    )
-  })
+  it("should throw an error if exchange is not specified", async () => {
+    await expect(new AMQPConnector().build()).rejects.toThrow(ExchangeNotSpecifiedError);
+  });
 
-  it('should throw an error if queue is not specified', async () => {
-    await expect(
-      new AMQPConnector().withExchange('test-exchange').build()
-    ).rejects.toThrow(QueueNotSpecifiedError)
-  })
+  it("should throw an error if queue is not specified", async () => {
+    await expect(new AMQPConnector().withExchange("test-exchange").build()).rejects.toThrow(QueueNotSpecifiedError);
+  });
 
-  it('should throw an error if message handler is not provided', async () => {
-    await expect(
-      new AMQPConnector()
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .build()
-    ).rejects.toThrow(MessageHandlerNotProvidedError)
-  })
+  it("should throw an error if message handler is not provided", async () => {
+    await expect(new AMQPConnector().withExchange("test-exchange").withQueue("test-queue").build()).rejects.toThrow(
+      MessageHandlerNotProvidedError,
+    );
+  });
 
-  it('should connect, assert queue, and call handler when a message is consumed', async () => {
-    const fakeMsg = { content: Buffer.from('hello') }
-    const mockHandler = jest.fn()
+  it("should connect, assert queue, and call handler when a message is consumed", async () => {
+    const fakeMsg = { content: Buffer.from("hello") };
+    const mockHandler = jest.fn();
 
     // adjust mockConsume to call the callback with fakeMsg
     mockConsume.mockImplementation((_queue, cb) => {
-      cb(fakeMsg)
-      return Promise.resolve({ consumerTag: 'test-tag' })
-    })
+      cb(fakeMsg);
+      return Promise.resolve({ consumerTag: "test-tag" });
+    });
 
     const connector = new AMQPConnector()
       .withConfig({
-        host: 'localhost',
+        host: "localhost",
         port: 5672,
-        username: 'guest',
-        password: 'guest',
-        vhost: '/',
-        tls: false
+        username: "guest",
+        password: "guest",
+        vhost: "/",
+        tls: false,
       })
-      .withExchange('test-exchange')
-      .withQueue('test-queue')
-      .onMessage(mockHandler)
+      .withExchange("test-exchange")
+      .withQueue("test-queue")
+      .onMessage(mockHandler);
 
-    await connector.build()
+    await connector.build();
 
-    expect(mockAssertExchange).toHaveBeenCalled()
-    expect(mockAssertQueue).toHaveBeenCalled()
-    expect(mockBindQueue).toHaveBeenCalled()
-    expect(mockHandler).toHaveBeenCalledWith(fakeMsg, mockChannel)
-    expect(mockAck).toHaveBeenCalledWith(fakeMsg)
-  })
+    expect(mockAssertExchange).toHaveBeenCalled();
+    expect(mockAssertQueue).toHaveBeenCalled();
+    expect(mockBindQueue).toHaveBeenCalled();
+    expect(mockHandler).toHaveBeenCalledWith(fakeMsg, mockChannel);
+    expect(mockAck).toHaveBeenCalledWith(fakeMsg);
+  });
 
-  it('should ignore null messages without throwing', async () => {
-    let consumerCallback: any
+  it("should ignore null messages without throwing", async () => {
+    let consumerCallback: any;
     mockConsume.mockImplementation((_queue, cb) => {
-      consumerCallback = cb
-      return Promise.resolve({ consumerTag: 'test-tag' })
-    })
+      consumerCallback = cb;
+      return Promise.resolve({ consumerTag: "test-tag" });
+    });
 
-    const handler = jest.fn()
+    const handler = jest.fn();
     const connector = new AMQPConnector()
-      .withUrl('amqp://localhost')
-      .withExchange('test-exchange')
-      .withQueue('test-queue')
-      .onMessage(handler)
+      .withUrl("amqp://localhost")
+      .withExchange("test-exchange")
+      .withQueue("test-queue")
+      .onMessage(handler);
 
-    await connector.build()
-    consumerCallback(null)
+    await connector.build();
+    consumerCallback(null);
 
-    expect(handler).not.toHaveBeenCalled()
-    expect(mockAck).not.toHaveBeenCalled()
-  })
+    expect(handler).not.toHaveBeenCalled();
+    expect(mockAck).not.toHaveBeenCalled();
+  });
 
-  it('should ack the message when handler succeeds', async () => {
-    let consumerCallback: any
+  it("should ack the message when handler succeeds", async () => {
+    let consumerCallback: any;
     mockConsume.mockImplementation((_queue, cb) => {
-      consumerCallback = cb
-      return Promise.resolve({ consumerTag: 'test-tag' })
-    })
+      consumerCallback = cb;
+      return Promise.resolve({ consumerTag: "test-tag" });
+    });
 
-    const handler = jest.fn().mockResolvedValue(undefined)
+    const handler = jest.fn().mockResolvedValue(undefined);
     const connector = new AMQPConnector()
-      .withUrl('amqp://localhost')
-      .withExchange('test-exchange')
-      .withQueue('test-queue')
-      .onMessage(handler)
+      .withUrl("amqp://localhost")
+      .withExchange("test-exchange")
+      .withQueue("test-queue")
+      .onMessage(handler);
 
-    await connector.build()
+    await connector.build();
 
-    const fakeMsg = { content: Buffer.from('test') }
-    await consumerCallback(fakeMsg)
+    const fakeMsg = { content: Buffer.from("test") };
+    await consumerCallback(fakeMsg);
 
-    expect(handler).toHaveBeenCalledWith(fakeMsg, expect.anything())
-    expect(mockAck).toHaveBeenCalledWith(fakeMsg)
-    expect(mockNack).not.toHaveBeenCalled()
-  })
+    expect(handler).toHaveBeenCalledWith(fakeMsg, expect.anything());
+    expect(mockAck).toHaveBeenCalledWith(fakeMsg);
+    expect(mockNack).not.toHaveBeenCalled();
+  });
 
-  it('should nack the message when handler throws an error', async () => {
-    let consumerCallback: any
+  it("should nack the message when handler throws an error", async () => {
+    let consumerCallback: any;
     mockConsume.mockImplementation((_queue, cb) => {
-      consumerCallback = cb
-      return Promise.resolve({ consumerTag: 'test-tag' })
-    })
+      consumerCallback = cb;
+      return Promise.resolve({ consumerTag: "test-tag" });
+    });
 
-    const handler = jest.fn().mockRejectedValue(new Error('Invalid JSON'))
+    const handler = jest.fn().mockRejectedValue(new Error("Invalid JSON"));
     const connector = new AMQPConnector()
-      .withUrl('amqp://localhost')
-      .withExchange('test-exchange')
-      .withQueue('test-queue')
-      .onMessage(handler)
+      .withUrl("amqp://localhost")
+      .withExchange("test-exchange")
+      .withQueue("test-queue")
+      .onMessage(handler);
 
-    await connector.build()
+    await connector.build();
 
-    const fakeMsg = { content: Buffer.from('test') }
-    await consumerCallback(fakeMsg)
+    const fakeMsg = { content: Buffer.from("test") };
+    await consumerCallback(fakeMsg);
 
-    expect(handler).toHaveBeenCalledWith(fakeMsg, expect.anything())
-    expect(mockAck).not.toHaveBeenCalled()
-    expect(mockNack).toHaveBeenCalledWith(fakeMsg, false, false)
-  })
+    expect(handler).toHaveBeenCalledWith(fakeMsg, expect.anything());
+    expect(mockAck).not.toHaveBeenCalled();
+    expect(mockNack).toHaveBeenCalledWith(fakeMsg, false, false);
+  });
 
-  it('should close channel and connection on close()', async () => {
+  it("should close channel and connection on close()", async () => {
     const connector = new AMQPConnector()
-      .withUrl('amqp://localhost')
-      .withExchange('test-exchange')
-      .withQueue('test-queue')
-      .onMessage(jest.fn())
+      .withUrl("amqp://localhost")
+      .withExchange("test-exchange")
+      .withQueue("test-queue")
+      .onMessage(jest.fn());
 
-    await connector.build()
-    await connector.close()
+    await connector.build();
+    await connector.close();
 
-    expect(mockChannel.close).toHaveBeenCalled()
-    expect(mockCloseConnection).toHaveBeenCalled()
-  })
-})
+    expect(mockChannel.close).toHaveBeenCalled();
+    expect(mockCloseConnection).toHaveBeenCalled();
+  });
+});
 
-describe('AMQPConnector Reconnection', () => {
-  const mockConsume = jest.fn()
-  const mockAck = jest.fn()
-  const mockNack = jest.fn()
-  const mockCancel = jest.fn(() => Promise.resolve())
-  const mockAssertExchange = jest.fn(() => Promise.resolve())
-  const mockAssertQueue = jest.fn(() => Promise.resolve())
-  const mockBindQueue = jest.fn(() => Promise.resolve())
-  const mockChannelOn = jest.fn()
-  const mockChannelClose = jest.fn(() => Promise.resolve())
+describe("AMQPConnector Reconnection", () => {
+  const mockConsume = jest.fn();
+  const mockAck = jest.fn();
+  const mockNack = jest.fn();
+  const mockCancel = jest.fn(() => Promise.resolve());
+  const mockAssertExchange = jest.fn(() => Promise.resolve());
+  const mockAssertQueue = jest.fn(() => Promise.resolve());
+  const mockBindQueue = jest.fn(() => Promise.resolve());
+  const mockChannelOn = jest.fn();
+  const mockChannelClose = jest.fn(() => Promise.resolve());
 
   const createMockChannel = () => ({
     assertExchange: mockAssertExchange,
@@ -209,875 +196,833 @@ describe('AMQPConnector Reconnection', () => {
     nack: mockNack,
     cancel: mockCancel,
     close: mockChannelClose,
-    on: mockChannelOn
-  })
+    on: mockChannelOn,
+  });
 
-  const mockCreateChannel = jest.fn(() => Promise.resolve(createMockChannel()))
-  const mockCloseConnection = jest.fn(() => Promise.resolve())
-  const mockConnectionOn = jest.fn()
+  const mockCreateChannel = jest.fn(() => Promise.resolve(createMockChannel()));
+  const mockCloseConnection = jest.fn(() => Promise.resolve());
+  const mockConnectionOn = jest.fn();
 
   const createMockConnection = () => ({
     createChannel: mockCreateChannel,
     close: mockCloseConnection,
-    on: mockConnectionOn
-  })
+    on: mockConnectionOn,
+  });
 
-  const mockConnect = jest.fn(() => Promise.resolve(createMockConnection()))
+  const mockConnect = jest.fn(() => Promise.resolve(createMockConnection()));
 
   beforeAll(() => {
-    ;(amqplib.connect as jest.Mock).mockImplementation(mockConnect)
-  })
+    (amqplib.connect as jest.Mock).mockImplementation(mockConnect);
+  });
 
   beforeEach(() => {
-    jest.clearAllMocks()
-    mockConsume.mockImplementation(() =>
-      Promise.resolve({ consumerTag: 'test-tag' })
-    )
-  })
+    jest.clearAllMocks();
+    mockConsume.mockImplementation(() => Promise.resolve({ consumerTag: "test-tag" }));
+  });
 
-  describe('Connection State', () => {
-    it('should start in Disconnected state', () => {
+  describe("Connection State", () => {
+    it("should start in Disconnected state", () => {
+      const connector = new AMQPConnector();
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+      expect(connector.isConnected()).toBe(false);
+    });
+
+    it("should be in Connected state after successful build", async () => {
       const connector = new AMQPConnector()
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-      expect(connector.isConnected()).toBe(false)
-    })
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-    it('should be in Connected state after successful build', async () => {
+      await connector.build();
+
+      expect(connector.getConnectionState()).toBe(ConnectionState.Connected);
+      expect(connector.isConnected()).toBe(true);
+    });
+
+    it("should be in Disconnected state after close", async () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await connector.build()
+      await connector.build();
+      await connector.close();
 
-      expect(connector.getConnectionState()).toBe(ConnectionState.Connected)
-      expect(connector.isConnected()).toBe(true)
-    })
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+      expect(connector.isConnected()).toBe(false);
+    });
 
-    it('should be in Disconnected state after close', async () => {
-      const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
-
-      await connector.build()
-      await connector.close()
-
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-      expect(connector.isConnected()).toBe(false)
-    })
-
-    it('should be in Disconnected state if build fails', async () => {
-      mockConnect.mockRejectedValueOnce(new Error('Connection failed'))
+    it("should be in Disconnected state if build fails", async () => {
+      mockConnect.mockRejectedValueOnce(new Error("Connection failed"));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await expect(connector.build()).rejects.toThrow('Connection failed')
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-    })
-  })
+      await expect(connector.build()).rejects.toThrow("Connection failed");
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+    });
+  });
 
-  describe('Reconnection Configuration', () => {
-    it('should use default reconnection config', () => {
+  describe("Reconnection Configuration", () => {
+    it("should use default reconnection config", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
       // Access private property for testing
-      const config = (connector as any).reconnectionConfig
-      expect(config.enabled).toBe(true)
-      expect(config.initialDelayMs).toBe(1000)
-      expect(config.maxDelayMs).toBe(30000)
-      expect(config.maxRetries).toBe(0)
-      expect(config.backoffMultiplier).toBe(2)
-    })
+      const config = (connector as any).reconnectionConfig;
+      expect(config.enabled).toBe(true);
+      expect(config.initialDelayMs).toBe(1000);
+      expect(config.maxDelayMs).toBe(30000);
+      expect(config.maxRetries).toBe(0);
+      expect(config.backoffMultiplier).toBe(2);
+    });
 
-    it('should allow custom reconnection config via builder', () => {
+    it("should allow custom reconnection config via builder", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
         .withReconnection({
           enabled: true,
           initialDelayMs: 500,
           maxDelayMs: 10000,
           maxRetries: 5,
-          backoffMultiplier: 1.5
-        })
+          backoffMultiplier: 1.5,
+        });
 
-      const config = (connector as any).reconnectionConfig
-      expect(config.initialDelayMs).toBe(500)
-      expect(config.maxDelayMs).toBe(10000)
-      expect(config.maxRetries).toBe(5)
-      expect(config.backoffMultiplier).toBe(1.5)
-    })
+      const config = (connector as any).reconnectionConfig;
+      expect(config.initialDelayMs).toBe(500);
+      expect(config.maxDelayMs).toBe(10000);
+      expect(config.maxRetries).toBe(5);
+      expect(config.backoffMultiplier).toBe(1.5);
+    });
 
-    it('should allow disabling reconnection', () => {
+    it("should allow disabling reconnection", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ enabled: false })
+        .withReconnection({ enabled: false });
 
-      const config = (connector as any).reconnectionConfig
-      expect(config.enabled).toBe(false)
-    })
+      const config = (connector as any).reconnectionConfig;
+      expect(config.enabled).toBe(false);
+    });
 
-    it('should merge partial config with defaults', () => {
+    it("should merge partial config with defaults", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ maxRetries: 10 })
+        .withReconnection({ maxRetries: 10 });
 
-      const config = (connector as any).reconnectionConfig
-      expect(config.enabled).toBe(true) // default
-      expect(config.initialDelayMs).toBe(1000) // default
-      expect(config.maxRetries).toBe(10) // overridden
-    })
-  })
+      const config = (connector as any).reconnectionConfig;
+      expect(config.enabled).toBe(true); // default
+      expect(config.initialDelayMs).toBe(1000); // default
+      expect(config.maxRetries).toBe(10); // overridden
+    });
+  });
 
-  describe('Automatic Reconnection', () => {
-    let connectionCloseCallback: () => void
-    let connectionErrorCallback: (error: Error) => void
+  describe("Automatic Reconnection", () => {
+    let connectionCloseCallback: () => void;
+    let connectionErrorCallback: (error: Error) => void;
 
     beforeEach(() => {
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
-        } else if (event === 'error') {
-          connectionErrorCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
+        } else if (event === "error") {
+          connectionErrorCallback = callback;
         }
-      })
-    })
+      });
+    });
 
-    it('should set up connection event handlers after build', async () => {
+    it("should set up connection event handlers after build", async () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await connector.build()
+      await connector.build();
 
-      expect(mockConnectionOn).toHaveBeenCalledWith(
-        'error',
-        expect.any(Function)
-      )
-      expect(mockConnectionOn).toHaveBeenCalledWith(
-        'close',
-        expect.any(Function)
-      )
-    })
+      expect(mockConnectionOn).toHaveBeenCalledWith("error", expect.any(Function));
+      expect(mockConnectionOn).toHaveBeenCalledWith("close", expect.any(Function));
+    });
 
-    it('should schedule reconnection when connection closes unexpectedly', async () => {
-      jest.useFakeTimers()
+    it("should schedule reconnection when connection closes unexpectedly", async () => {
+      jest.useFakeTimers();
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 1000 })
+        .withReconnection({ initialDelayMs: 1000 });
 
-      await connector.build()
+      await connector.build();
 
       // Clear previous connect calls
-      mockConnect.mockClear()
+      mockConnect.mockClear();
 
       // Simulate unexpected connection close
-      connectionCloseCallback()
+      connectionCloseCallback();
 
-      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting)
+      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting);
 
       // Fast-forward timer
-      jest.advanceTimersByTime(1100) // initialDelayMs + jitter
+      jest.advanceTimersByTime(1100); // initialDelayMs + jitter
 
       // Should have attempted to reconnect
-      expect(mockConnect).toHaveBeenCalledTimes(1)
+      expect(mockConnect).toHaveBeenCalledTimes(1);
 
-      jest.useRealTimers()
-    })
+      jest.useRealTimers();
+    });
 
-    it('should not reconnect after intentional close', async () => {
-      jest.useFakeTimers()
+    it("should not reconnect after intentional close", async () => {
+      jest.useFakeTimers();
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 100 })
+        .withReconnection({ initialDelayMs: 100 });
 
-      await connector.build()
-      mockConnect.mockClear()
+      await connector.build();
+      mockConnect.mockClear();
 
-      await connector.close()
+      await connector.close();
 
       // Fast-forward timer
-      jest.advanceTimersByTime(5000)
+      jest.advanceTimersByTime(5000);
 
       // Should not have attempted to reconnect
-      expect(mockConnect).not.toHaveBeenCalled()
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
+      expect(mockConnect).not.toHaveBeenCalled();
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
 
-      jest.useRealTimers()
-    })
+      jest.useRealTimers();
+    });
 
-    it('should not reconnect when reconnection is disabled', async () => {
-      jest.useFakeTimers()
+    it("should not reconnect when reconnection is disabled", async () => {
+      jest.useFakeTimers();
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ enabled: false })
+        .withReconnection({ enabled: false });
 
-      await connector.build()
-      mockConnect.mockClear()
+      await connector.build();
+      mockConnect.mockClear();
 
       // Simulate unexpected connection close
-      connectionCloseCallback()
+      connectionCloseCallback();
 
       // Fast-forward timer
-      jest.advanceTimersByTime(5000)
+      jest.advanceTimersByTime(5000);
 
       // Should not have attempted to reconnect
-      expect(mockConnect).not.toHaveBeenCalled()
+      expect(mockConnect).not.toHaveBeenCalled();
 
-      jest.useRealTimers()
-    })
+      jest.useRealTimers();
+    });
 
-    it('should stop reconnecting after max retries', async () => {
-      jest.useFakeTimers()
+    it("should stop reconnecting after max retries", async () => {
+      jest.useFakeTimers();
 
       // Make connect always fail after initial build
-      let buildComplete = false
+      let buildComplete = false;
       mockConnect.mockImplementation(() => {
         if (!buildComplete) {
-          buildComplete = true
-          return Promise.resolve(createMockConnection())
+          buildComplete = true;
+          return Promise.resolve(createMockConnection());
         }
-        return Promise.reject(new Error('Connection failed'))
-      })
+        return Promise.reject(new Error("Connection failed"));
+      });
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
         .withReconnection({
           maxRetries: 3,
           initialDelayMs: 100,
-          backoffMultiplier: 1
-        })
+          backoffMultiplier: 1,
+        });
 
-      await connector.build()
-      mockConnect.mockClear()
+      await connector.build();
+      mockConnect.mockClear();
 
       // Simulate unexpected connection close
-      connectionCloseCallback()
+      connectionCloseCallback();
 
       // Run through all retry attempts using advanceTimersByTimeAsync
       // to properly handle async promise resolution
       for (let i = 0; i < 5; i++) {
-        await jest.advanceTimersByTimeAsync(200)
+        await jest.advanceTimersByTimeAsync(200);
       }
 
       // Should have stopped at 3 retries
-      expect(mockConnect).toHaveBeenCalledTimes(3)
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
+      expect(mockConnect).toHaveBeenCalledTimes(3);
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
 
-      jest.useRealTimers()
-    })
+      jest.useRealTimers();
+    });
 
-    it('should reset retry count on successful reconnection', async () => {
-      jest.useFakeTimers()
+    it("should reset retry count on successful reconnection", async () => {
+      jest.useFakeTimers();
 
       // Reset mock to always succeed
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 100 })
+        .withReconnection({ initialDelayMs: 100 });
 
-      await connector.build()
+      await connector.build();
 
       // Simulate close then successful reconnect
-      connectionCloseCallback()
+      connectionCloseCallback();
 
       // Advance timer and flush all pending promises
-      await jest.advanceTimersByTimeAsync(200)
+      await jest.advanceTimersByTimeAsync(200);
 
-      expect(connector.getConnectionState()).toBe(ConnectionState.Connected)
-      expect((connector as any).reconnectAttempts).toBe(0)
+      expect(connector.getConnectionState()).toBe(ConnectionState.Connected);
+      expect((connector as any).reconnectAttempts).toBe(0);
 
-      jest.useRealTimers()
-    })
-  })
+      jest.useRealTimers();
+    });
+  });
 
-  describe('Exponential Backoff', () => {
-    it('should calculate increasing delays with backoff', () => {
+  describe("Exponential Backoff", () => {
+    it("should calculate increasing delays with backoff", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
         .withReconnection({
           initialDelayMs: 1000,
           maxDelayMs: 30000,
-          backoffMultiplier: 2
-        })
+          backoffMultiplier: 2,
+        });
 
-      const calculateDelay = (connector as any).calculateReconnectDelay.bind(
-        connector
-      )
+      const calculateDelay = (connector as any).calculateReconnectDelay.bind(connector);
 
       // Mock Math.random to remove jitter for predictable testing
-      const originalRandom = Math.random
-      Math.random = () => 0
-      ;(connector as any).reconnectAttempts = 0
-      expect(calculateDelay()).toBe(1000) // 1000 * 2^0
-      ;(connector as any).reconnectAttempts = 1
-      expect(calculateDelay()).toBe(2000) // 1000 * 2^1
-      ;(connector as any).reconnectAttempts = 2
-      expect(calculateDelay()).toBe(4000) // 1000 * 2^2
-      ;(connector as any).reconnectAttempts = 3
-      expect(calculateDelay()).toBe(8000) // 1000 * 2^3
+      const originalRandom = Math.random;
+      Math.random = () => 0;
+      (connector as any).reconnectAttempts = 0;
+      expect(calculateDelay()).toBe(1000); // 1000 * 2^0
+      (connector as any).reconnectAttempts = 1;
+      expect(calculateDelay()).toBe(2000); // 1000 * 2^1
+      (connector as any).reconnectAttempts = 2;
+      expect(calculateDelay()).toBe(4000); // 1000 * 2^2
+      (connector as any).reconnectAttempts = 3;
+      expect(calculateDelay()).toBe(8000); // 1000 * 2^3
 
-      Math.random = originalRandom
-    })
+      Math.random = originalRandom;
+    });
 
-    it('should cap delay at maxDelayMs', () => {
+    it("should cap delay at maxDelayMs", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
         .withReconnection({
           initialDelayMs: 1000,
           maxDelayMs: 5000,
-          backoffMultiplier: 2
-        })
+          backoffMultiplier: 2,
+        });
 
-      const calculateDelay = (connector as any).calculateReconnectDelay.bind(
-        connector
-      )
+      const calculateDelay = (connector as any).calculateReconnectDelay.bind(connector);
 
       // Mock Math.random to remove jitter
-      const originalRandom = Math.random
-      Math.random = () => 0
-      ;(connector as any).reconnectAttempts = 10 // Would be 1024000ms without cap
-      expect(calculateDelay()).toBe(5000)
+      const originalRandom = Math.random;
+      Math.random = () => 0;
+      (connector as any).reconnectAttempts = 10; // Would be 1024000ms without cap
+      expect(calculateDelay()).toBe(5000);
 
-      Math.random = originalRandom
-    })
+      Math.random = originalRandom;
+    });
 
-    it('should add jitter to delay', () => {
+    it("should add jitter to delay", () => {
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
         .withReconnection({
           initialDelayMs: 1000,
           maxDelayMs: 30000,
-          backoffMultiplier: 2
-        })
+          backoffMultiplier: 2,
+        });
 
-      const calculateDelay = (connector as any).calculateReconnectDelay.bind(
-        connector
-      )
+      const calculateDelay = (connector as any).calculateReconnectDelay.bind(connector);
 
-      ;(connector as any).reconnectAttempts = 0
+      (connector as any).reconnectAttempts = 0;
 
       // With jitter, delay should be between 1000 and 1100 (10% jitter)
-      const delay = calculateDelay()
-      expect(delay).toBeGreaterThanOrEqual(1000)
-      expect(delay).toBeLessThanOrEqual(1100)
-    })
-  })
+      const delay = calculateDelay();
+      expect(delay).toBeGreaterThanOrEqual(1000);
+      expect(delay).toBeLessThanOrEqual(1100);
+    });
+  });
 
-  describe('Close with pending reconnection', () => {
-    it('should cancel pending reconnection timeout on close', async () => {
-      jest.useFakeTimers()
+  describe("Close with pending reconnection", () => {
+    it("should cancel pending reconnection timeout on close", async () => {
+      jest.useFakeTimers();
 
       // Make reconnection fail to keep it pending
-      let buildComplete = false
+      let buildComplete = false;
       mockConnect.mockImplementation(() => {
         if (!buildComplete) {
-          buildComplete = true
-          return Promise.resolve(createMockConnection())
+          buildComplete = true;
+          return Promise.resolve(createMockConnection());
         }
-        return Promise.reject(new Error('Connection failed'))
-      })
+        return Promise.reject(new Error("Connection failed"));
+      });
 
-      let connectionCloseCallback: () => void = () => {}
+      let connectionCloseCallback: () => void = () => {};
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
         }
-      })
+      });
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 5000 })
+        .withReconnection({ initialDelayMs: 5000 });
 
-      await connector.build()
-      mockConnect.mockClear()
+      await connector.build();
+      mockConnect.mockClear();
 
       // Simulate close which schedules reconnection
-      connectionCloseCallback()
-      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting)
+      connectionCloseCallback();
+      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting);
 
       // Close before reconnection timeout fires
-      await connector.close()
+      await connector.close();
 
       // Advance timer past reconnection delay
-      jest.advanceTimersByTime(10000)
-      await Promise.resolve()
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve();
 
       // Should not have attempted reconnection
-      expect(mockConnect).not.toHaveBeenCalled()
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
+      expect(mockConnect).not.toHaveBeenCalled();
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
 
-      jest.useRealTimers()
-    })
-  })
+      jest.useRealTimers();
+    });
+  });
 
-  describe('Build clears pending reconnect timer', () => {
-    it('should clear pending reconnection timer when build() is called', async () => {
-      jest.useFakeTimers()
+  describe("Build clears pending reconnect timer", () => {
+    it("should clear pending reconnection timer when build() is called", async () => {
+      jest.useFakeTimers();
 
-      let connectionCloseCallback: () => void = () => {}
+      let connectionCloseCallback: () => void = () => {};
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
         }
-      })
+      });
 
       // First build succeeds
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 5000 })
+        .withReconnection({ initialDelayMs: 5000 });
 
-      await connector.build()
+      await connector.build();
 
       // Simulate connection close to trigger reconnection scheduling
-      connectionCloseCallback()
-      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting)
+      connectionCloseCallback();
+      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting);
 
-      mockConnect.mockClear()
+      mockConnect.mockClear();
 
       // Call build() again before reconnection timer fires
-      await connector.build()
+      await connector.build();
 
       // Advance timer past original reconnection delay
-      jest.advanceTimersByTime(10000)
-      await Promise.resolve()
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve();
 
       // Should have only connected once (from build()), not from scheduled reconnection
-      expect(mockConnect).toHaveBeenCalledTimes(1)
-      expect(connector.getConnectionState()).toBe(ConnectionState.Connected)
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(connector.getConnectionState()).toBe(ConnectionState.Connected);
 
-      jest.useRealTimers()
-    })
-  })
+      jest.useRealTimers();
+    });
+  });
 
-  describe('Channel-only reconnection', () => {
-    let channelCloseCallback: () => void
-    let connectionCloseCallback: () => void
+  describe("Channel-only reconnection", () => {
+    let channelCloseCallback: () => void;
+    let connectionCloseCallback: () => void;
 
     beforeEach(() => {
       mockChannelOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          channelCloseCallback = callback
+        if (event === "close") {
+          channelCloseCallback = callback;
         }
-      })
+      });
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
         }
-      })
-    })
+      });
+    });
 
-    it('should recreate channel when channel closes but connection remains', async () => {
-      jest.useFakeTimers()
+    it("should recreate channel when channel closes but connection remains", async () => {
+      jest.useFakeTimers();
 
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await connector.build()
+      await connector.build();
 
       // Clear to track new channel creation
-      mockCreateChannel.mockClear()
-      mockAssertExchange.mockClear()
-      mockAssertQueue.mockClear()
-      mockBindQueue.mockClear()
-      mockConsume.mockClear()
+      mockCreateChannel.mockClear();
+      mockAssertExchange.mockClear();
+      mockAssertQueue.mockClear();
+      mockBindQueue.mockClear();
+      mockConsume.mockClear();
 
       // Simulate channel-only close (connection still exists)
-      channelCloseCallback()
+      channelCloseCallback();
 
       // Allow promises to resolve
-      await jest.advanceTimersByTimeAsync(0)
+      await jest.advanceTimersByTimeAsync(0);
 
       // Should have recreated the channel
-      expect(mockCreateChannel).toHaveBeenCalledTimes(1)
-      expect(mockAssertExchange).toHaveBeenCalledTimes(1)
-      expect(mockAssertQueue).toHaveBeenCalledTimes(1)
-      expect(mockBindQueue).toHaveBeenCalledTimes(1)
-      expect(mockConsume).toHaveBeenCalledTimes(1)
+      expect(mockCreateChannel).toHaveBeenCalledTimes(1);
+      expect(mockAssertExchange).toHaveBeenCalledTimes(1);
+      expect(mockAssertQueue).toHaveBeenCalledTimes(1);
+      expect(mockBindQueue).toHaveBeenCalledTimes(1);
+      expect(mockConsume).toHaveBeenCalledTimes(1);
 
       // Connection should NOT have been re-established
-      expect(mockConnect).toHaveBeenCalledTimes(1) // Only from initial build
+      expect(mockConnect).toHaveBeenCalledTimes(1); // Only from initial build
 
-      jest.useRealTimers()
-    })
+      jest.useRealTimers();
+    });
 
-    it('should not recreate channel on intentional close', async () => {
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
+    it("should not recreate channel on intentional close", async () => {
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await connector.build()
+      await connector.build();
 
       // Close intentionally
-      await connector.close()
+      await connector.close();
 
-      mockCreateChannel.mockClear()
+      mockCreateChannel.mockClear();
 
       // Simulate channel close event (would have been triggered by close())
-      channelCloseCallback()
+      channelCloseCallback();
 
-      await Promise.resolve()
+      await Promise.resolve();
 
       // Should NOT have tried to recreate channel
-      expect(mockCreateChannel).not.toHaveBeenCalled()
-    })
+      expect(mockCreateChannel).not.toHaveBeenCalled();
+    });
 
-    it('should trigger full reconnection if channel recreation fails', async () => {
-      jest.useFakeTimers()
+    it("should trigger full reconnection if channel recreation fails", async () => {
+      jest.useFakeTimers();
 
-      let channelCreationCount = 0
+      let channelCreationCount = 0;
       mockCreateChannel.mockImplementation(() => {
-        channelCreationCount++
+        channelCreationCount++;
         if (channelCreationCount === 1) {
           // First channel creation succeeds (during build)
-          return Promise.resolve(createMockChannel())
+          return Promise.resolve(createMockChannel());
         }
         // Subsequent channel creations fail
-        return Promise.reject(new Error('Channel creation failed'))
-      })
+        return Promise.reject(new Error("Channel creation failed"));
+      });
 
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 100, enabled: true })
+        .withReconnection({ initialDelayMs: 100, enabled: true });
 
-      await connector.build()
+      await connector.build();
 
-      mockConnect.mockClear()
+      mockConnect.mockClear();
 
       // Simulate channel close - recreation will fail
-      channelCloseCallback()
+      channelCloseCallback();
 
       // Allow the failed channel recreation to complete
-      await jest.advanceTimersByTimeAsync(0)
+      await jest.advanceTimersByTimeAsync(0);
 
       // Should schedule full reconnection
-      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting)
+      expect(connector.getConnectionState()).toBe(ConnectionState.Reconnecting);
 
       // Advance timer to trigger reconnection
-      await jest.advanceTimersByTimeAsync(200)
+      await jest.advanceTimersByTimeAsync(200);
 
       // Should have attempted full reconnection
-      expect(mockConnect).toHaveBeenCalled()
+      expect(mockConnect).toHaveBeenCalled();
 
-      jest.useRealTimers()
-    })
-  })
+      jest.useRealTimers();
+    });
+  });
 
-  describe('Cleanup on build failure', () => {
+  describe("Cleanup on build failure", () => {
     beforeEach(() => {
       // Reset mocks to default for these tests
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
-      mockCreateChannel.mockImplementation(() =>
-        Promise.resolve(createMockChannel())
-      )
-    })
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
+      mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
+    });
 
-    it('should cleanup partial resources when connection fails during build', async () => {
-      mockConnect.mockRejectedValueOnce(new Error('Connection failed'))
+    it("should cleanup partial resources when connection fails during build", async () => {
+      mockConnect.mockRejectedValueOnce(new Error("Connection failed"));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await expect(connector.build()).rejects.toThrow('Connection failed')
+      await expect(connector.build()).rejects.toThrow("Connection failed");
 
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-      expect((connector as any).channel).toBeUndefined()
-      expect((connector as any).connection).toBeUndefined()
-      expect((connector as any).consumerTag).toBeUndefined()
-    })
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+      expect((connector as any).channel).toBeUndefined();
+      expect((connector as any).connection).toBeUndefined();
+      expect((connector as any).consumerTag).toBeUndefined();
+    });
 
-    it('should cleanup partial resources when channel creation fails during build', async () => {
-      mockCreateChannel.mockRejectedValueOnce(
-        new Error('Channel creation failed')
-      )
+    it("should cleanup partial resources when channel creation fails during build", async () => {
+      mockCreateChannel.mockRejectedValueOnce(new Error("Channel creation failed"));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
-      await expect(connector.build()).rejects.toThrow('Channel creation failed')
+      await expect(connector.build()).rejects.toThrow("Channel creation failed");
 
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-      expect((connector as any).channel).toBeUndefined()
-      expect((connector as any).connection).toBeUndefined()
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+      expect((connector as any).channel).toBeUndefined();
+      expect((connector as any).connection).toBeUndefined();
       // Connection close should have been called to cleanup
-      expect(mockCloseConnection).toHaveBeenCalled()
-    })
-  })
+      expect(mockCloseConnection).toHaveBeenCalled();
+    });
+  });
 
-  describe('Cleanup on reconnection failure', () => {
-    it('should cleanup partial resources when reconnection fails', async () => {
-      jest.useFakeTimers()
+  describe("Cleanup on reconnection failure", () => {
+    it("should cleanup partial resources when reconnection fails", async () => {
+      jest.useFakeTimers();
 
       // Reset mock to default for this test
-      mockCreateChannel.mockImplementation(() =>
-        Promise.resolve(createMockChannel())
-      )
+      mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
 
-      let connectionCloseCallback: () => void = () => {}
+      let connectionCloseCallback: () => void = () => {};
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
         }
-      })
+      });
 
       // First build succeeds, subsequent connects fail
-      let buildComplete = false
+      let buildComplete = false;
       mockConnect.mockImplementation(() => {
         if (!buildComplete) {
-          buildComplete = true
-          return Promise.resolve(createMockConnection())
+          buildComplete = true;
+          return Promise.resolve(createMockConnection());
         }
-        return Promise.reject(new Error('Reconnection failed'))
-      })
+        return Promise.reject(new Error("Reconnection failed"));
+      });
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 100, maxRetries: 1 })
+        .withReconnection({ initialDelayMs: 100, maxRetries: 1 });
 
-      await connector.build()
+      await connector.build();
 
       // Simulate connection close
-      connectionCloseCallback()
+      connectionCloseCallback();
 
       // Advance timer to trigger reconnection
-      await jest.advanceTimersByTimeAsync(200)
+      await jest.advanceTimersByTimeAsync(200);
 
       // After failed reconnection attempt, state should be disconnected
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
 
-      jest.useRealTimers()
-    })
-  })
+      jest.useRealTimers();
+    });
+  });
 
-  describe('Message handling when channel unavailable', () => {
-    it('should handle message gracefully when channel becomes unavailable', async () => {
+  describe("Message handling when channel unavailable", () => {
+    it("should handle message gracefully when channel becomes unavailable", async () => {
       // Reset mocks to default for this test
-      mockConnect.mockImplementation(() =>
-        Promise.resolve(createMockConnection())
-      )
-      mockCreateChannel.mockImplementation(() =>
-        Promise.resolve(createMockChannel())
-      )
+      mockConnect.mockImplementation(() => Promise.resolve(createMockConnection()));
+      mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
 
-      let consumerCallback: any
+      let consumerCallback: any;
       mockConsume.mockImplementation((_queue, cb) => {
-        consumerCallback = cb
-        return Promise.resolve({ consumerTag: 'test-tag' })
-      })
+        consumerCallback = cb;
+        return Promise.resolve({ consumerTag: "test-tag" });
+      });
 
-      const handler = jest.fn()
+      const handler = jest.fn();
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(handler)
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(handler);
 
-      await connector.build()
+      await connector.build();
 
       // Simulate channel becoming unavailable
-      ;(connector as any).channel = undefined
+      (connector as any).channel = undefined;
 
-      const fakeMsg = { content: Buffer.from('test') }
-      await consumerCallback(fakeMsg)
+      const fakeMsg = { content: Buffer.from("test") };
+      await consumerCallback(fakeMsg);
 
       // Handler should not be called when channel is unavailable
-      expect(handler).not.toHaveBeenCalled()
-      expect(mockAck).not.toHaveBeenCalled()
-      expect(mockNack).not.toHaveBeenCalled()
-    })
-  })
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockAck).not.toHaveBeenCalled();
+      expect(mockNack).not.toHaveBeenCalled();
+    });
+  });
 
-  describe('Race condition: close() during build()', () => {
-    it('should cleanup when close() is called during build()', async () => {
+  describe("Race condition: close() during build()", () => {
+    it("should cleanup when close() is called during build()", async () => {
       // Reset channel mock to default
-      mockCreateChannel.mockImplementation(() =>
-        Promise.resolve(createMockChannel())
-      )
+      mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
 
       // Slow down connect to simulate race condition
-      let resolveConnect: (value: any) => void
+      let resolveConnect: (value: any) => void;
       mockConnect.mockImplementation(
         () =>
           new Promise((resolve) => {
-            resolveConnect = resolve
-          })
-      )
+            resolveConnect = resolve;
+          }),
+      );
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
-        .onMessage(jest.fn())
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
+        .onMessage(jest.fn());
 
       // Start build (will wait for connect)
-      const buildPromise = connector.build()
+      const buildPromise = connector.build();
 
       // Call close() while build is in progress
-      const closePromise = connector.close()
+      const closePromise = connector.close();
 
       // Now resolve the connect
-      resolveConnect!(createMockConnection())
+      resolveConnect!(createMockConnection());
 
       // Both should complete
-      await Promise.all([buildPromise, closePromise])
+      await Promise.all([buildPromise, closePromise]);
 
       // Should be in disconnected state
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
-      expect((connector as any).channel).toBeUndefined()
-      expect((connector as any).connection).toBeUndefined()
-    })
-  })
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
+      expect((connector as any).channel).toBeUndefined();
+      expect((connector as any).connection).toBeUndefined();
+    });
+  });
 
-  describe('Race condition: close() during attemptReconnection()', () => {
-    it('should cleanup when close() is called during reconnection', async () => {
-      jest.useFakeTimers()
+  describe("Race condition: close() during attemptReconnection()", () => {
+    it("should cleanup when close() is called during reconnection", async () => {
+      jest.useFakeTimers();
 
       // Reset mocks to default for this test
-      mockCreateChannel.mockImplementation(() =>
-        Promise.resolve(createMockChannel())
-      )
+      mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
 
-      let connectionCloseCallback: () => void = () => {}
+      let connectionCloseCallback: () => void = () => {};
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
-        if (event === 'close') {
-          connectionCloseCallback = callback
+        if (event === "close") {
+          connectionCloseCallback = callback;
         }
-      })
+      });
 
       // First build succeeds
-      mockConnect.mockImplementationOnce(() =>
-        Promise.resolve(createMockConnection())
-      )
+      mockConnect.mockImplementationOnce(() => Promise.resolve(createMockConnection()));
 
       const connector = new AMQPConnector()
-        .withUrl('amqp://localhost')
-        .withExchange('test-exchange')
-        .withQueue('test-queue')
+        .withUrl("amqp://localhost")
+        .withExchange("test-exchange")
+        .withQueue("test-queue")
         .onMessage(jest.fn())
-        .withReconnection({ initialDelayMs: 100 })
+        .withReconnection({ initialDelayMs: 100 });
 
-      await connector.build()
+      await connector.build();
 
       // Make next connect slow
-      let resolveReconnect: (value: any) => void
+      let resolveReconnect: (value: any) => void;
       mockConnect.mockImplementationOnce(
         () =>
           new Promise((resolve) => {
-            resolveReconnect = resolve
-          })
-      )
+            resolveReconnect = resolve;
+          }),
+      );
 
       // Trigger reconnection
-      connectionCloseCallback()
+      connectionCloseCallback();
 
       // Advance timer to start reconnection
-      jest.advanceTimersByTime(200)
+      jest.advanceTimersByTime(200);
 
       // Call close() while reconnection is in progress
-      const closePromise = connector.close()
+      const closePromise = connector.close();
 
       // Resolve the reconnect
-      resolveReconnect!(createMockConnection())
+      resolveReconnect!(createMockConnection());
 
-      await closePromise
-      await jest.advanceTimersByTimeAsync(0)
+      await closePromise;
+      await jest.advanceTimersByTimeAsync(0);
 
       // Should be in disconnected state
-      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected)
+      expect(connector.getConnectionState()).toBe(ConnectionState.Disconnected);
 
-      jest.useRealTimers()
-    })
-  })
-})
+      jest.useRealTimers();
+    });
+  });
+});

--- a/packages/amqp-connector/src/index.test.ts
+++ b/packages/amqp-connector/src/index.test.ts
@@ -936,7 +936,7 @@ describe("AMQPConnector Reconnection", () => {
       mockCreateChannel.mockImplementation(() => Promise.resolve(createMockChannel()));
 
       // Slow down connect to simulate race condition
-      let resolveConnect: (value: any) => void;
+      let resolveConnect!: (value: any) => void;
       mockConnect.mockImplementation(
         () =>
           new Promise((resolve) => {
@@ -996,7 +996,7 @@ describe("AMQPConnector Reconnection", () => {
       await connector.build();
 
       // Make next connect slow
-      let resolveReconnect: (value: any) => void;
+      let resolveReconnect!: (value: any) => void;
       mockConnect.mockImplementationOnce(
         () =>
           new Promise((resolve) => {

--- a/packages/amqp-connector/src/index.test.ts
+++ b/packages/amqp-connector/src/index.test.ts
@@ -335,14 +335,14 @@ describe("AMQPConnector Reconnection", () => {
 
   describe("Automatic Reconnection", () => {
     let connectionCloseCallback: () => void;
-    let connectionErrorCallback: (error: Error) => void;
+    let _connectionErrorCallback: (error: Error) => void;
 
     beforeEach(() => {
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
         if (event === "close") {
           connectionCloseCallback = callback;
         } else if (event === "error") {
-          connectionErrorCallback = callback;
+          _connectionErrorCallback = callback;
         }
       });
     });
@@ -682,7 +682,7 @@ describe("AMQPConnector Reconnection", () => {
 
   describe("Channel-only reconnection", () => {
     let channelCloseCallback: () => void;
-    let connectionCloseCallback: () => void;
+    let _connectionCloseCallback: () => void;
 
     beforeEach(() => {
       mockChannelOn.mockImplementation((event: string, callback: any) => {
@@ -692,7 +692,7 @@ describe("AMQPConnector Reconnection", () => {
       });
       mockConnectionOn.mockImplementation((event: string, callback: any) => {
         if (event === "close") {
-          connectionCloseCallback = callback;
+          _connectionCloseCallback = callback;
         }
       });
     });
@@ -957,7 +957,7 @@ describe("AMQPConnector Reconnection", () => {
       const closePromise = connector.close();
 
       // Now resolve the connect
-      resolveConnect!(createMockConnection());
+      resolveConnect?.(createMockConnection());
 
       // Both should complete
       await Promise.all([buildPromise, closePromise]);
@@ -1014,7 +1014,7 @@ describe("AMQPConnector Reconnection", () => {
       const closePromise = connector.close();
 
       // Resolve the reconnect
-      resolveReconnect!(createMockConnection());
+      resolveReconnect?.(createMockConnection());
 
       await closePromise;
       await jest.advanceTimersByTimeAsync(0);

--- a/packages/amqp-connector/src/index.ts
+++ b/packages/amqp-connector/src/index.ts
@@ -1,52 +1,48 @@
-import amqplib, { type Options } from 'amqplib'
-import { type TwakeLogger } from '@twake/logger'
+import type { TwakeLogger } from "@twake/logger";
+import amqplib, { type Options } from "amqplib";
+import { ExchangeNotSpecifiedError, MessageHandlerNotProvidedError, QueueNotSpecifiedError } from "./errors";
 import {
   type AmqpConfig,
-  type MessageHandler,
   ConnectionState,
+  DEFAULT_RECONNECTION_CONFIG,
+  type MessageHandler,
   type ReconnectionConfig,
-  DEFAULT_RECONNECTION_CONFIG
-} from './types'
-import {
-  QueueNotSpecifiedError,
-  MessageHandlerNotProvidedError,
-  ExchangeNotSpecifiedError
-} from './errors'
+} from "./types";
 
 export {
+  type AmqpConfig,
   ConnectionState,
   type ReconnectionConfig,
-  type AmqpConfig
-} from './types'
+} from "./types";
 
 export class AMQPConnector {
-  private readonly logger?: TwakeLogger
-  private url: string = ''
-  private exchange?: string
-  private queue?: string
-  private routingKey: string = '#'
-  private exchangeOptions: Options.AssertExchange = { durable: true }
-  private queueOptions: Options.AssertQueue = { durable: true }
-  private onMessageHandler?: MessageHandler
-  private connection?: amqplib.ChannelModel
-  private channel?: amqplib.Channel
+  private readonly logger?: TwakeLogger;
+  private url: string = "";
+  private exchange?: string;
+  private queue?: string;
+  private routingKey: string = "#";
+  private exchangeOptions: Options.AssertExchange = { durable: true };
+  private queueOptions: Options.AssertQueue = { durable: true };
+  private onMessageHandler?: MessageHandler;
+  private connection?: amqplib.ChannelModel;
+  private channel?: amqplib.Channel;
 
   // Reconnection properties
-  private connectionState: ConnectionState = ConnectionState.Disconnected
+  private connectionState: ConnectionState = ConnectionState.Disconnected;
   private reconnectionConfig: Required<ReconnectionConfig> = {
-    ...DEFAULT_RECONNECTION_CONFIG
-  }
-  private reconnectAttempts: number = 0
-  private reconnectTimeoutId?: ReturnType<typeof setTimeout>
-  private isIntentionalClose: boolean = false
-  private consumerTag?: string
+    ...DEFAULT_RECONNECTION_CONFIG,
+  };
+  private reconnectAttempts: number = 0;
+  private reconnectTimeoutId?: ReturnType<typeof setTimeout>;
+  private isIntentionalClose: boolean = false;
+  private consumerTag?: string;
 
   /**
    * Constructor for AMQPConnector
    * @param logger - Optional TwakeLogger instance for logging
    */
   constructor(logger?: TwakeLogger) {
-    this.logger = logger
+    this.logger = logger;
   }
 
   /**
@@ -55,13 +51,11 @@ export class AMQPConnector {
    * @returns this
    */
   withConfig(conf: AmqpConfig): this {
-    const protocol = conf.tls === true ? 'amqps' : 'amqp'
+    const protocol = conf.tls === true ? "amqps" : "amqp";
     const url = `${protocol}://${encodeURIComponent(
-      conf.username
-    )}:${encodeURIComponent(conf.password)}@${conf.host}:${conf.port}/${
-      conf.vhost
-    }`
-    return this.withUrl(url)
+      conf.username,
+    )}:${encodeURIComponent(conf.password)}@${conf.host}:${conf.port}/${conf.vhost}`;
+    return this.withUrl(url);
   }
 
   /**
@@ -70,17 +64,14 @@ export class AMQPConnector {
    * @returns this
    */
   withUrl(url: string): this {
-    this.url = url
-    return this
+    this.url = url;
+    return this;
   }
 
-  withExchange(
-    exchange: string,
-    options: Options.AssertExchange = { durable: true }
-  ): this {
-    this.exchange = exchange
-    this.exchangeOptions = options
-    return this
+  withExchange(exchange: string, options: Options.AssertExchange = { durable: true }): this {
+    this.exchange = exchange;
+    this.exchangeOptions = options;
+    return this;
   }
 
   /**
@@ -89,15 +80,11 @@ export class AMQPConnector {
    * @param options - Queue options (default: { durable: true })
    * @returns this
    */
-  withQueue(
-    queue: string,
-    options: Options.AssertQueue = { durable: true },
-    routingKey?: string
-  ): this {
-    this.queue = queue
-    this.queueOptions = options
-    if (routingKey != null) this.routingKey = routingKey
-    return this
+  withQueue(queue: string, options: Options.AssertQueue = { durable: true }, routingKey?: string): this {
+    this.queue = queue;
+    this.queueOptions = options;
+    if (routingKey != null) this.routingKey = routingKey;
+    return this;
   }
 
   /**
@@ -106,8 +93,8 @@ export class AMQPConnector {
    * @returns this
    */
   onMessage(handler: MessageHandler): this {
-    this.onMessageHandler = handler
-    return this
+    this.onMessageHandler = handler;
+    return this;
   }
 
   /**
@@ -118,9 +105,9 @@ export class AMQPConnector {
   withReconnection(config: ReconnectionConfig): this {
     this.reconnectionConfig = {
       ...DEFAULT_RECONNECTION_CONFIG,
-      ...config
-    }
-    return this
+      ...config,
+    };
+    return this;
   }
 
   /**
@@ -128,7 +115,7 @@ export class AMQPConnector {
    * @returns The current ConnectionState
    */
   getConnectionState(): ConnectionState {
-    return this.connectionState
+    return this.connectionState;
   }
 
   /**
@@ -136,7 +123,7 @@ export class AMQPConnector {
    * @returns true if connected, false otherwise
    */
   isConnected(): boolean {
-    return this.connectionState === ConnectionState.Connected
+    return this.connectionState === ConnectionState.Connected;
   }
 
   /**
@@ -146,59 +133,50 @@ export class AMQPConnector {
    * @returns Promise that resolves when the connector is built and started
    */
   async build(): Promise<void> {
-    if (this.exchange == null || this.exchange === undefined)
-      throw new ExchangeNotSpecifiedError()
+    if (this.exchange == null || this.exchange === undefined) throw new ExchangeNotSpecifiedError();
 
-    if (this.queue == null || this.queue === undefined)
-      throw new QueueNotSpecifiedError()
+    if (this.queue == null || this.queue === undefined) throw new QueueNotSpecifiedError();
 
-    if (this.onMessageHandler == null)
-      throw new MessageHandlerNotProvidedError()
+    if (this.onMessageHandler == null) throw new MessageHandlerNotProvidedError();
 
     // Clear any pending reconnect timer to avoid overlapping connection attempts
     if (this.reconnectTimeoutId != null) {
-      clearTimeout(this.reconnectTimeoutId)
-      this.reconnectTimeoutId = undefined
+      clearTimeout(this.reconnectTimeoutId);
+      this.reconnectTimeoutId = undefined;
     }
 
     // Reset state for fresh build
-    this.isIntentionalClose = false
-    this.reconnectAttempts = 0
-    this.connectionState = ConnectionState.Connecting
+    this.isIntentionalClose = false;
+    this.reconnectAttempts = 0;
+    this.connectionState = ConnectionState.Connecting;
 
-    this.logger?.info(`[AMQPConnector] Connecting to AMQP server...`)
+    this.logger?.info(`[AMQPConnector] Connecting to AMQP server...`);
 
     try {
-      this.connection = await amqplib.connect(this.url)
+      this.connection = await amqplib.connect(this.url);
 
       // Set up channel with exchange, queue, bindings, and consumer
-      await this.setupChannel()
+      await this.setupChannel();
 
-      this.logger?.info(
-        `[AMQPConnector] Connected and listening on queue: ${this.queue}`
-      )
+      this.logger?.info(`[AMQPConnector] Connected and listening on queue: ${this.queue}`);
 
       // Check if close() was called during connection establishment
       if (this.isIntentionalClose) {
-        await this.cleanupResources()
-        this.logger?.info(
-          '[AMQPConnector] Connection closed during build - close() was called concurrently.'
-        )
-        return
+        await this.cleanupResources();
+        this.logger?.info("[AMQPConnector] Connection closed during build - close() was called concurrently.");
+        return;
       }
 
       // Set up event handlers for automatic reconnection
-      this.setupConnectionEventHandlers()
+      this.setupConnectionEventHandlers();
 
-      this.connectionState = ConnectionState.Connected
+      this.connectionState = ConnectionState.Connected;
     } catch (error) {
       this.logger?.debug(
-        `[AMQPConnector] Connection failed, cleaning up partial resources: ${
-          (error as Error).message
-        }`
-      )
-      await this.cleanupResources()
-      throw error
+        `[AMQPConnector] Connection failed, cleaning up partial resources: ${(error as Error).message}`,
+      );
+      await this.cleanupResources();
+      throw error;
     }
   }
 
@@ -208,11 +186,11 @@ export class AMQPConnector {
    */
   async close(): Promise<void> {
     // Mark as intentional close to prevent reconnection
-    this.isIntentionalClose = true
+    this.isIntentionalClose = true;
 
-    await this.cleanupResources()
+    await this.cleanupResources();
 
-    this.logger?.info(`[AMQPConnector] Connection closed.`)
+    this.logger?.info(`[AMQPConnector] Connection closed.`);
   }
 
   /**
@@ -220,7 +198,7 @@ export class AMQPConnector {
    * @returns The current channel or undefined if not connected
    */
   getChannel(): amqplib.Channel | undefined {
-    return this.channel
+    return this.channel;
   }
 
   /**
@@ -230,24 +208,24 @@ export class AMQPConnector {
   private async cleanupResources(): Promise<void> {
     if (this.consumerTag != null && this.channel != null) {
       try {
-        await this.channel.cancel(this.consumerTag)
+        await this.channel.cancel(this.consumerTag);
       } catch {
         // Ignore errors during cleanup
       }
-      this.consumerTag = undefined
+      this.consumerTag = undefined;
     }
 
     if (this.reconnectTimeoutId != null) {
-      clearTimeout(this.reconnectTimeoutId)
-      this.reconnectTimeoutId = undefined
+      clearTimeout(this.reconnectTimeoutId);
+      this.reconnectTimeoutId = undefined;
     }
 
-    await this.channel?.close().catch(() => {})
-    await this.connection?.close().catch(() => {})
+    await this.channel?.close().catch(() => {});
+    await this.connection?.close().catch(() => {});
 
-    this.channel = undefined
-    this.connection = undefined
-    this.connectionState = ConnectionState.Disconnected
+    this.channel = undefined;
+    this.connection = undefined;
+    this.connectionState = ConnectionState.Disconnected;
   }
 
   /**
@@ -259,91 +237,73 @@ export class AMQPConnector {
    */
   private async setupChannel(): Promise<void> {
     if (this.connection == null) {
-      throw new Error('Cannot setup channel without connection')
+      throw new Error("Cannot setup channel without connection");
     }
 
     if (this.exchange == null || this.queue == null) {
-      throw new Error('Cannot setup channel: exchange or queue not configured')
+      throw new Error("Cannot setup channel: exchange or queue not configured");
     }
 
-    this.channel = await this.connection.createChannel()
+    this.channel = await this.connection.createChannel();
 
-    await this.channel.assertExchange(
-      this.exchange,
-      'topic',
-      this.exchangeOptions
-    )
-    await this.channel.assertQueue(this.queue, this.queueOptions)
-    await this.channel.bindQueue(this.queue, this.exchange, this.routingKey)
+    await this.channel.assertExchange(this.exchange, "topic", this.exchangeOptions);
+    await this.channel.assertQueue(this.queue, this.queueOptions);
+    await this.channel.bindQueue(this.queue, this.exchange, this.routingKey);
 
-    const consumeResult = await this.channel.consume(
-      this.queue,
-      this.createMessageConsumer(),
-      { noAck: false }
-    )
+    const consumeResult = await this.channel.consume(this.queue, this.createMessageConsumer(), { noAck: false });
 
-    this.consumerTag = consumeResult.consumerTag
+    this.consumerTag = consumeResult.consumerTag;
 
     // Set up channel event handlers
-    this.channel.on('error', (error: Error) => {
-      this.logger?.error(`[AMQPConnector] Channel error: ${error.message}`)
-    })
+    this.channel.on("error", (error: Error) => {
+      this.logger?.error(`[AMQPConnector] Channel error: ${error.message}`);
+    });
 
-    this.channel.on('close', () => {
-      this.logger?.warn('[AMQPConnector] Channel closed')
-      this.channel = undefined
-      this.consumerTag = undefined
+    this.channel.on("close", () => {
+      this.logger?.warn("[AMQPConnector] Channel closed");
+      this.channel = undefined;
+      this.consumerTag = undefined;
 
       // Recreate channel if connection still exists and not intentionally closing
       if (!this.isIntentionalClose && this.connection != null) {
-        this.logger?.info('[AMQPConnector] Attempting to recreate channel...')
+        this.logger?.info("[AMQPConnector] Attempting to recreate channel...");
         this.setupChannel().catch((error) => {
-          this.logger?.error(
-            `[AMQPConnector] Failed to recreate channel: ${
-              (error as Error).message
-            }`
-          )
+          this.logger?.error(`[AMQPConnector] Failed to recreate channel: ${(error as Error).message}`);
           // If channel recreation fails, trigger full reconnection
           if (!this.isIntentionalClose && this.reconnectionConfig.enabled) {
-            this.scheduleReconnection()
+            this.scheduleReconnection();
           }
-        })
+        });
       }
-    })
+    });
   }
 
   /**
    * Create the message consumer callback
    * @returns The consumer callback function
    */
-  private createMessageConsumer(): (
-    msg: amqplib.ConsumeMessage | null
-  ) => Promise<void> {
+  private createMessageConsumer(): (msg: amqplib.ConsumeMessage | null) => Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return async (msg) => {
       if (msg != null) {
         // Capture channel reference to avoid race conditions
-        const channel = this.channel
+        const channel = this.channel;
         if (channel == null) {
           this.logger?.warn(
-            '[AMQPConnector] Message received but channel is unavailable. Message will be redelivered.'
-          )
-          return
+            "[AMQPConnector] Message received but channel is unavailable. Message will be redelivered.",
+          );
+          return;
         }
 
         try {
-          await this.onMessageHandler?.(msg, channel)
-          channel.ack(msg)
+          await this.onMessageHandler?.(msg, channel);
+          channel.ack(msg);
         } catch (error) {
-          this.logger?.error(
-            `[AMQPConnector] Error processing message: ${
-              (error as Error).message
-            }`
-          )
-          channel.nack(msg, false, false)
+          this.logger?.error(`[AMQPConnector] Error processing message: ${(error as Error).message}`);
+          channel.nack(msg, false, false);
         }
       }
-    }
+    };
   }
 
   /**
@@ -351,26 +311,26 @@ export class AMQPConnector {
    * Note: Channel event handlers are set up in setupChannel().
    */
   private setupConnectionEventHandlers(): void {
-    if (this.connection == null) return
+    if (this.connection == null) return;
 
-    this.connection.on('error', (error: Error) => {
-      this.logger?.error(`[AMQPConnector] Connection error: ${error.message}`)
+    this.connection.on("error", (error: Error) => {
+      this.logger?.error(`[AMQPConnector] Connection error: ${error.message}`);
       // Note: 'close' event will be emitted after 'error', so reconnection
       // will be triggered by the 'close' handler
-    })
+    });
 
-    this.connection.on('close', () => {
-      this.logger?.warn('[AMQPConnector] Connection closed')
-      this.connectionState = ConnectionState.Disconnected
-      this.channel = undefined
-      this.connection = undefined
-      this.consumerTag = undefined
+    this.connection.on("close", () => {
+      this.logger?.warn("[AMQPConnector] Connection closed");
+      this.connectionState = ConnectionState.Disconnected;
+      this.channel = undefined;
+      this.connection = undefined;
+      this.consumerTag = undefined;
 
       // Only attempt reconnection if this was not an intentional close
       if (!this.isIntentionalClose && this.reconnectionConfig.enabled) {
-        this.scheduleReconnection()
+        this.scheduleReconnection();
       }
-    })
+    });
   }
 
   /**
@@ -378,53 +338,43 @@ export class AMQPConnector {
    * @returns Delay in milliseconds
    */
   private calculateReconnectDelay(): number {
-    const { initialDelayMs, maxDelayMs, backoffMultiplier } =
-      this.reconnectionConfig
-    const delay = Math.min(
-      initialDelayMs * Math.pow(backoffMultiplier, this.reconnectAttempts),
-      maxDelayMs
-    )
+    const { initialDelayMs, maxDelayMs, backoffMultiplier } = this.reconnectionConfig;
+    const delay = Math.min(initialDelayMs * backoffMultiplier ** this.reconnectAttempts, maxDelayMs);
     // Add jitter (0-10% random variation) to prevent thundering herd
-    const jitter = delay * 0.1 * Math.random()
-    return Math.floor(delay + jitter)
+    const jitter = delay * 0.1 * Math.random();
+    return Math.floor(delay + jitter);
   }
 
   /**
    * Schedule a reconnection attempt
    */
   private scheduleReconnection(): void {
-    const { maxRetries } = this.reconnectionConfig
+    const { maxRetries } = this.reconnectionConfig;
 
     // Check if max retries exceeded (0 means infinite)
     if (maxRetries > 0 && this.reconnectAttempts >= maxRetries) {
-      this.logger?.error(
-        `[AMQPConnector] Max reconnection attempts (${maxRetries}) exceeded. Giving up.`
-      )
-      this.connectionState = ConnectionState.Disconnected
-      return
+      this.logger?.error(`[AMQPConnector] Max reconnection attempts (${maxRetries}) exceeded. Giving up.`);
+      this.connectionState = ConnectionState.Disconnected;
+      return;
     }
 
-    const delay = this.calculateReconnectDelay()
-    this.reconnectAttempts++
+    const delay = this.calculateReconnectDelay();
+    this.reconnectAttempts++;
 
     this.logger?.info(
       `[AMQPConnector] Scheduling reconnection attempt ${this.reconnectAttempts}` +
-        `${maxRetries > 0 ? `/${maxRetries}` : ''} in ${delay}ms`
-    )
+        `${maxRetries > 0 ? `/${maxRetries}` : ""} in ${delay}ms`,
+    );
 
-    this.connectionState = ConnectionState.Reconnecting
+    this.connectionState = ConnectionState.Reconnecting;
 
     this.reconnectTimeoutId = setTimeout(() => {
       this.attemptReconnection().catch((error) => {
-        this.logger?.error(
-          `[AMQPConnector] Reconnection attempt failed: ${
-            (error as Error).message
-          }`
-        )
+        this.logger?.error(`[AMQPConnector] Reconnection attempt failed: ${(error as Error).message}`);
         // Schedule next attempt
-        this.scheduleReconnection()
-      })
-    }, delay)
+        this.scheduleReconnection();
+      });
+    }, delay);
   }
 
   /**
@@ -433,51 +383,43 @@ export class AMQPConnector {
   private async attemptReconnection(): Promise<void> {
     // Safety check: abort if close was called during reconnection scheduling
     if (this.isIntentionalClose) {
-      this.logger?.info(
-        '[AMQPConnector] Reconnection aborted: intentional close in progress'
-      )
-      return
+      this.logger?.info("[AMQPConnector] Reconnection aborted: intentional close in progress");
+      return;
     }
 
-    this.logger?.info('[AMQPConnector] Attempting to reconnect...')
-    this.connectionState = ConnectionState.Connecting
+    this.logger?.info("[AMQPConnector] Attempting to reconnect...");
+    this.connectionState = ConnectionState.Connecting;
 
     try {
       // Establish new connection
-      this.connection = await amqplib.connect(this.url)
+      this.connection = await amqplib.connect(this.url);
 
       // Set up channel with exchange, queue, bindings, and consumer
-      await this.setupChannel()
+      await this.setupChannel();
 
       // Check if close() was called during reconnection establishment
       if (this.isIntentionalClose) {
-        await this.cleanupResources()
-        this.logger?.info(
-          '[AMQPConnector] Reconnection aborted: close() was called concurrently.'
-        )
-        return
+        await this.cleanupResources();
+        this.logger?.info("[AMQPConnector] Reconnection aborted: close() was called concurrently.");
+        return;
       }
 
       // Set up event handlers for the new connection
-      this.setupConnectionEventHandlers()
+      this.setupConnectionEventHandlers();
 
       // Reset reconnection state on successful connection
-      this.reconnectAttempts = 0
-      this.connectionState = ConnectionState.Connected
+      this.reconnectAttempts = 0;
+      this.connectionState = ConnectionState.Connected;
 
-      this.logger?.info(
-        `[AMQPConnector] Successfully reconnected and listening on queue: ${this.queue}`
-      )
+      this.logger?.info(`[AMQPConnector] Successfully reconnected and listening on queue: ${this.queue}`);
     } catch (error) {
       this.logger?.debug(
-        `[AMQPConnector] Reconnection failed, cleaning up partial resources: ${
-          (error as Error).message
-        }`
-      )
-      await this.cleanupResources()
-      throw error
+        `[AMQPConnector] Reconnection failed, cleaning up partial resources: ${(error as Error).message}`,
+      );
+      await this.cleanupResources();
+      throw error;
     }
   }
 }
 
-export default AMQPConnector
+export default AMQPConnector;

--- a/packages/amqp-connector/src/index.ts
+++ b/packages/amqp-connector/src/index.ts
@@ -83,7 +83,7 @@ export class AMQPConnector {
   withQueue(queue: string, options: Options.AssertQueue = { durable: true }, routingKey?: string): this {
     this.queue = queue;
     this.queueOptions = options;
-    if (routingKey != null) this.routingKey = routingKey;
+    if (routingKey !== null) this.routingKey = routingKey;
     return this;
   }
 
@@ -133,14 +133,14 @@ export class AMQPConnector {
    * @returns Promise that resolves when the connector is built and started
    */
   async build(): Promise<void> {
-    if (this.exchange == null || this.exchange === undefined) throw new ExchangeNotSpecifiedError();
+    if (this.exchange === null || this.exchange === undefined) throw new ExchangeNotSpecifiedError();
 
-    if (this.queue == null || this.queue === undefined) throw new QueueNotSpecifiedError();
+    if (this.queue === null || this.queue === undefined) throw new QueueNotSpecifiedError();
 
-    if (this.onMessageHandler == null) throw new MessageHandlerNotProvidedError();
+    if (this.onMessageHandler === null) throw new MessageHandlerNotProvidedError();
 
     // Clear any pending reconnect timer to avoid overlapping connection attempts
-    if (this.reconnectTimeoutId != null) {
+    if (this.reconnectTimeoutId !== null) {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = undefined;
     }
@@ -206,7 +206,7 @@ export class AMQPConnector {
    * @returns Promise that resolves when cleanup is complete
    */
   private async cleanupResources(): Promise<void> {
-    if (this.consumerTag != null && this.channel != null) {
+    if (this.consumerTag !== null && this.channel !== null) {
       try {
         await this.channel.cancel(this.consumerTag);
       } catch {
@@ -215,7 +215,7 @@ export class AMQPConnector {
       this.consumerTag = undefined;
     }
 
-    if (this.reconnectTimeoutId != null) {
+    if (this.reconnectTimeoutId !== null) {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = undefined;
     }
@@ -236,11 +236,11 @@ export class AMQPConnector {
    * @returns Promise that resolves when the channel is set up
    */
   private async setupChannel(): Promise<void> {
-    if (this.connection == null) {
+    if (this.connection === null) {
       throw new Error("Cannot setup channel without connection");
     }
 
-    if (this.exchange == null || this.queue == null) {
+    if (this.exchange === null || this.queue === null) {
       throw new Error("Cannot setup channel: exchange or queue not configured");
     }
 
@@ -265,7 +265,7 @@ export class AMQPConnector {
       this.consumerTag = undefined;
 
       // Recreate channel if connection still exists and not intentionally closing
-      if (!this.isIntentionalClose && this.connection != null) {
+      if (!this.isIntentionalClose && this.connection !== null) {
         this.logger?.info("[AMQPConnector] Attempting to recreate channel...");
         this.setupChannel().catch((error) => {
           this.logger?.error(`[AMQPConnector] Failed to recreate channel: ${(error as Error).message}`);
@@ -285,10 +285,10 @@ export class AMQPConnector {
   private createMessageConsumer(): (msg: amqplib.ConsumeMessage | null) => Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return async (msg) => {
-      if (msg != null) {
+      if (msg !== null) {
         // Capture channel reference to avoid race conditions
         const channel = this.channel;
-        if (channel == null) {
+        if (channel === null) {
           this.logger?.warn(
             "[AMQPConnector] Message received but channel is unavailable. Message will be redelivered.",
           );
@@ -311,7 +311,7 @@ export class AMQPConnector {
    * Note: Channel event handlers are set up in setupChannel().
    */
   private setupConnectionEventHandlers(): void {
-    if (this.connection == null) return;
+    if (this.connection === null) return;
 
     this.connection.on("error", (error: Error) => {
       this.logger?.error(`[AMQPConnector] Connection error: ${error.message}`);

--- a/packages/amqp-connector/src/index.ts
+++ b/packages/amqp-connector/src/index.ts
@@ -83,7 +83,7 @@ export class AMQPConnector {
   withQueue(queue: string, options: Options.AssertQueue = { durable: true }, routingKey?: string): this {
     this.queue = queue;
     this.queueOptions = options;
-    if (routingKey) this.routingKey = routingKey;
+    if (routingKey !== null && routingKey !== undefined) this.routingKey = routingKey;
     return this;
   }
 
@@ -137,7 +137,7 @@ export class AMQPConnector {
 
     if (this.queue === null || this.queue === undefined) throw new QueueNotSpecifiedError();
 
-    if (this.onMessageHandler === null) throw new MessageHandlerNotProvidedError();
+    if (this.onMessageHandler === null || this.onMessageHandler === undefined) throw new MessageHandlerNotProvidedError();
 
     // Clear any pending reconnect timer to avoid overlapping connection attempts
     if (this.reconnectTimeoutId !== null) {

--- a/packages/amqp-connector/src/index.ts
+++ b/packages/amqp-connector/src/index.ts
@@ -83,7 +83,7 @@ export class AMQPConnector {
   withQueue(queue: string, options: Options.AssertQueue = { durable: true }, routingKey?: string): this {
     this.queue = queue;
     this.queueOptions = options;
-    if (routingKey !== null) this.routingKey = routingKey;
+    if (routingKey) this.routingKey = routingKey;
     return this;
   }
 
@@ -206,7 +206,7 @@ export class AMQPConnector {
    * @returns Promise that resolves when cleanup is complete
    */
   private async cleanupResources(): Promise<void> {
-    if (this.consumerTag !== null && this.channel !== null) {
+    if (this.consumerTag && this.channel) {
       try {
         await this.channel.cancel(this.consumerTag);
       } catch {
@@ -236,11 +236,11 @@ export class AMQPConnector {
    * @returns Promise that resolves when the channel is set up
    */
   private async setupChannel(): Promise<void> {
-    if (this.connection === null) {
+    if (!this.connection) {
       throw new Error("Cannot setup channel without connection");
     }
 
-    if (this.exchange === null || this.queue === null) {
+    if (!this.exchange || !this.queue) {
       throw new Error("Cannot setup channel: exchange or queue not configured");
     }
 
@@ -265,7 +265,7 @@ export class AMQPConnector {
       this.consumerTag = undefined;
 
       // Recreate channel if connection still exists and not intentionally closing
-      if (!this.isIntentionalClose && this.connection !== null) {
+      if (!this.isIntentionalClose && this.connection) {
         this.logger?.info("[AMQPConnector] Attempting to recreate channel...");
         this.setupChannel().catch((error) => {
           this.logger?.error(`[AMQPConnector] Failed to recreate channel: ${(error as Error).message}`);
@@ -284,11 +284,11 @@ export class AMQPConnector {
    */
   private createMessageConsumer(): (msg: amqplib.ConsumeMessage | null) => Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    return async (msg) => {
-      if (msg !== null) {
+    return async (msg: amqplib.ConsumeMessage | null): Promise<void> => {
+      if (msg) {
         // Capture channel reference to avoid race conditions
         const channel = this.channel;
-        if (channel === null) {
+        if (!channel) {
           this.logger?.warn(
             "[AMQPConnector] Message received but channel is unavailable. Message will be redelivered.",
           );
@@ -311,7 +311,7 @@ export class AMQPConnector {
    * Note: Channel event handlers are set up in setupChannel().
    */
   private setupConnectionEventHandlers(): void {
-    if (this.connection === null) return;
+    if (!this.connection) return;
 
     this.connection.on("error", (error: Error) => {
       this.logger?.error(`[AMQPConnector] Connection error: ${error.message}`);

--- a/packages/amqp-connector/src/index.ts
+++ b/packages/amqp-connector/src/index.ts
@@ -140,7 +140,7 @@ export class AMQPConnector {
     if (this.onMessageHandler === null || this.onMessageHandler === undefined) throw new MessageHandlerNotProvidedError();
 
     // Clear any pending reconnect timer to avoid overlapping connection attempts
-    if (this.reconnectTimeoutId !== null) {
+    if (this.reconnectTimeoutId !== null && this.reconnectTimeoutId !== undefined) {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = undefined;
     }
@@ -215,7 +215,7 @@ export class AMQPConnector {
       this.consumerTag = undefined;
     }
 
-    if (this.reconnectTimeoutId !== null) {
+    if (this.reconnectTimeoutId !== null && this.reconnectTimeoutId !== undefined) {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = undefined;
     }

--- a/packages/amqp-connector/src/types.ts
+++ b/packages/amqp-connector/src/types.ts
@@ -1,4 +1,4 @@
-import { type Channel, type ConsumeMessage } from 'amqplib'
+import type { Channel, ConsumeMessage } from "amqplib";
 
 /**
  * AMQP configuration interface
@@ -11,12 +11,12 @@ import { type Channel, type ConsumeMessage } from 'amqplib'
  * @returns void
  */
 export interface AmqpConfig {
-  host: string
-  port: number
-  vhost: string
-  username: string
-  password: string
-  tls?: boolean
+  host: string;
+  port: number;
+  vhost: string;
+  username: string;
+  password: string;
+  tls?: boolean;
 }
 
 /**
@@ -25,19 +25,16 @@ export interface AmqpConfig {
  * @param channel - The channel the message was received on
  * @returns void
  */
-export type MessageHandler = (
-  msg: ConsumeMessage,
-  channel: Channel
-) => Promise<void> | void
+export type MessageHandler = (msg: ConsumeMessage, channel: Channel) => Promise<void> | void;
 
 /**
  * Connection state enum for tracking AMQPConnector status
  */
 export enum ConnectionState {
-  Disconnected = 'disconnected',
-  Connecting = 'connecting',
-  Connected = 'connected',
-  Reconnecting = 'reconnecting'
+  Disconnected = "disconnected",
+  Connecting = "connecting",
+  Connected = "connected",
+  Reconnecting = "reconnecting",
 }
 
 /**
@@ -49,11 +46,11 @@ export enum ConnectionState {
  * @property backoffMultiplier - Multiplier for exponential backoff (default: 2)
  */
 export interface ReconnectionConfig {
-  enabled?: boolean
-  initialDelayMs?: number
-  maxDelayMs?: number
-  maxRetries?: number
-  backoffMultiplier?: number
+  enabled?: boolean;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  maxRetries?: number;
+  backoffMultiplier?: number;
 }
 
 /**
@@ -64,5 +61,5 @@ export const DEFAULT_RECONNECTION_CONFIG: Required<ReconnectionConfig> = {
   initialDelayMs: 1000,
   maxDelayMs: 30000,
   maxRetries: 0,
-  backoffMultiplier: 2
-}
+  backoffMultiplier: 2,
+};


### PR DESCRIPTION
## What

A simple PR that runs biomejs against amqp-connector JS/TS files to auto fix what can be, in accordance with the new coding style.

## Why

The update of the coding style and the CI now makes the "lint" job fail due to legacy files.
This PR fixes what can be autofixed and serves as an excuse to run RabbitAI against the code base to gather some overall review and comments for future fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fundamental flaw fixed
- CI lint failing due to new BiomeJS rules. This PR is an autofix-only pass to make AMQP-connector files conform so lint CI passes.

Systemic data flow / core logic changes
- Almost entirely formatting/type-only changes: double quotes, semicolons, type-only imports, re-export syntax, punctuation/whitespace normalization.
- Behavior-affecting changes to watch:
  - consumer message guard: changed from if (msg != null) to if (msg) — now uses truthiness; previously only null/undefined were ignored, now falsy messages (0, "", false) will also be ignored. This is the only substantive behavioral change.
  - routingKey guard tightened from loose nullish to explicit checks (if (routingKey !== null && routingKey !== undefined)) — effectively equivalent for null/undefined values.
  - reconnection backoff computation switched from Math.pow(...) to exponentiation operator (backoffMultiplier ** this.reconnectAttempts) — semantic equivalent.
- Tests: only syntactic cleanups and one unused-variable rename (_connectionErrorCallback) to silence warnings; assertions and test flows unchanged.

Deprecated APIs / deleted legacy code
- None. No public API signatures or exports removed.

Explicitly ignored technical debt
- This PR only applies autofixes. RabbitAI generated additional review comments for manual fixes; those items are intentionally deferred and remain unaddressed.

Verdict
- Low-risk formatting pass. Merge if you accept the consumer message truthiness change; revert that single check and rerun autofix if you do not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->