### PR TITLE
Config-Parser - Just a BiomeJS Pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -239,3 +239,54 @@ the changed surface area. Audit `bridge.test.ts` to confirm coverage of:
 
 If any of these are not exercised, add targeted tests or extend the shared mock to
 eliminate the dependency on the real v11 implementation.
+
+## Config Parser
+
+### `index.ts` — Align `loadConfigFromFile` Signature with `ConfigurationFile` Contract
+
+`ConfigurationFile` is declared as `fs.PathOrFileDescriptor` (`string | number | Buffer | URL`),
+but `loadConfigFromFile` only accepts `string`. This creates a silent failure path:
+numeric file descriptors, `Buffer`, and `URL` objects bypass the file loader and fall
+through to `JSON.parse` instead. The truthiness guard is also broken for `0`, which
+is a valid file descriptor.
+
+`fs.readFileSync()` natively handles the full union, so widening the loader to match
+the declared contract is straightforward:
+
+```diff
+-const loadConfigFromFile = (filePath: string): Configuration => {
++const loadConfigFromFile = (filePath: fs.PathOrFileDescriptor): Configuration => {
+```
+
+And update the type guard accordingly:
+
+```diff
+-  if (defaultConfigurationFile) {
+-    if (typeof defaultConfigurationFile === "string") {
++  if (defaultConfigurationFile !== undefined) {
++    if (
++      typeof defaultConfigurationFile === "string" ||
++      typeof defaultConfigurationFile === "number" ||
++      defaultConfigurationFile instanceof URL ||
++      Buffer.isBuffer(defaultConfigurationFile)
++    ) {
+       config = loadConfigFromFile(defaultConfigurationFile);
+```
+
+Alternatively, narrow `ConfigurationFile` to `object | string | undefined` in
+`types.ts` if the other variants are never actually needed.
+
+### `index.ts` — Re-export Error Classes from the Package Entry Point
+
+`package.json` only exposes `./dist/index.js`, so error types living in `./errors`
+are effectively private to consumers. Anyone relying on `instanceof` checks is forced
+into an undocumented deep import that the export map does not publish. Re-export all
+error classes from `src/index.ts` so they are part of the stable public API.
+
+### `utils.ts` — Throw `UnacceptedKeyError` Instead of Raw `Error`
+
+The legacy parser path throws a generic `Error` for invalid keys, while the new path
+throws `UnacceptedKeyError`. This makes the two paths diverge for the same invalid
+input and breaks `instanceof` handling for callers who catch `UnacceptedKeyError`.
+Replace the raw `throw new Error(...)` in `utils.ts` with `throw new UnacceptedKeyError(...)`
+to keep error types consistent across both code paths.

--- a/packages/config-parser/jest.config.js
+++ b/packages/config-parser/jest.config.js
@@ -1,9 +1,9 @@
-import jestConfigBase from '../../jest-base.config.js'
+import jestConfigBase from "../../jest-base.config.js";
 
 export default {
   ...jestConfigBase,
   collectCoverageFrom: [
-    './src/**/{!(pg|redis),}.ts',
-    '!./src/utils.ts',   // exclude utils file for legacy code coverage
+    "./src/**/{!(pg|redis),}.ts",
+    "!./src/utils.ts", // exclude utils file for legacy code coverage
   ],
-}
+};

--- a/packages/config-parser/package.json
+++ b/packages/config-parser/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "test": "LOG_TRANSPORTS=File LOG_FILE=/dev/null jest",
+    "test": "cross-env LOG_TRANSPORTS=File LOG_FILE=/dev/null jest",
     "check": "biome check ."
   },
   "engines": {

--- a/packages/config-parser/rollup.config.js
+++ b/packages/config-parser/rollup.config.js
@@ -1,3 +1,3 @@
-import config from '../../rollup-template.js'
+import config from "../../rollup-template.js";
 
-export default config(['fs'])
+export default config(["fs"]);

--- a/packages/config-parser/src/errors.ts
+++ b/packages/config-parser/src/errors.ts
@@ -5,8 +5,8 @@
  */
 export class ConfigError extends Error {
   constructor(message: string) {
-    super(message)
-    this.name = 'ConfigError'
+    super(message);
+    this.name = "ConfigError";
   }
 }
 
@@ -17,8 +17,8 @@ export class ConfigError extends Error {
  */
 export class InvalidNumberFormatError extends ConfigError {
   constructor(value: string) {
-    super(`Invalid number format for value: '${value}'`)
-    this.name = 'InvalidNumberFormatError'
+    super(`Invalid number format for value: '${value}'`);
+    this.name = "InvalidNumberFormatError";
   }
 }
 
@@ -29,10 +29,8 @@ export class InvalidNumberFormatError extends ConfigError {
  */
 export class InvalidBooleanFormatError extends ConfigError {
   constructor(value: string) {
-    super(
-      `Invalid boolean format for value: '${value}'. Expected 'true', 'false', '1', or '0'.`
-    )
-    this.name = 'InvalidBooleanFormatError'
+    super(`Invalid boolean format for value: '${value}'. Expected 'true', 'false', '1', or '0'.`);
+    this.name = "InvalidBooleanFormatError";
   }
 }
 
@@ -44,11 +42,9 @@ export class InvalidBooleanFormatError extends ConfigError {
  */
 export class InvalidJsonFormatError extends ConfigError {
   constructor(value: string, originalError: Error) {
-    super(
-      `Invalid JSON format for value: '${value}'. Error: ${originalError.message}`
-    )
-    this.name = 'InvalidJsonFormatError'
-    this.cause = originalError
+    super(`Invalid JSON format for value: '${value}'. Error: ${originalError.message}`);
+    this.name = "InvalidJsonFormatError";
+    this.cause = originalError;
   }
 }
 
@@ -60,11 +56,9 @@ export class InvalidJsonFormatError extends ConfigError {
  */
 export class FileReadParseError extends ConfigError {
   constructor(filePath: string, originalError: Error) {
-    super(
-      `Failed to read or parse configuration file '${filePath}': ${originalError.message}`
-    )
-    this.name = 'FileReadParseError'
-    this.cause = originalError
+    super(`Failed to read or parse configuration file '${filePath}': ${originalError.message}`);
+    this.name = "FileReadParseError";
+    this.cause = originalError;
   }
 }
 
@@ -75,10 +69,8 @@ export class FileReadParseError extends ConfigError {
  */
 export class UnacceptedKeyError extends ConfigError {
   constructor(key: string) {
-    super(
-      `Configuration key '${key}' isn't accepted as it's not defined in the ConfigDescription.`
-    )
-    this.name = 'UnacceptedKeyError'
+    super(`Configuration key '${key}' isn't accepted as it's not defined in the ConfigDescription.`);
+    this.name = "UnacceptedKeyError";
   }
 }
 
@@ -89,20 +81,12 @@ export class UnacceptedKeyError extends ConfigError {
  * @property {Error} cause - The original error that caused this error.
  */
 export class ConfigCoercionError extends ConfigError {
-  constructor(
-    key: string,
-    source: 'environment' | 'default',
-    originalError: Error
-  ) {
+  constructor(key: string, source: "environment" | "default", originalError: Error) {
     const sourceMsg =
-      source === 'environment'
-        ? `from environment variable '${key.toUpperCase()}'`
-        : `for default value of '${key}'`
-    super(
-      `Configuration error for '${key}' ${sourceMsg}: ${originalError.message}`
-    )
-    this.name = 'ConfigCoercionError'
-    this.cause = originalError
+      source === "environment" ? `from environment variable '${key.toUpperCase()}'` : `for default value of '${key}'`;
+    super(`Configuration error for '${key}' ${sourceMsg}: ${originalError.message}`);
+    this.name = "ConfigCoercionError";
+    this.cause = originalError;
   }
 }
 
@@ -113,7 +97,7 @@ export class ConfigCoercionError extends ConfigError {
  */
 export class MissingRequiredConfigError extends ConfigError {
   constructor(key: string) {
-    super(`Required configuration key '${key}' is missing.`)
-    this.name = 'MissingRequiredConfigError'
+    super(`Required configuration key '${key}' is missing.`);
+    this.name = "MissingRequiredConfigError";
   }
 }

--- a/packages/config-parser/src/index.test.ts
+++ b/packages/config-parser/src/index.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { ConfigCoercionError, FileReadParseError, MissingRequiredConfigError, UnacceptedKeyError } from "./errors";
 import twakeConfig from "./index";
 import type { ConfigDescription, Configuration } from "./types";

--- a/packages/config-parser/src/index.test.ts
+++ b/packages/config-parser/src/index.test.ts
@@ -1,61 +1,56 @@
-import twakeConfig from './index'
-import { type ConfigDescription, type Configuration } from './types'
-import {
-  FileReadParseError,
-  UnacceptedKeyError,
-  ConfigCoercionError,
-  MissingRequiredConfigError
-} from './errors'
-import fs from 'fs'
-import path from 'path'
+import fs from "fs";
+import path from "path";
+import { ConfigCoercionError, FileReadParseError, MissingRequiredConfigError, UnacceptedKeyError } from "./errors";
+import twakeConfig from "./index";
+import type { ConfigDescription, Configuration } from "./types";
 
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
   readFileSync: jest.fn(),
   existsSync: jest.fn(),
   writeFileSync: jest.fn(),
   mkdirSync: jest.fn(),
   promises: {
-    readFile: jest.fn()
-  }
-}))
+    readFile: jest.fn(),
+  },
+}));
 
-process.env.TWAKE_CONFIG_PARSER_NEW = '1'
+process.env.TWAKE_CONFIG_PARSER_NEW = "1";
 
 /**
  * Helper function to create a ConfigDescription object for tests.
  * @returns {ConfigDescription} A ConfigDescription object with various key types and defaults.
  */
 const createTestConfigDesc = (): ConfigDescription => ({
-  STRING_KEY: { type: 'string', default: 'defaultString' },
-  NUMBER_KEY: { type: 'number', default: 100 },
-  BOOLEAN_KEY: { type: 'boolean', default: true },
-  ARRAY_KEY: { type: 'array', default: ['defaultArrayItem'] },
-  JSON_KEY: { type: 'json', default: { default: 'json' } },
-  OBJECT_KEY: { type: 'object', default: { defaultObject: 'value' } },
-  NULL_KEY: { type: 'string', default: null },
-  UNDEFINED_KEY: { type: 'string', default: undefined },
-  NO_DEFAULT_KEY: { type: 'string' },
-  REQUIRED_KEY: { type: 'string', default: 'defaultRequiredValue' }
-})
+  STRING_KEY: { type: "string", default: "defaultString" },
+  NUMBER_KEY: { type: "number", default: 100 },
+  BOOLEAN_KEY: { type: "boolean", default: true },
+  ARRAY_KEY: { type: "array", default: ["defaultArrayItem"] },
+  JSON_KEY: { type: "json", default: { default: "json" } },
+  OBJECT_KEY: { type: "object", default: { defaultObject: "value" } },
+  NULL_KEY: { type: "string", default: null },
+  UNDEFINED_KEY: { type: "string", default: undefined },
+  NO_DEFAULT_KEY: { type: "string" },
+  REQUIRED_KEY: { type: "string", default: "defaultRequiredValue" },
+});
 
 /**
  * Helper to clear environment variables used in tests.
  */
 const clearEnv = () => {
-  const testDesc = createTestConfigDesc()
+  const testDesc = createTestConfigDesc();
   Object.keys(testDesc).forEach((key) => {
-    delete process.env[key.toUpperCase()]
-  })
-  delete process.env.TEST_ENV_STRING
-  delete process.env.TEST_ENV_NUMBER
-  delete process.env.TEST_ENV_BOOLEAN
-  delete process.env.TEST_ENV_ARRAY
-  delete process.env.TEST_ENV_JSON
-  delete process.env.TEST_ENV_OBJECT
-  delete process.env.UNWANTED_VALUE
-  delete process.env.MY_REQUIRED_KEY
-}
+    delete process.env[key.toUpperCase()];
+  });
+  delete process.env.TEST_ENV_STRING;
+  delete process.env.TEST_ENV_NUMBER;
+  delete process.env.TEST_ENV_BOOLEAN;
+  delete process.env.TEST_ENV_ARRAY;
+  delete process.env.TEST_ENV_JSON;
+  delete process.env.TEST_ENV_OBJECT;
+  delete process.env.UNWANTED_VALUE;
+  delete process.env.MY_REQUIRED_KEY;
+};
 
 /**
  * Sets up mock file system behavior for tests.
@@ -63,577 +58,486 @@ const clearEnv = () => {
  */
 const setupMockFs = (files: { [key: string]: string }) => {
   // mock existsSync
-  ;(fs.existsSync as jest.Mock).mockImplementation((filePath: string) => {
-    return Object.keys(files).some(
-      (mockPath) => path.resolve(mockPath) === path.resolve(filePath)
-    )
-  })
+  (fs.existsSync as jest.Mock).mockImplementation((filePath: string) => {
+    return Object.keys(files).some((mockPath) => path.resolve(mockPath) === path.resolve(filePath));
+  });
 
   // mock async readFile
-  ;(fs.promises.readFile as jest.Mock).mockImplementation(
-    async (filePath: string) => {
-      const content = files[filePath]
-      if (content === undefined) {
-        const error = new Error(
-          `ENOENT: no such file or directory, open '${filePath}'`
-        )
-        ;(error as any).code = 'ENOENT'
-        throw error
-      }
-      return content
+  (fs.promises.readFile as jest.Mock).mockImplementation(async (filePath: string) => {
+    const content = files[filePath];
+    if (content === undefined) {
+      const error = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (error as any).code = "ENOENT";
+      throw error;
     }
-  )
+    return content;
+  });
 
   // mock sync readFileSync
-  ;(fs.readFileSync as jest.Mock).mockImplementation((filePath: string) => {
-    const content = files[filePath]
+  (fs.readFileSync as jest.Mock).mockImplementation((filePath: string) => {
+    const content = files[filePath];
     if (content === undefined) {
-      const error = new Error(
-        `ENOENT: no such file or directory, open '${filePath}'`
-      )
-      ;(error as any).code = 'ENOENT'
-      throw error
+      const error = new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+      (error as any).code = "ENOENT";
+      throw error;
     }
-    return content
-  })
-}
+    return content;
+  });
+};
 
-describe('twakeConfig - Basic Cases', () => {
+describe("twakeConfig - Basic Cases", () => {
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+  });
 
-  test('Should return default values when no file or env vars are provided', async () => {
-    const res: Configuration = twakeConfig(createTestConfigDesc())
+  test("Should return default values when no file or env vars are provided", async () => {
+    const res: Configuration = twakeConfig(createTestConfigDesc());
     expect(res).toEqual({
-      STRING_KEY: 'defaultString',
+      STRING_KEY: "defaultString",
       NUMBER_KEY: 100,
       BOOLEAN_KEY: true,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { defaultObject: 'value' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { defaultObject: "value" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-  })
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+  });
 
-  test('Should load config from file and override defaults', async () => {
-    const mockFilePath = 'config.json'
+  test("Should load config from file and override defaults", async () => {
+    const mockFilePath = "config.json";
     setupMockFs({
       [mockFilePath]: JSON.stringify({
-        STRING_KEY: 'fileString',
+        STRING_KEY: "fileString",
         NUMBER_KEY: 200,
-        OBJECT_KEY: { fileObject: 'newValue' }
-      })
-    })
+        OBJECT_KEY: { fileObject: "newValue" },
+      }),
+    });
 
-    const res: Configuration = twakeConfig(createTestConfigDesc(), mockFilePath)
+    const res: Configuration = twakeConfig(createTestConfigDesc(), mockFilePath);
     expect(res).toEqual({
-      STRING_KEY: 'fileString',
+      STRING_KEY: "fileString",
       NUMBER_KEY: 200,
       BOOLEAN_KEY: true,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { fileObject: 'newValue' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { fileObject: "newValue" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-    expect(fs.readFileSync).toHaveBeenCalledWith(mockFilePath, 'utf8')
-  })
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+    expect(fs.readFileSync).toHaveBeenCalledWith(mockFilePath, "utf8");
+  });
 
-  test('Should load config from object and override defaults', async () => {
+  test("Should load config from object and override defaults", async () => {
     const initialConfig: Configuration = {
-      STRING_KEY: 'objectString',
+      STRING_KEY: "objectString",
       BOOLEAN_KEY: false,
-      OBJECT_KEY: { objectOverride: 'test' }
-    }
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      initialConfig
-    )
+      OBJECT_KEY: { objectOverride: "test" },
+    };
+    const res: Configuration = twakeConfig(createTestConfigDesc(), initialConfig);
     expect(res).toEqual({
-      STRING_KEY: 'objectString',
+      STRING_KEY: "objectString",
       NUMBER_KEY: 100,
       BOOLEAN_KEY: false,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { objectOverride: 'test' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { objectOverride: "test" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-  })
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+  });
 
-  test('Should override defaults with environment variables when useEnv is true', async () => {
-    process.env.STRING_KEY = 'envString'
-    process.env.NUMBER_KEY = '300'
-    process.env.BOOLEAN_KEY = 'false'
-    process.env.OBJECT_KEY = '{"envObject": "envValue"}'
+  test("Should override defaults with environment variables when useEnv is true", async () => {
+    process.env.STRING_KEY = "envString";
+    process.env.NUMBER_KEY = "300";
+    process.env.BOOLEAN_KEY = "false";
+    process.env.OBJECT_KEY = '{"envObject": "envValue"}';
 
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
     expect(res).toEqual({
-      STRING_KEY: 'envString',
+      STRING_KEY: "envString",
       NUMBER_KEY: 300,
       BOOLEAN_KEY: false,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { envObject: 'envValue' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { envObject: "envValue" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-  })
-})
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+  });
+});
 
-describe('twakeConfig - Easy Cases (Mixed Sources)', () => {
+describe("twakeConfig - Easy Cases (Mixed Sources)", () => {
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+  });
 
-  test('Environment variables should override file values', async () => {
-    const mockFilePath = 'config.json'
+  test("Environment variables should override file values", async () => {
+    const mockFilePath = "config.json";
     setupMockFs({
       [mockFilePath]: JSON.stringify({
-        STRING_KEY: 'fileString',
+        STRING_KEY: "fileString",
         NUMBER_KEY: 200,
         BOOLEAN_KEY: false,
-        OBJECT_KEY: { fileObject: 'oldValue' }
-      })
-    })
+        OBJECT_KEY: { fileObject: "oldValue" },
+      }),
+    });
 
-    process.env.STRING_KEY = 'envOverrideString'
-    process.env.NUMBER_KEY = '999'
-    process.env.BOOLEAN_KEY = 'true'
-    process.env.OBJECT_KEY = '{"envObject": "newValue"}'
+    process.env.STRING_KEY = "envOverrideString";
+    process.env.NUMBER_KEY = "999";
+    process.env.BOOLEAN_KEY = "true";
+    process.env.OBJECT_KEY = '{"envObject": "newValue"}';
 
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      mockFilePath,
-      true
-    )
+    const res: Configuration = twakeConfig(createTestConfigDesc(), mockFilePath, true);
     expect(res).toEqual({
-      STRING_KEY: 'envOverrideString',
+      STRING_KEY: "envOverrideString",
       NUMBER_KEY: 999,
       BOOLEAN_KEY: true,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { envObject: 'newValue' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { envObject: "newValue" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-  })
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+  });
 
-  test('File values should override defaults when env vars are not used', async () => {
-    const mockFilePath = 'config.json'
+  test("File values should override defaults when env vars are not used", async () => {
+    const mockFilePath = "config.json";
     setupMockFs({
       [mockFilePath]: JSON.stringify({
-        STRING_KEY: 'fileString',
+        STRING_KEY: "fileString",
         NUMBER_KEY: 200,
         BOOLEAN_KEY: false,
-        OBJECT_KEY: { fileObject: 'fromFile' }
-      })
-    })
+        OBJECT_KEY: { fileObject: "fromFile" },
+      }),
+    });
 
-    process.env.STRING_KEY = 'thisShouldBeIgnored'
+    process.env.STRING_KEY = "thisShouldBeIgnored";
 
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      mockFilePath,
-      false
-    )
+    const res: Configuration = twakeConfig(createTestConfigDesc(), mockFilePath, false);
     expect(res).toEqual({
-      STRING_KEY: 'fileString',
+      STRING_KEY: "fileString",
       NUMBER_KEY: 200,
       BOOLEAN_KEY: false,
-      ARRAY_KEY: ['defaultArrayItem'],
-      JSON_KEY: { default: 'json' },
-      OBJECT_KEY: { fileObject: 'fromFile' },
+      ARRAY_KEY: ["defaultArrayItem"],
+      JSON_KEY: { default: "json" },
+      OBJECT_KEY: { fileObject: "fromFile" },
       NULL_KEY: null,
       UNDEFINED_KEY: undefined,
       NO_DEFAULT_KEY: undefined,
-      REQUIRED_KEY: 'defaultRequiredValue'
-    })
-  })
-})
+      REQUIRED_KEY: "defaultRequiredValue",
+    });
+  });
+});
 
-describe('twakeConfig - Medium Cases (Coercion Details)', () => {
+describe("twakeConfig - Medium Cases (Coercion Details)", () => {
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+  });
 
-  test('Array type coercion from comma-separated string', async () => {
-    process.env.ARRAY_KEY = 'item1,item2, item3 , item4'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.ARRAY_KEY).toEqual(['item1', 'item2', 'item3', 'item4'])
-  })
+  test("Array type coercion from comma-separated string", async () => {
+    process.env.ARRAY_KEY = "item1,item2, item3 , item4";
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.ARRAY_KEY).toEqual(["item1", "item2", "item3", "item4"]);
+  });
 
-  test('Array type coercion from space-separated string', async () => {
-    process.env.ARRAY_KEY = 'itemA itemB  itemC'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.ARRAY_KEY).toEqual(['itemA', 'itemB', 'itemC'])
-  })
+  test("Array type coercion from space-separated string", async () => {
+    process.env.ARRAY_KEY = "itemA itemB  itemC";
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.ARRAY_KEY).toEqual(["itemA", "itemB", "itemC"]);
+  });
 
-  test('JSON type coercion from simple JSON string', async () => {
-    process.env.JSON_KEY = '{"name": "test", "value": 123}'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.JSON_KEY).toEqual({ name: 'test', value: 123 })
-  })
+  test("JSON type coercion from simple JSON string", async () => {
+    process.env.JSON_KEY = '{"name": "test", "value": 123}';
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.JSON_KEY).toEqual({ name: "test", value: 123 });
+  });
 
-  test('Object type coercion from simple JSON string (environment variable)', async () => {
-    process.env.OBJECT_KEY = '{"key": "value", "num": 456}'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.OBJECT_KEY).toEqual({ key: 'value', num: 456 })
-  })
+  test("Object type coercion from simple JSON string (environment variable)", async () => {
+    process.env.OBJECT_KEY = '{"key": "value", "num": 456}';
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.OBJECT_KEY).toEqual({ key: "value", num: 456 });
+  });
 
   test('Boolean coercion with "1" and "0"', async () => {
-    process.env.BOOLEAN_KEY = '1'
-    let res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.BOOLEAN_KEY).toBe(true)
+    process.env.BOOLEAN_KEY = "1";
+    let res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.BOOLEAN_KEY).toBe(true);
 
-    process.env.BOOLEAN_KEY = '0'
-    res = twakeConfig(createTestConfigDesc(), undefined, true)
-    expect(res.BOOLEAN_KEY).toBe(false)
-  })
+    process.env.BOOLEAN_KEY = "0";
+    res = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.BOOLEAN_KEY).toBe(false);
+  });
 
   test('Boolean coercion with mixed case "TRUE" and "FALSE"', async () => {
-    process.env.BOOLEAN_KEY = 'TRUE'
-    let res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.BOOLEAN_KEY).toBe(true)
+    process.env.BOOLEAN_KEY = "TRUE";
+    let res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.BOOLEAN_KEY).toBe(true);
 
-    process.env.BOOLEAN_KEY = 'fAlSe'
-    res = twakeConfig(createTestConfigDesc(), undefined, true)
-    expect(res.BOOLEAN_KEY).toBe(false)
-  })
-})
+    process.env.BOOLEAN_KEY = "fAlSe";
+    res = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.BOOLEAN_KEY).toBe(false);
+  });
+});
 
-describe('twakeConfig - Hard Cases (Complex Coercion & Defaults)', () => {
+describe("twakeConfig - Hard Cases (Complex Coercion & Defaults)", () => {
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+  });
 
-  test('JSON type coercion from complex JSON string', async () => {
-    process.env.JSON_KEY =
-      '{"data": [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}], "meta": {"version": "1.0"}}'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
+  test("JSON type coercion from complex JSON string", async () => {
+    process.env.JSON_KEY = '{"data": [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}], "meta": {"version": "1.0"}}';
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
     expect(res.JSON_KEY).toEqual({
       data: [
-        { id: 1, val: 'a' },
-        { id: 2, val: 'b' }
+        { id: 1, val: "a" },
+        { id: 2, val: "b" },
       ],
-      meta: { version: '1.0' }
-    })
-  })
+      meta: { version: "1.0" },
+    });
+  });
 
-  test('Object type coercion from complex JSON string (environment variable)', async () => {
-    process.env.OBJECT_KEY =
-      '{"complex": {"nested": true, "items": [1, 2, 3]}, "status": "active"}'
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
+  test("Object type coercion from complex JSON string (environment variable)", async () => {
+    process.env.OBJECT_KEY = '{"complex": {"nested": true, "items": [1, 2, 3]}, "status": "active"}';
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
     expect(res.OBJECT_KEY).toEqual({
       complex: { nested: true, items: [1, 2, 3] },
-      status: 'active'
-    })
-  })
+      status: "active",
+    });
+  });
 
-  test('Array coercion with empty string items', () => {
-    process.env.ARRAY_KEY = 'item1,,item2'
+  test("Array coercion with empty string items", () => {
+    process.env.ARRAY_KEY = "item1,,item2";
 
-    const res = twakeConfig(createTestConfigDesc(), undefined, true)
-    expect(res.ARRAY_KEY).toEqual(['item1', 'item2'])
+    const res = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.ARRAY_KEY).toEqual(["item1", "item2"]);
 
-    process.env.ARRAY_KEY = ''
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Empty string values are not allowed/
-    )
-  })
+    process.env.ARRAY_KEY = "";
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(/Empty string values are not allowed/);
+  });
 
-  test('Default value is a string but needs coercion to target type', async () => {
+  test("Default value is a string but needs coercion to target type", async () => {
     const descWithCoercibleDefault: ConfigDescription = {
-      NUM_FROM_STRING: { type: 'number', default: '42' },
-      BOOL_FROM_STRING: { type: 'boolean', default: 'true' },
-      OBJ_FROM_STRING: { type: 'object', default: '{"defaultObj": "fromStr"}' },
-      ARRAY_FROM_STRING: { type: 'array', default: 'itemA,itemB' }
-    }
-    const res: Configuration = twakeConfig(descWithCoercibleDefault)
-    expect(res.NUM_FROM_STRING).toBe(42)
-    expect(res.BOOL_FROM_STRING).toBe(true)
-    expect(res.OBJ_FROM_STRING).toEqual({ defaultObj: 'fromStr' })
-    expect(res.ARRAY_FROM_STRING).toEqual(['itemA', 'itemB'])
-  })
+      NUM_FROM_STRING: { type: "number", default: "42" },
+      BOOL_FROM_STRING: { type: "boolean", default: "true" },
+      OBJ_FROM_STRING: { type: "object", default: '{"defaultObj": "fromStr"}' },
+      ARRAY_FROM_STRING: { type: "array", default: "itemA,itemB" },
+    };
+    const res: Configuration = twakeConfig(descWithCoercibleDefault);
+    expect(res.NUM_FROM_STRING).toBe(42);
+    expect(res.BOOL_FROM_STRING).toBe(true);
+    expect(res.OBJ_FROM_STRING).toEqual({ defaultObj: "fromStr" });
+    expect(res.ARRAY_FROM_STRING).toEqual(["itemA", "itemB"]);
+  });
 
-  test('Default value is already correct type, no coercion needed', async () => {
+  test("Default value is already correct type, no coercion needed", async () => {
     const descWithCorrectDefault: ConfigDescription = {
-      NUM_FROM_NUMBER: { type: 'number', default: 42 },
-      BOOL_FROM_BOOLEAN: { type: 'boolean', default: true },
-      OBJ_FROM_OBJECT: { type: 'object', default: { defaultObj: 'fromObj' } }
-    }
-    const res: Configuration = twakeConfig(descWithCorrectDefault)
-    expect(res.NUM_FROM_NUMBER).toBe(42)
-    expect(res.BOOL_FROM_BOOLEAN).toBe(true)
-    expect(res.OBJ_FROM_OBJECT).toEqual({ defaultObj: 'fromObj' })
-  })
-})
+      NUM_FROM_NUMBER: { type: "number", default: 42 },
+      BOOL_FROM_BOOLEAN: { type: "boolean", default: true },
+      OBJ_FROM_OBJECT: { type: "object", default: { defaultObj: "fromObj" } },
+    };
+    const res: Configuration = twakeConfig(descWithCorrectDefault);
+    expect(res.NUM_FROM_NUMBER).toBe(42);
+    expect(res.BOOL_FROM_BOOLEAN).toBe(true);
+    expect(res.OBJ_FROM_OBJECT).toEqual({ defaultObj: "fromObj" });
+  });
+});
 
-describe('twakeConfig - Side Effects', () => {
+describe("twakeConfig - Side Effects", () => {
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+  });
 
-  test('Should not modify the input ConfigDescription object', async () => {
-    const originalDesc = createTestConfigDesc()
-    const descCopy = JSON.parse(JSON.stringify(originalDesc))
-    twakeConfig(originalDesc)
-    expect(originalDesc).toEqual(descCopy)
-  })
+  test("Should not modify the input ConfigDescription object", async () => {
+    const originalDesc = createTestConfigDesc();
+    const descCopy = JSON.parse(JSON.stringify(originalDesc));
+    twakeConfig(originalDesc);
+    expect(originalDesc).toEqual(descCopy);
+  });
 
-  test('Should not modify the input defaultConfigurationFile object', async () => {
+  test("Should not modify the input defaultConfigurationFile object", async () => {
     const originalFileConfig: Configuration = {
-      STRING_KEY: 'initial',
+      STRING_KEY: "initial",
       NUMBER_KEY: 123,
-      OBJECT_KEY: { some: 'value' }
-    }
-    const fileConfigCopy = JSON.parse(JSON.stringify(originalFileConfig))
-    twakeConfig(createTestConfigDesc(), originalFileConfig)
-    expect(originalFileConfig).toEqual(fileConfigCopy)
-  })
-})
+      OBJECT_KEY: { some: "value" },
+    };
+    const fileConfigCopy = JSON.parse(JSON.stringify(originalFileConfig));
+    twakeConfig(createTestConfigDesc(), originalFileConfig);
+    expect(originalFileConfig).toEqual(fileConfigCopy);
+  });
+});
 
-describe('twakeConfig - Edge Cases and Error Handling', () => {
-  let consoleWarnSpy: jest.SpyInstance
+describe("twakeConfig - Edge Cases and Error Handling", () => {
+  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    clearEnv()
-    ;(fs.promises.readFile as jest.Mock).mockClear()
-    ;(fs.readFileSync as jest.Mock).mockClear()
-    ;(fs.existsSync as jest.Mock).mockClear()
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-  })
+    clearEnv();
+    (fs.promises.readFile as jest.Mock).mockClear();
+    (fs.readFileSync as jest.Mock).mockClear();
+    (fs.existsSync as jest.Mock).mockClear();
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    consoleWarnSpy.mockRestore()
-  })
+    consoleWarnSpy.mockRestore();
+  });
 
-  test('Should throw ConfigCoercionError if environment variable is empty string', () => {
-    process.env.STRING_KEY = ''
+  test("Should throw ConfigCoercionError if environment variable is empty string", () => {
+    process.env.STRING_KEY = "";
 
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
 
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Empty string values are not allowed/
-    )
-  })
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(/Empty string values are not allowed/);
+  });
 
-  test('Should fall back to default if environment variable is null/undefined (not set)', () => {
-    const res: Configuration = twakeConfig(
-      createTestConfigDesc(),
-      undefined,
-      true
-    )
-    expect(res.STRING_KEY).toBe('defaultString')
-  })
+  test("Should fall back to default if environment variable is null/undefined (not set)", () => {
+    const res: Configuration = twakeConfig(createTestConfigDesc(), undefined, true);
+    expect(res.STRING_KEY).toBe("defaultString");
+  });
 
-  test('Should throw UnacceptedKeyError for unwanted key in defaultConfigurationFile object', () => {
+  test("Should throw UnacceptedKeyError for unwanted key in defaultConfigurationFile object", () => {
     const initialConfig: Configuration = {
-      STRING_KEY: 'valid',
-      UNWANTED_KEY_FROM_OBJECT: 'bad'
-    }
+      STRING_KEY: "valid",
+      UNWANTED_KEY_FROM_OBJECT: "bad",
+    };
+
+    expect(() => twakeConfig(createTestConfigDesc(), initialConfig)).toThrow(UnacceptedKeyError);
 
     expect(() => twakeConfig(createTestConfigDesc(), initialConfig)).toThrow(
-      UnacceptedKeyError
-    )
+      "Configuration key 'UNWANTED_KEY_FROM_OBJECT' isn't accepted as it's not defined in the ConfigDescription.",
+    );
+  });
 
-    expect(() => twakeConfig(createTestConfigDesc(), initialConfig)).toThrow(
-      "Configuration key 'UNWANTED_KEY_FROM_OBJECT' isn't accepted as it's not defined in the ConfigDescription."
-    )
-  })
-
-  test('Should throw UnacceptedKeyError for unwanted key in defaultConfigurationFile (JSON file)', () => {
-    const mockFilePath = 'unwanted_key_file.json'
+  test("Should throw UnacceptedKeyError for unwanted key in defaultConfigurationFile (JSON file)", () => {
+    const mockFilePath = "unwanted_key_file.json";
     setupMockFs({
       [mockFilePath]: JSON.stringify({
-        STRING_KEY: 'valid',
-        unwanted_value: 'bad'
-      })
-    })
+        STRING_KEY: "valid",
+        unwanted_value: "bad",
+      }),
+    });
+    expect(() => twakeConfig(createTestConfigDesc(), mockFilePath)).toThrow(UnacceptedKeyError);
     expect(() => twakeConfig(createTestConfigDesc(), mockFilePath)).toThrow(
-      UnacceptedKeyError
-    )
-    expect(() => twakeConfig(createTestConfigDesc(), mockFilePath)).toThrow(
-      "Configuration key 'unwanted_value' isn't accepted as it's not defined in the ConfigDescription."
-    )
-  })
+      "Configuration key 'unwanted_value' isn't accepted as it's not defined in the ConfigDescription.",
+    );
+  });
 
-  test('Should throw ConfigCoercionError for invalid boolean format from environment variable', () => {
-    process.env.BOOLEAN_KEY = 'not_a_boolean'
+  test("Should throw ConfigCoercionError for invalid boolean format from environment variable", () => {
+    process.env.BOOLEAN_KEY = "not_a_boolean";
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
     expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
+      /Configuration error for 'BOOLEAN_KEY' from environment variable 'BOOLEAN_KEY': Invalid boolean format for value: 'not_a_boolean'/,
+    );
+  });
+
+  test("Should throw ConfigCoercionError for invalid number format from environment variable", () => {
+    process.env.NUMBER_KEY = "not_a_number";
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
     expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Configuration error for 'BOOLEAN_KEY' from environment variable 'BOOLEAN_KEY': Invalid boolean format for value: 'not_a_boolean'/
-    )
-  })
+      /Configuration error for 'NUMBER_KEY' from environment variable 'NUMBER_KEY': Invalid number format for value: 'not_a_number'/,
+    );
+  });
 
-  test('Should throw ConfigCoercionError for invalid number format from environment variable', () => {
-    process.env.NUMBER_KEY = 'not_a_number'
+  test("Should throw ConfigCoercionError for invalid JSON format from environment variable (JSON type)", () => {
+    process.env.JSON_KEY = "{invalid json";
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
     expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
+      /Configuration error for 'JSON_KEY' from environment variable 'JSON_KEY': Invalid JSON format for value: '\{invalid json'/,
+    );
+  });
+
+  test("Should throw ConfigCoercionError for invalid JSON format from environment variable (OBJECT type)", () => {
+    process.env.OBJECT_KEY = "invalid object json";
+    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(ConfigCoercionError);
     expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Configuration error for 'NUMBER_KEY' from environment variable 'NUMBER_KEY': Invalid number format for value: 'not_a_number'/
-    )
-  })
+      /Configuration error for 'OBJECT_KEY' from environment variable 'OBJECT_KEY': Invalid JSON format for value: 'invalid object json'/,
+    );
+  });
 
-  test('Should throw ConfigCoercionError for invalid JSON format from environment variable (JSON type)', () => {
-    process.env.JSON_KEY = '{invalid json'
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Configuration error for 'JSON_KEY' from environment variable 'JSON_KEY': Invalid JSON format for value: '\{invalid json'/
-    )
-  })
+  test("Should throw FileReadParseError if config file is not found", () => {
+    const nonExistentPath = "non_existent_config.json";
 
-  test('Should throw ConfigCoercionError for invalid JSON format from environment variable (OBJECT type)', () => {
-    process.env.OBJECT_KEY = 'invalid object json'
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      ConfigCoercionError
-    )
-    expect(() => twakeConfig(createTestConfigDesc(), undefined, true)).toThrow(
-      /Configuration error for 'OBJECT_KEY' from environment variable 'OBJECT_KEY': Invalid JSON format for value: 'invalid object json'/
-    )
-  })
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (fs.promises.readFile as jest.Mock).mockImplementation(() => {
+      const error = new Error(`ENOENT: no such file or directory, open '${nonExistentPath}'`);
+      (error as any).code = "ENOENT";
+      throw error;
+    });
 
-  test('Should throw FileReadParseError if config file is not found', () => {
-    const nonExistentPath = 'non_existent_config.json'
+    expect(() => twakeConfig(createTestConfigDesc(), nonExistentPath)).toThrow(FileReadParseError);
 
-    ;(fs.existsSync as jest.Mock).mockReturnValue(false)
-    ;(fs.promises.readFile as jest.Mock).mockImplementation(() => {
-      const error = new Error(
-        `ENOENT: no such file or directory, open '${nonExistentPath}'`
-      )
-      ;(error as any).code = 'ENOENT'
-      throw error
-    })
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
 
-    expect(() => twakeConfig(createTestConfigDesc(), nonExistentPath)).toThrow(
-      FileReadParseError
-    )
-
-    expect(consoleWarnSpy).not.toHaveBeenCalled()
-  })
-
-  test('Should throw FileReadParseError if config file contains invalid JSON', () => {
-    const invalidJsonPath = 'invalid.json'
+  test("Should throw FileReadParseError if config file contains invalid JSON", () => {
+    const invalidJsonPath = "invalid.json";
     setupMockFs({
-      [invalidJsonPath]: '{ "key": "value", "another": }'
-    })
+      [invalidJsonPath]: '{ "key": "value", "another": }',
+    });
 
-    expect(() => twakeConfig(createTestConfigDesc(), invalidJsonPath)).toThrow(
-      FileReadParseError
-    )
+    expect(() => twakeConfig(createTestConfigDesc(), invalidJsonPath)).toThrow(FileReadParseError);
 
-    expect(consoleWarnSpy).not.toHaveBeenCalled()
-  })
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
 
-  test('Should handle null default values correctly', async () => {
-    const res: Configuration = twakeConfig(createTestConfigDesc())
-    expect(res.NULL_KEY).toBeNull()
-  })
+  test("Should handle null default values correctly", async () => {
+    const res: Configuration = twakeConfig(createTestConfigDesc());
+    expect(res.NULL_KEY).toBeNull();
+  });
 
-  test('Should handle undefined default values correctly', async () => {
-    const res: Configuration = twakeConfig(createTestConfigDesc())
-    expect(res.UNDEFINED_KEY).toBeUndefined()
-    expect(res.NO_DEFAULT_KEY).toBeUndefined()
-  })
+  test("Should handle undefined default values correctly", async () => {
+    const res: Configuration = twakeConfig(createTestConfigDesc());
+    expect(res.UNDEFINED_KEY).toBeUndefined();
+    expect(res.NO_DEFAULT_KEY).toBeUndefined();
+  });
 
-  test('Should throw MissingRequiredConfigError if a required key is not provided', async () => {
+  test("Should throw MissingRequiredConfigError if a required key is not provided", async () => {
     const descWithRequired: ConfigDescription = {
-      MY_REQUIRED_KEY: { type: 'string', required: true }
-    }
-    expect(() => twakeConfig(descWithRequired)).toThrow(
-      MissingRequiredConfigError
-    )
-    expect(() => twakeConfig(descWithRequired)).toThrow(
-      "Required configuration key 'MY_REQUIRED_KEY' is missing."
-    )
-  })
+      MY_REQUIRED_KEY: { type: "string", required: true },
+    };
+    expect(() => twakeConfig(descWithRequired)).toThrow(MissingRequiredConfigError);
+    expect(() => twakeConfig(descWithRequired)).toThrow("Required configuration key 'MY_REQUIRED_KEY' is missing.");
+  });
 
-  test('Should not throw MissingRequiredConfigError if a required key is provided by env', async () => {
+  test("Should not throw MissingRequiredConfigError if a required key is provided by env", async () => {
     const descWithRequired: ConfigDescription = {
-      MY_REQUIRED_KEY: { type: 'string', required: true }
-    }
-    process.env.MY_REQUIRED_KEY = 'present'
-    const res: Configuration = twakeConfig(descWithRequired, undefined, true)
-    expect(res.MY_REQUIRED_KEY).toBe('present')
-  })
+      MY_REQUIRED_KEY: { type: "string", required: true },
+    };
+    process.env.MY_REQUIRED_KEY = "present";
+    const res: Configuration = twakeConfig(descWithRequired, undefined, true);
+    expect(res.MY_REQUIRED_KEY).toBe("present");
+  });
 
-  test('Should not throw MissingRequiredConfigError if a required key is provided by default', async () => {
+  test("Should not throw MissingRequiredConfigError if a required key is provided by default", async () => {
     const descWithRequired: ConfigDescription = {
       MY_REQUIRED_KEY: {
-        type: 'string',
+        type: "string",
         required: true,
-        default: 'default_value'
-      }
-    }
-    const res: Configuration = twakeConfig(descWithRequired)
-    expect(res.MY_REQUIRED_KEY).toBe('default_value')
-  })
-})
+        default: "default_value",
+      },
+    };
+    const res: Configuration = twakeConfig(descWithRequired);
+    expect(res.MY_REQUIRED_KEY).toBe("default_value");
+  });
+});

--- a/packages/config-parser/src/index.test.ts
+++ b/packages/config-parser/src/index.test.ts
@@ -4,8 +4,8 @@ import { ConfigCoercionError, FileReadParseError, MissingRequiredConfigError, Un
 import twakeConfig from "./index";
 import type { ConfigDescription, Configuration } from "./types";
 
-jest.mock("fs", () => ({
-  ...jest.requireActual("fs"),
+jest.mock("node:fs", () => ({
+  ...jest.requireActual("node:fs"),
   readFileSync: jest.fn(),
   existsSync: jest.fn(),
   writeFileSync: jest.fn(),

--- a/packages/config-parser/src/index.ts
+++ b/packages/config-parser/src/index.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import {
   ConfigCoercionError,
   FileReadParseError,
@@ -15,7 +15,7 @@ import type {
   ConfigValueType,
   NewConfigDescription,
 } from "./types";
-import { oldParser } from "./utils";
+import { isTruthy, oldParser } from "./utils";
 
 /**
  * Coerces a string value to the target type.
@@ -30,7 +30,7 @@ const coerceValue = (value: string, targetType: ConfigValueType): any => {
   switch (targetType) {
     case "number": {
       const num = parseFloat(value);
-      if (isNaN(num)) {
+      if (Number.isNaN(num)) {
         throw new InvalidNumberFormatError(value);
       }
       return num;
@@ -55,7 +55,6 @@ const coerceValue = (value: string, targetType: ConfigValueType): any => {
         const error = e instanceof Error ? e : new Error(String(e));
         throw new InvalidJsonFormatError(value, error);
       }
-    case "string":
     default:
       return value;
   }
@@ -119,7 +118,7 @@ const applyEnvironmentVariables = (config: Configuration, desc: NewConfigDescrip
 const applyDefaultValues = (config: Configuration, desc: NewConfigDescription): void => {
   Object.keys(desc).forEach((key: string) => {
     const configProp = desc[key];
-    if (config[key] == null && configProp.default !== undefined) {
+    if (!config[key] && configProp.default !== undefined) {
       if (typeof configProp.default === "string" && configProp.type !== "string" && configProp.type !== "array") {
         try {
           config[key] = coerceValue(configProp.default, configProp.type);
@@ -191,12 +190,12 @@ const twakeConfig = (
   useOldParser: boolean = true,
 ): Configuration => {
   // Determine if we should use the old parser
-  const shouldUseOldParser = useOldParser && process.env.TWAKE_CONFIG_PARSER_NEW == null;
+  const shouldUseOldParser = useOldParser && !isTruthy(process.env.TWAKE_CONFIG_PARSER_NEW);
 
   // Start with an empty config
   let config: Configuration = {};
 
-  if (defaultConfigurationFile != null) {
+  if (defaultConfigurationFile) {
     if (typeof defaultConfigurationFile === "string") {
       config = loadConfigFromFile(defaultConfigurationFile);
     } else {

--- a/packages/config-parser/src/index.ts
+++ b/packages/config-parser/src/index.ts
@@ -1,21 +1,21 @@
-import fs from 'fs'
+import fs from "fs";
 import {
-  type ConfigValueType,
-  type ConfigDescription,
-  type ConfigurationFile,
-  type Configuration,
-  type NewConfigDescription
-} from './types'
-import {
-  InvalidNumberFormatError,
+  ConfigCoercionError,
+  FileReadParseError,
   InvalidBooleanFormatError,
   InvalidJsonFormatError,
-  FileReadParseError,
+  InvalidNumberFormatError,
+  MissingRequiredConfigError,
   UnacceptedKeyError,
-  ConfigCoercionError,
-  MissingRequiredConfigError
-} from './errors'
-import { oldParser } from './utils'
+} from "./errors";
+import type {
+  ConfigDescription,
+  Configuration,
+  ConfigurationFile,
+  ConfigValueType,
+  NewConfigDescription,
+} from "./types";
+import { oldParser } from "./utils";
 
 /**
  * Coerces a string value to the target type.
@@ -28,38 +28,38 @@ import { oldParser } from './utils'
  */
 const coerceValue = (value: string, targetType: ConfigValueType): any => {
   switch (targetType) {
-    case 'number': {
-      const num = parseFloat(value)
+    case "number": {
+      const num = parseFloat(value);
       if (isNaN(num)) {
-        throw new InvalidNumberFormatError(value)
+        throw new InvalidNumberFormatError(value);
       }
-      return num
+      return num;
     }
-    case 'boolean': {
-      const lowerValue = value.toLowerCase().trim()
-      if (lowerValue === 'true' || lowerValue === '1') {
-        return true
+    case "boolean": {
+      const lowerValue = value.toLowerCase().trim();
+      if (lowerValue === "true" || lowerValue === "1") {
+        return true;
       }
-      if (lowerValue === 'false' || lowerValue === '0') {
-        return false
+      if (lowerValue === "false" || lowerValue === "0") {
+        return false;
       }
-      throw new InvalidBooleanFormatError(value)
+      throw new InvalidBooleanFormatError(value);
     }
-    case 'array':
-      return value.split(/[,\s]+/).filter((s) => s.length > 0)
-    case 'json':
-    case 'object':
+    case "array":
+      return value.split(/[,\s]+/).filter((s) => s.length > 0);
+    case "json":
+    case "object":
       try {
-        return JSON.parse(value)
+        return JSON.parse(value);
       } catch (e: unknown) {
-        const error = e instanceof Error ? e : new Error(String(e))
-        throw new InvalidJsonFormatError(value, error)
+        const error = e instanceof Error ? e : new Error(String(e));
+        throw new InvalidJsonFormatError(value, error);
       }
-    case 'string':
+    case "string":
     default:
-      return value
+      return value;
   }
-}
+};
 
 /**
  * Loads configuration from a specified file path.
@@ -69,13 +69,13 @@ const coerceValue = (value: string, targetType: ConfigValueType): any => {
  */
 const loadConfigFromFile = (filePath: string): Configuration => {
   try {
-    const fileContent = fs.readFileSync(filePath, 'utf8')
-    return JSON.parse(fileContent)
+    const fileContent = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(fileContent);
   } catch (e: unknown) {
-    const error = e instanceof Error ? e : new Error(String(e))
-    throw new FileReadParseError(filePath, error)
+    const error = e instanceof Error ? e : new Error(String(e));
+    throw new FileReadParseError(filePath, error);
   }
-}
+};
 
 /**
  * Applies environment variable overrides to the configuration.
@@ -84,36 +84,30 @@ const loadConfigFromFile = (filePath: string): Configuration => {
  * @param {boolean} useEnv - Whether to enable environment variable overrides.
  * @throws {ConfigCoercionError} if an environment variable value cannot be coerced to the expected type or is an empty string.
  */
-const applyEnvironmentVariables = (
-  config: Configuration,
-  desc: NewConfigDescription,
-  useEnv: boolean
-): void => {
+const applyEnvironmentVariables = (config: Configuration, desc: NewConfigDescription, useEnv: boolean): void => {
   Object.keys(desc).forEach((key: string) => {
-    const configProp = desc[key]
-    const envVarName = key.toUpperCase()
-    const envValue = process.env[envVarName]
+    const configProp = desc[key];
+    const envVarName = key.toUpperCase();
+    const envValue = process.env[envVarName];
 
-    if (useEnv && process.env.hasOwnProperty(envVarName)) {
-      if (envValue === '') {
+    if (useEnv && Object.hasOwn(process.env, envVarName)) {
+      if (envValue === "") {
         throw new ConfigCoercionError(
           key,
-          'environment',
-          new Error(
-            'Empty string values are not allowed for this configuration key from environment variables.'
-          )
-        )
+          "environment",
+          new Error("Empty string values are not allowed for this configuration key from environment variables."),
+        );
       }
 
       try {
-        config[key] = coerceValue(envValue as string, configProp.type)
+        config[key] = coerceValue(envValue as string, configProp.type);
       } catch (e: unknown) {
-        const error = e instanceof Error ? e : new Error(String(e))
-        throw new ConfigCoercionError(key, 'environment', error)
+        const error = e instanceof Error ? e : new Error(String(e));
+        throw new ConfigCoercionError(key, "environment", error);
       }
     }
-  })
-}
+  });
+};
 
 /**
  * Applies default values from ConfigDescription if a key is not already set.
@@ -122,40 +116,30 @@ const applyEnvironmentVariables = (
  * @param {ConfigDescription} desc - The ConfigDescription for default values and type information.
  * @throws {ConfigCoercionError} if a default value string cannot be coerced to its expected type.
  */
-const applyDefaultValues = (
-  config: Configuration,
-  desc: NewConfigDescription
-): void => {
+const applyDefaultValues = (config: Configuration, desc: NewConfigDescription): void => {
   Object.keys(desc).forEach((key: string) => {
-    const configProp = desc[key]
+    const configProp = desc[key];
     if (config[key] == null && configProp.default !== undefined) {
-      if (
-        typeof configProp.default === 'string' &&
-        configProp.type !== 'string' &&
-        configProp.type !== 'array'
-      ) {
+      if (typeof configProp.default === "string" && configProp.type !== "string" && configProp.type !== "array") {
         try {
-          config[key] = coerceValue(configProp.default, configProp.type)
+          config[key] = coerceValue(configProp.default, configProp.type);
         } catch (e: unknown) {
-          const error = e instanceof Error ? e : new Error(String(e))
-          throw new ConfigCoercionError(key, 'default', error)
+          const error = e instanceof Error ? e : new Error(String(e));
+          throw new ConfigCoercionError(key, "default", error);
         }
-      } else if (
-        typeof configProp.default === 'string' &&
-        configProp.type === 'array'
-      ) {
+      } else if (typeof configProp.default === "string" && configProp.type === "array") {
         try {
-          config[key] = coerceValue(configProp.default, configProp.type)
+          config[key] = coerceValue(configProp.default, configProp.type);
         } catch (e: unknown) {
-          const error = e instanceof Error ? e : new Error(String(e))
-          throw new ConfigCoercionError(key, 'default', error)
+          const error = e instanceof Error ? e : new Error(String(e));
+          throw new ConfigCoercionError(key, "default", error);
         }
       } else {
-        config[key] = configProp.default
+        config[key] = configProp.default;
       }
     }
-  })
-}
+  });
+};
 
 /**
  * Validates that all keys in the final configuration are defined in the ConfigDescription.
@@ -163,16 +147,13 @@ const applyDefaultValues = (
  * @param {ConfigDescription} desc - The ConfigDescription.
  * @throws {UnacceptedKeyError} if an unexpected key is found in the configuration.
  */
-const validateUnwantedKeys = (
-  config: Configuration,
-  desc: NewConfigDescription
-): void => {
+const validateUnwantedKeys = (config: Configuration, desc: NewConfigDescription): void => {
   Object.keys(config).forEach((key: string) => {
     if (desc[key] === undefined) {
-      throw new UnacceptedKeyError(key)
+      throw new UnacceptedKeyError(key);
     }
-  })
-}
+  });
+};
 
 /**
  * Validates that all required configuration keys are present in the final configuration.
@@ -180,17 +161,14 @@ const validateUnwantedKeys = (
  * @param {ConfigDescription} desc - The ConfigDescription.
  * @throws {MissingRequiredConfigError} if a required key is missing.
  */
-const validateRequiredKeys = (
-  config: Configuration,
-  desc: NewConfigDescription
-): void => {
+const validateRequiredKeys = (config: Configuration, desc: NewConfigDescription): void => {
   Object.keys(desc).forEach((key: string) => {
-    const configProp = desc[key]
+    const configProp = desc[key];
     if ((configProp.required ?? false) && config[key] === undefined) {
-      throw new MissingRequiredConfigError(key)
+      throw new MissingRequiredConfigError(key);
     }
-  })
-}
+  });
+};
 
 /**
  * Loads and consolidates application configuration from multiple sources.
@@ -210,43 +188,39 @@ const twakeConfig = (
   desc: ConfigDescription,
   defaultConfigurationFile?: ConfigurationFile,
   useEnv: boolean = false,
-  useOldParser: boolean = true
+  useOldParser: boolean = true,
 ): Configuration => {
   // Determine if we should use the old parser
-  const shouldUseOldParser =
-    useOldParser && process.env.TWAKE_CONFIG_PARSER_NEW == null
+  const shouldUseOldParser = useOldParser && process.env.TWAKE_CONFIG_PARSER_NEW == null;
 
   // Start with an empty config
-  let config: Configuration = {}
+  let config: Configuration = {};
 
   if (defaultConfigurationFile != null) {
-    if (typeof defaultConfigurationFile === 'string') {
-      config = loadConfigFromFile(defaultConfigurationFile)
+    if (typeof defaultConfigurationFile === "string") {
+      config = loadConfigFromFile(defaultConfigurationFile);
     } else {
-      config = shouldUseOldParser
-        ? defaultConfigurationFile
-        : JSON.parse(JSON.stringify(defaultConfigurationFile))
+      config = shouldUseOldParser ? defaultConfigurationFile : JSON.parse(JSON.stringify(defaultConfigurationFile));
     }
   }
 
   if (shouldUseOldParser) {
     // Use old parser by default unless explicitly opting into the new parser
-    oldParser(desc, config)
-    return config
-  } else {
-    // New parser
-    // Ensure desc is treated as NewConfigDescription
-    const newDesc = desc as NewConfigDescription
-
-    applyEnvironmentVariables(config, newDesc, useEnv)
-    applyDefaultValues(config, newDesc)
-    validateUnwantedKeys(config, newDesc)
-    validateRequiredKeys(config, newDesc)
+    oldParser(desc, config);
+    return config;
   }
+  // New parser
+  // Ensure desc is treated as NewConfigDescription
+  const newDesc = desc as NewConfigDescription;
 
-  return config
-}
+  applyEnvironmentVariables(config, newDesc, useEnv);
+  applyDefaultValues(config, newDesc);
+  validateUnwantedKeys(config, newDesc);
+  validateRequiredKeys(config, newDesc);
 
-export type { ConfigDescription } from './types'
+  return config;
+};
 
-export default twakeConfig
+export type { ConfigDescription } from "./types";
+
+export default twakeConfig;

--- a/packages/config-parser/src/index.ts
+++ b/packages/config-parser/src/index.ts
@@ -118,8 +118,14 @@ const applyEnvironmentVariables = (config: Configuration, desc: NewConfigDescrip
 const applyDefaultValues = (config: Configuration, desc: NewConfigDescription): void => {
   Object.keys(desc).forEach((key: string) => {
     const configProp = desc[key];
-    if (!config[key] && configProp.default !== undefined) {
-      if (typeof configProp.default === "string" && configProp.type !== "string" && configProp.type !== "array") {
+    if (config[key] === undefined) {
+      if (configProp.default === undefined) {
+        config[key] = undefined;
+      } else if (
+        typeof configProp.default === "string" &&
+        configProp.type !== "string" &&
+        configProp.type !== "array"
+      ) {
         try {
           config[key] = coerceValue(configProp.default, configProp.type);
         } catch (e: unknown) {

--- a/packages/config-parser/src/types.ts
+++ b/packages/config-parser/src/types.ts
@@ -1,16 +1,10 @@
-import fs from 'fs'
+import type fs from "fs";
 
 /**
  * Defines the possible types for configuration values.
  * @typedef {'string' | 'number' | 'boolean' | 'array' | 'object' | 'json'} ConfigValueType
  */
-export type ConfigValueType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'array'
-  | 'object'
-  | 'json'
+export type ConfigValueType = "string" | "number" | "boolean" | "array" | "object" | "json";
 
 /**
  * Defines the properties of a single configuration key.
@@ -20,9 +14,9 @@ export type ConfigValueType =
  * @property {boolean} [required] - Indicates if the configuration key is mandatory.
  */
 export interface ConfigProperty {
-  type: ConfigValueType
-  default?: any
-  required?: boolean
+  type: ConfigValueType;
+  default?: any;
+  required?: boolean;
 }
 
 /**
@@ -31,7 +25,7 @@ export interface ConfigProperty {
  * @property {Object.<string, ConfigProperty>} [key: string] - A mapping of configuration keys to their respective ConfigProperty definitions.
  */
 export interface NewConfigDescription {
-  [key: string]: ConfigProperty
+  [key: string]: ConfigProperty;
 }
 
 /**
@@ -39,10 +33,7 @@ export interface NewConfigDescription {
  * @interface OldConfigDescription
  * @property {Object.<string, string|Object|number|boolean|null|undefined>} [key: string] - A mapping of configuration keys to their respective values, which can be of various types.
  */
-export type OldConfigDescription = Record<
-  string,
-  string | Record<string, any> | number | boolean | null | undefined
->
+export type OldConfigDescription = Record<string, string | Record<string, any> | number | boolean | null | undefined>;
 
 /**
  * Defines the overall structure of the configuration description.
@@ -51,17 +42,17 @@ export type OldConfigDescription = Record<
  * @see {NewConfigDescription}
  * @see {OldConfigDescription}
  */
-export type ConfigDescription = NewConfigDescription | OldConfigDescription
+export type ConfigDescription = NewConfigDescription | OldConfigDescription;
 
 /**
  * Defines the possible types for the default configuration file input.
  * It can be an object representing configuration or a file path.
  * @typedef {object | fs.PathOrFileDescriptor | undefined} ConfigurationFile
  */
-export type ConfigurationFile = object | fs.PathOrFileDescriptor | undefined
+export type ConfigurationFile = object | fs.PathOrFileDescriptor | undefined;
 
 /**
  * Represents the consolidated configuration object, where keys are strings and values can be of any type.
  * @typedef {Record<string, any>} Configuration
  */
-export type Configuration = Record<string, any>
+export type Configuration = Record<string, any>;

--- a/packages/config-parser/src/types.ts
+++ b/packages/config-parser/src/types.ts
@@ -1,4 +1,4 @@
-import type fs from "fs";
+import type fs from "node:fs";
 
 /**
  * Defines the possible types for configuration values.

--- a/packages/config-parser/src/utils.ts
+++ b/packages/config-parser/src/utils.ts
@@ -1,33 +1,27 @@
-import { type ConfigDescription, type Configuration } from './types'
+import type { ConfigDescription, Configuration } from "./types";
 
 /**
  * Parses the configuration using the old parser strategy.
  * @param desc - The configuration description.
  * @param res - The resulting configuration.
  */
-export const oldParser = (
-  desc: ConfigDescription,
-  res: Configuration
-): void => {
+export const oldParser = (desc: ConfigDescription, res: Configuration): void => {
   // Parse wanted keys
   Object.keys(desc).forEach((key: string) => {
     // If environment variable exists, it overrides current value
-    if (
-      process.env[key.toUpperCase()] != null &&
-      process.env[key.toUpperCase()] !== ''
-    ) {
-      res[key] = process.env[key.toUpperCase()]
+    if (process.env[key.toUpperCase()] != null && process.env[key.toUpperCase()] !== "") {
+      res[key] = process.env[key.toUpperCase()];
     } else {
       // if default value exists use it
       if (res[key] == null && desc[key] != null) {
-        res[key] = desc[key]
+        res[key] = desc[key];
       }
     }
-  })
+  });
   // Verify that result as no unwanted keys
   Object.keys(res).forEach((key: string) => {
     if (desc[key] === undefined) {
-      throw new Error(`Key ${key} isn't accepted`)
+      throw new Error(`Key ${key} isn't accepted`);
     }
-  })
-}
+  });
+};

--- a/packages/config-parser/src/utils.ts
+++ b/packages/config-parser/src/utils.ts
@@ -9,11 +9,11 @@ export const oldParser = (desc: ConfigDescription, res: Configuration): void => 
   // Parse wanted keys
   Object.keys(desc).forEach((key: string) => {
     // If environment variable exists, it overrides current value
-    if (process.env[key.toUpperCase()] != null && process.env[key.toUpperCase()] !== "") {
+    if (process.env[key.toUpperCase()] && process.env[key.toUpperCase()] !== "") {
       res[key] = process.env[key.toUpperCase()];
     } else {
       // if default value exists use it
-      if (res[key] == null && desc[key] != null) {
+      if (!res[key] && desc[key]) {
         res[key] = desc[key];
       }
     }
@@ -25,3 +25,6 @@ export const oldParser = (desc: ConfigDescription, res: Configuration): void => 
     }
   });
 };
+
+export const isTruthy = (value: string | null | undefined): boolean =>
+  ["1", "true", "on", "enable", "enabled", "active", "activated"].includes(value?.toLowerCase() ?? "");

--- a/packages/config-parser/src/utils.ts
+++ b/packages/config-parser/src/utils.ts
@@ -13,7 +13,7 @@ export const oldParser = (desc: ConfigDescription, res: Configuration): void => 
       res[key] = process.env[key.toUpperCase()];
     } else {
       // if default value exists use it
-      if (!res[key] && desc[key]) {
+      if ((res[key] === null || res[key] === undefined) && desc[key]) {
         res[key] = desc[key];
       }
     }

--- a/packages/config-parser/src/utils.ts
+++ b/packages/config-parser/src/utils.ts
@@ -13,7 +13,7 @@ export const oldParser = (desc: ConfigDescription, res: Configuration): void => 
       res[key] = process.env[key.toUpperCase()];
     } else {
       // if default value exists use it
-      if ((res[key] === null || res[key] === undefined) && desc[key]) {
+      if ((res[key] === null || res[key] === undefined) && desc[key] !== undefined) {
         res[key] = desc[key];
       }
     }


### PR DESCRIPTION
## What

A simple PR that runs biomejs against config-parser JS/TS files to auto fix what can be, in accordance with the new coding style.

## Why

The update of the coding style and the CI now makes the "lint" job fail due to legacy files.
This PR fixes what can be autofixed and serves as an excuse to run RabbitAI against the code base to gather some overall review and comments for future fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fundamental flaw being fixed
This PR was presented as a style/lint autofix but contains behavioral changes that are the real, dangerous fixes: environment opt-in semantics, defaulting behavior, coercion rules, and falsy handling were tightened. Hiding semantic changes inside a formatting pass is the fundamental problem.

Systemic data-flow and core algorithm changes
- Parser selection: new parser opt-in is now strict. Old behavior treated any non-null value as switching parser; new code uses isTruthy(process.env.TWAKE_CONFIG_PARSER_NEW) with an allowlist ["1","true","on","enable","enabled","active","activated"]. Effect: arbitrary non-empty strings that previously toggled parser no longer do.
- Environment overrides: presence detection changed from hasOwnProperty/loose checks to Object.hasOwn(process.env, name) and explicit rejection of empty-string env values. Empty strings now cause coercion errors instead of being accepted.
- Defaulting and presence: default application changed from loose nullish checks (== null) to strict undefined checks (=== undefined). Missing keys without defaults are explicitly set to undefined in the new path; old loose behavior that left keys absent is no longer guaranteed.
- Coercion and parsing: coerceValue tightened (Number.isNaN vs isNaN), boolean parsing stricter, JSON parse and read errors wrapped with causes, and empty env values are rejected for typed coercion. applyEnvironmentVariables enforces these stricter rules.
- Validation: legacy unaccepted-key handling now throws UnacceptedKeyError consistently (instead of generic Error), and checks use strict undefined comparisons.

Type / API / imports
- Non-functional modernizations: ESM node: specifiers (node:fs, node:path), type-only imports, quoting/semicolon/style normalization. Public API signatures (exported types and default export twakeConfig) were not removed or renamed.

Tests and infra
- Tests updated to node:fs mocking, updated expectations for stricter behaviors (e.g., empty env rejection). package.json test script wrapped with cross-env. Many formatting-only changes across tests.

Deprecated APIs / deleted legacy code
- No public API was deprecated or deleted. Internal legacy permissiveness was tightened and some legacy error throwing normalized, but symbols remain.

Explicitly ignored technical debt
1. No changelog, migration note, or documentation for the changed semantics of TWAKE_CONFIG_PARSER_NEW.
2. No compatibility plan for consumers that relied on loose nullish/falsy behavior (empty string, 0, false).
3. No tests or migration steps ensuring downstream code tolerates keys being set to undefined vs being absent.
4. Semantic changes concealed in a style commit — commit messages and PR framing do not call out behavioral diffs; reviewer attention required.

Review priority (pragmatic)
- High: Confirm intended semantics for TWAKE_CONFIG_PARSER_NEW (allowlist) and validate downstream impact on consumers relying on empty strings/0/false or presence vs absence of keys. Run integration tests.
- High: Verify coercion/error changes (empty env rejection, Number.isNaN, wrapped causes) do not break callers.
- Medium: Confirm switching to Object.hasOwn(process.env, ...) is safe in all CI/runtime environments.
- Low: Accept stylistic fixes once behavioral changes are approved.

Verdict
Not a pure style pass. Treat this as a behavioral change that must be documented, covered by targeted tests, and validated against downstream consumers before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->