### PR TITLE
DB - Just a BiomeJS Pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -335,3 +335,84 @@ export function toBase64Url(base64: string): string {
 
 This is O(n) with no backtracking and satisfies static analysis tools flagging
 polynomial regex on uncontrolled data.
+
+## DB
+
+### `sql/pg.ts` — Extract `.then()` Callback to Reduce Cognitive Complexity (17 > 10)
+
+The `.then()` callback at line 25 does module interop, config validation, connection
+pool setup, error handling, and table creation all at once — cognitive complexity 17,
+CI limit 10. Extract into at least two private methods:
+
+- `#validateConfig(config)` — validates required fields and returns a typed pool config
+- `#createPool(config)` — constructs and returns the `pg.Pool` instance
+
+Keep the `.then()` callback as a thin orchestrator that calls these in sequence.
+
+### `sql/pg.ts` — Drop `async` from `addColumn` (No `await` Inside)
+
+`addColumn` is marked `async` but constructs and returns a manual `Promise` without
+any `await`. The `async` keyword adds a redundant wrapper `Promise` around an
+already-a-`Promise`. Either drop `async`, or refactor to use `await` internally for
+consistency with the rest of the codebase.
+
+### `sql/pg.ts` — Replace `forEach` with `for...of` (Biome `noForEach`)
+
+Biome rejects `.forEach()` in favour of `for...of`. Three identical patterns need
+converting: line 25 callback, lines 162–165, and lines 215–218.
+
+```diff
+-  items.forEach((item) => {
+-    // ...
+-  });
++  for (const item of items) {
++    // ...
++  }
+```
+
+### `sql/sqlite.ts` — Drop `async` from `getTableColumns` and `addColumn` (CI Blocker)
+
+Both methods are marked `async` but construct manual `Promise`s internally without
+using `await`. This is one of the 31 errors blocking the pipeline. The fix is a
+one-line removal:
+
+```diff
+-  async getTableColumns(table: T): Promise<ColumnInfo[]> {
++  getTableColumns(table: T): Promise<ColumnInfo[]> {
+```
+
+Same applies to `addColumn` and the pattern at lines 1075–1078. Alternatively,
+promisify `db.all` / `db.run` with `await` if a full async refactor is preferred.
+
+### `sql/sqlite.ts` — `this.ready` Hangs on `sqlite3` Load Failure
+
+The `.catch()` handler in the constructor rethrows into the void instead of calling
+`reject(e)`. If `import("sqlite3")` or `new sqlite3.Database()` fails, the `Promise`
+chain breaks silently and `this.ready` never resolves or rejects, hanging startup
+indefinitely. Compare against `pg.ts` lines 55–58, which correctly call `reject(e)`.
+
+```diff
+-  }).catch((e) => { throw e; });
++  }).catch((e) => { reject(e); });
+```
+
+### `sql/sql.ts` — Remove `any` from `getCount()` Return Path
+
+Lines 33 and 40 in the shared base class pass `any` through the count helper. The
+method has exactly two call patterns — type them with a union and chain `.catch(reject)`
+directly to eliminate the `any`s without changing runtime behaviour.
+
+### `database.ts` — Fix `DbBackend` Interface Instead of Working Around It
+
+The wrapper in `database.ts` correctly delegates, but it is constrained by the
+`DbBackend<T>` interface in `types.ts`, which declares `createDatabases` as
+`...args: any`. Replace that signature with a properly typed one (or a typed overload
+alias if arguments vary by backend). Fixing the interface makes the wrapper strict
+automatically, rather than patching symptoms at the call site.
+
+### `types.ts` — Consolidate 6-Parameter Function into Options Object
+
+Biome flags functions exceeding a reasonable parameter count, and a 6-parameter
+signature is error-prone and hard to call correctly. This is pre-existing API surface,
+so it is out of scope for a formatting pass, but should be addressed as dedicated
+technical debt: consolidate into a single typed options object.

--- a/TODO.md
+++ b/TODO.md
@@ -396,6 +396,31 @@ indefinitely. Compare against `pg.ts` lines 55–58, which correctly call `rejec
 +  }).catch((e) => { reject(e); });
 ```
 
+### `sql/pg.ts` + `sql/sqlite.ts` — Empty String Filter Values Silently Drop `WHERE` Constraints
+
+The nullish checks fixed `0`, but the `.toString() !== [].toString()` comparison is
+`"" !== ""` for empty strings — which evaluates to `false`, silently discarding the
+constraint. A caller querying `{ status: "" }` expecting `WHERE status = ''` gets a
+full table scan instead. This is a silent data leakage risk.
+
+The filter predicate must explicitly allow empty strings through:
+
+```diff
+-  .filter((key) => value.toString() !== [].toString())
++  .filter((key) => value !== null && value !== undefined)
+```
+
+Or, if array values need separate handling, be explicit about each case rather than
+relying on `toString()` coercion:
+
+```typescript
+const isValidFilterValue = (v: unknown): boolean =>
+  v !== null && v !== undefined && !Array.isArray(v);
+```
+
+Applies to both `pg.ts` and `sqlite.ts` — audit all filter predicate sites in both
+files for this pattern.
+
 ### `sql/sql.ts` — Remove `any` from `getCount()` Return Path
 
 Lines 33 and 40 in the shared base class pass `any` through the count helper. The

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "test": "LOG_TRANSPORTS=File LOG_FILE=/dev/null jest --passWithNoTests",
+    "test": "cross-env LOG_TRANSPORTS=File LOG_FILE=/dev/null jest --passWithNoTests",
     "check": "biome check ."
   },
   "dependencies": {

--- a/packages/db/rollup.config.js
+++ b/packages/db/rollup.config.js
@@ -1,8 +1,3 @@
-import config from '../../rollup-template.js'
+import config from "../../rollup-template.js";
 
-export default config([
-  '@twake/logger',
-  'pg',
-  'sqlite3',
-  'tls'
-])
+export default config(["@twake/logger", "pg", "sqlite3", "tls"]);

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -53,17 +53,14 @@ class Database<T extends string> implements DbBackend<T> {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   createDatabases(conf: DatabaseConfig, ...args: any): Promise<void> {
     return this.db.createDatabases(conf, ...args);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
     return this.db.insert(table, values);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   update(
     table: T,
     values: Record<string, string | number>,
@@ -73,7 +70,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.update(table, values, field, value);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   updateAnd(
     table: T,
     values: Record<string, string | number>,
@@ -83,7 +79,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.updateAnd(table, values, condition1, condition2);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   get(
     table: T,
     fields: string[],
@@ -93,7 +88,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.get(table, fields, filterFields, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getJoin(
     tables: T[],
     fields: string[],
@@ -104,7 +98,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getJoin(tables, fields, filterFields, joinFields, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getWhereEqualOrDifferent(
     table: T,
     fields: string[],
@@ -115,7 +108,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getWhereEqualOrDifferent(table, fields, filterFields1, filterFields2, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getWhereEqualAndHigher(
     table: T,
     fields: string[],
@@ -126,7 +118,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getWhereEqualAndHigher(table, fields, filterFields1, filterFields2, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getMaxWhereEqual(
     table: T,
     targetField: string,
@@ -137,7 +128,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMaxWhereEqual(table, targetField, fields, filterFields, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getMaxWhereEqualAndLower(
     table: T,
     targetField: string,
@@ -149,7 +139,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMaxWhereEqualAndLower(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getMinWhereEqualAndHigher(
     table: T,
     targetField: string,
@@ -161,7 +150,6 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMinWhereEqualAndHigher(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getMaxWhereEqualAndLowerJoin(
     tables: T[],
     targetField: string,
@@ -182,17 +170,14 @@ class Database<T extends string> implements DbBackend<T> {
     );
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return this.db.getCount(table, field, value);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getAll(table: T, fields: string[], order?: string): Promise<DbGetResult> {
     return this.db.getAll(table, fields, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getHigherThan(
     table: T,
     fields: string[],
@@ -202,17 +187,14 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getHigherThan(table, fields, filterFields, order);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   match(table: T, fields: string[], searchFields: string[], value: string | number): Promise<DbGetResult> {
     return this.db.match(table, fields, searchFields, value);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
     return this.db.deleteEqual(table, field, value);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteEqualAnd(
     table: T,
     condition1: {
@@ -227,27 +209,22 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.deleteEqualAnd(table, condition1, condition2);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
     return this.db.deleteLowerThan(table, field, value);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteWhere(table: T, conditions: ISQLCondition | ISQLCondition[]): Promise<void> {
     return this.db.deleteWhere(table, conditions);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getTableColumns(table: T): Promise<ColumnInfo[]> {
     return this.db.getTableColumns(table);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   addColumn(table: T, column: ColumnDefinition): Promise<void> {
     return this.db.addColumn(table, column);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   ensureColumns(table: T, columns: ColumnDefinition[]): Promise<void> {
     return this.db.ensureColumns(table, columns);
   }

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,14 +1,7 @@
-import { type TwakeLogger } from '@twake/logger'
-import {
-  type DatabaseConfig,
-  type DbGetResult,
-  type DbBackend,
-  type ISQLCondition,
-  type ColumnDefinition,
-  type ColumnInfo
-} from './types'
-import Pg from './sql/pg'
-import SQLite from './sql/sqlite'
+import type { TwakeLogger } from "@twake/logger";
+import Pg from "./sql/pg";
+import SQLite from "./sql/sqlite";
+import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "./types";
 
 /**
  * Generic Database class that provides a unified interface for SQLite and PostgreSQL
@@ -17,68 +10,57 @@ import SQLite from './sql/sqlite'
  * @template T - Union type of table names (e.g., 'users' | 'settings')
  */
 class Database<T extends string> implements DbBackend<T> {
-  ready: Promise<void>
-  private readonly db: DbBackend<T>
-  private readonly logger: TwakeLogger
+  ready: Promise<void>;
+  private readonly db: DbBackend<T>;
+  private readonly logger: TwakeLogger;
 
   constructor(
     conf: DatabaseConfig,
     logger: TwakeLogger,
     tables: Record<T, string>,
     indexes?: Partial<Record<T, string[]>>,
-    initializeValues?: Partial<
-      Record<T, Array<Record<string, string | number>>>
-    >
+    initializeValues?: Partial<Record<T, Array<Record<string, string | number>>>>,
   ) {
-    this.logger = logger
+    this.logger = logger;
 
-    let Module: typeof SQLite | typeof Pg
+    let Module: typeof SQLite | typeof Pg;
     switch (conf.database_engine) {
-      case 'sqlite': {
-        Module = SQLite
-        break
+      case "sqlite": {
+        Module = SQLite;
+        break;
       }
-      case 'pg': {
-        Module = Pg
-        break
+      case "pg": {
+        Module = Pg;
+        break;
       }
       default: {
-        throw new Error(`Unsupported database type ${conf.database_engine}`)
+        throw new Error(`Unsupported database type ${conf.database_engine}`);
       }
     }
 
-    this.db = new Module<T>(
-      conf,
-      logger,
-      tables,
-      indexes ?? {},
-      initializeValues ?? {}
-    )
+    this.db = new Module<T>(conf, logger, tables, indexes ?? {}, initializeValues ?? {});
 
     this.ready = new Promise((resolve, reject) => {
       this.db.ready
         .then(() => {
-          this.logger.info('[Database] initialized.')
-          resolve()
+          this.logger.info("[Database] initialized.");
+          resolve();
         })
         .catch((e) => {
-          this.logger.error('[Database] initialization failed', e)
-          reject(e)
-        })
-    })
+          this.logger.error("[Database] initialization failed", e);
+          reject(e);
+        });
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   createDatabases(conf: DatabaseConfig, ...args: any): Promise<void> {
-    return this.db.createDatabases(conf, ...args)
+    return this.db.createDatabases(conf, ...args);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  insert(
-    table: T,
-    values: Record<string, string | number>
-  ): Promise<DbGetResult> {
-    return this.db.insert(table, values)
+  insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
+    return this.db.insert(table, values);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -86,9 +68,9 @@ class Database<T extends string> implements DbBackend<T> {
     table: T,
     values: Record<string, string | number>,
     field: string,
-    value: string | number
+    value: string | number,
   ): Promise<DbGetResult> {
-    return this.db.update(table, values, field, value)
+    return this.db.update(table, values, field, value);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -96,9 +78,9 @@ class Database<T extends string> implements DbBackend<T> {
     table: T,
     values: Record<string, string | number>,
     condition1: { field: string; value: string | number },
-    condition2: { field: string; value: string | number }
+    condition2: { field: string; value: string | number },
   ): Promise<DbGetResult> {
-    return this.db.updateAnd(table, values, condition1, condition2)
+    return this.db.updateAnd(table, values, condition1, condition2);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -106,9 +88,9 @@ class Database<T extends string> implements DbBackend<T> {
     table: T,
     fields: string[],
     filterFields: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.get(table, fields, filterFields, order)
+    return this.db.get(table, fields, filterFields, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -117,9 +99,9 @@ class Database<T extends string> implements DbBackend<T> {
     fields: string[],
     filterFields: Record<string, string | number | Array<string | number>>,
     joinFields: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getJoin(tables, fields, filterFields, joinFields, order)
+    return this.db.getJoin(tables, fields, filterFields, joinFields, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -128,15 +110,9 @@ class Database<T extends string> implements DbBackend<T> {
     fields: string[],
     filterFields1: Record<string, string | number | Array<string | number>>,
     filterFields2: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getWhereEqualOrDifferent(
-      table,
-      fields,
-      filterFields1,
-      filterFields2,
-      order
-    )
+    return this.db.getWhereEqualOrDifferent(table, fields, filterFields1, filterFields2, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -145,15 +121,9 @@ class Database<T extends string> implements DbBackend<T> {
     fields: string[],
     filterFields1: Record<string, string | number | Array<string | number>>,
     filterFields2: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getWhereEqualAndHigher(
-      table,
-      fields,
-      filterFields1,
-      filterFields2,
-      order
-    )
+    return this.db.getWhereEqualAndHigher(table, fields, filterFields1, filterFields2, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -162,15 +132,9 @@ class Database<T extends string> implements DbBackend<T> {
     targetField: string,
     fields: string[],
     filterFields: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getMaxWhereEqual(
-      table,
-      targetField,
-      fields,
-      filterFields,
-      order
-    )
+    return this.db.getMaxWhereEqual(table, targetField, fields, filterFields, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -180,16 +144,9 @@ class Database<T extends string> implements DbBackend<T> {
     fields: string[],
     filterFields1: Record<string, string | number | Array<string | number>>,
     filterFields2: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getMaxWhereEqualAndLower(
-      table,
-      targetField,
-      fields,
-      filterFields1,
-      filterFields2,
-      order
-    )
+    return this.db.getMaxWhereEqualAndLower(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -199,16 +156,9 @@ class Database<T extends string> implements DbBackend<T> {
     fields: string[],
     filterFields1: Record<string, string | number | Array<string | number>>,
     filterFields2: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getMinWhereEqualAndHigher(
-      table,
-      targetField,
-      fields,
-      filterFields1,
-      filterFields2,
-      order
-    )
+    return this.db.getMinWhereEqualAndHigher(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -219,7 +169,7 @@ class Database<T extends string> implements DbBackend<T> {
     filterFields1: Record<string, string | number | Array<string | number>>,
     filterFields2: Record<string, string | number | Array<string | number>>,
     joinFields: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this.db.getMaxWhereEqualAndLowerJoin(
       tables,
@@ -228,22 +178,18 @@ class Database<T extends string> implements DbBackend<T> {
       filterFields1,
       filterFields2,
       joinFields,
-      order
-    )
+      order,
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  getCount(
-    table: T,
-    field: string,
-    value?: string | number | string[]
-  ): Promise<number> {
-    return this.db.getCount(table, field, value)
+  getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
+    return this.db.getCount(table, field, value);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   getAll(table: T, fields: string[], order?: string): Promise<DbGetResult> {
-    return this.db.getAll(table, fields, order)
+    return this.db.getAll(table, fields, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -251,76 +197,64 @@ class Database<T extends string> implements DbBackend<T> {
     table: T,
     fields: string[],
     filterFields: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
-    return this.db.getHigherThan(table, fields, filterFields, order)
+    return this.db.getHigherThan(table, fields, filterFields, order);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  match(
-    table: T,
-    fields: string[],
-    searchFields: string[],
-    value: string | number
-  ): Promise<DbGetResult> {
-    return this.db.match(table, fields, searchFields, value)
+  match(table: T, fields: string[], searchFields: string[], value: string | number): Promise<DbGetResult> {
+    return this.db.match(table, fields, searchFields, value);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
-    return this.db.deleteEqual(table, field, value)
+    return this.db.deleteEqual(table, field, value);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   deleteEqualAnd(
     table: T,
     condition1: {
-      field: string
-      value: string | number | Array<string | number>
+      field: string;
+      value: string | number | Array<string | number>;
     },
     condition2: {
-      field: string
-      value: string | number | Array<string | number>
-    }
+      field: string;
+      value: string | number | Array<string | number>;
+    },
   ): Promise<void> {
-    return this.db.deleteEqualAnd(table, condition1, condition2)
+    return this.db.deleteEqualAnd(table, condition1, condition2);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  deleteLowerThan(
-    table: T,
-    field: string,
-    value: string | number
-  ): Promise<void> {
-    return this.db.deleteLowerThan(table, field, value)
+  deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
+    return this.db.deleteLowerThan(table, field, value);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  deleteWhere(
-    table: T,
-    conditions: ISQLCondition | ISQLCondition[]
-  ): Promise<void> {
-    return this.db.deleteWhere(table, conditions)
+  deleteWhere(table: T, conditions: ISQLCondition | ISQLCondition[]): Promise<void> {
+    return this.db.deleteWhere(table, conditions);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   getTableColumns(table: T): Promise<ColumnInfo[]> {
-    return this.db.getTableColumns(table)
+    return this.db.getTableColumns(table);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   addColumn(table: T, column: ColumnDefinition): Promise<void> {
-    return this.db.addColumn(table, column)
+    return this.db.addColumn(table, column);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   ensureColumns(table: T, columns: ColumnDefinition[]): Promise<void> {
-    return this.db.ensureColumns(table, columns)
+    return this.db.ensureColumns(table, columns);
   }
 
   close(): void {
-    this.db.close()
+    this.db.close();
   }
 }
 
-export default Database
+export default Database;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,26 +1,21 @@
 // Main Database class
-export { default } from './database'
-export { default as Database } from './database'
-
-// SQL adapters
-export { default as Pg } from './sql/pg'
-export { default as SQLite } from './sql/sqlite'
-
+export { default, default as Database } from "./database";
 // Utilities
-export { default as createTables } from './sql/_createTables'
-
+export { default as createTables } from "./sql/_createTables";
+// Re-export adapter database types
+export type { PgDatabase } from "./sql/pg";
+// SQL adapters
+export { default as Pg } from "./sql/pg";
+export type { SQLiteDatabase, SQLiteStatement } from "./sql/sqlite";
+export { default as SQLite } from "./sql/sqlite";
 // Types
 export type {
-  SupportedDatabases,
-  DatabaseConfig,
-  DbGetResult,
-  SqlComparaisonOperator,
-  ISQLCondition,
-  DbBackend,
   ColumnDefinition,
-  ColumnInfo
-} from './types'
-
-// Re-export adapter database types
-export type { PgDatabase } from './sql/pg'
-export type { SQLiteDatabase, SQLiteStatement } from './sql/sqlite'
+  ColumnInfo,
+  DatabaseConfig,
+  DbBackend,
+  DbGetResult,
+  ISQLCondition,
+  SqlComparaisonOperator,
+  SupportedDatabases,
+} from "./types";

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -23,7 +23,7 @@ function createTables<T extends string>(
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
-                    ((indexes[table] as string[]) != null ? (indexes[table] as string[]) : []).map<
+                    ((indexes[table] as string[]) !== null ? (indexes[table] as string[]) : []).map<
                       Promise<any>
                       // eslint-disable-next-line @typescript-eslint/promise-function-async
                     >((index) =>
@@ -37,7 +37,7 @@ function createTables<T extends string>(
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
-                    (initializeValues[table] != null
+                    (initializeValues[table] !== null
                       ? (initializeValues[table] as Array<Record<string, string | number>>)
                       : []
                     ).map<

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -17,15 +17,12 @@ function createTables<T extends string>(
       new Promise<void>((_resolve, _reject) => {
         db.exists(table)
           .then((count) => {
-            /* istanbul ignore else */ // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (!count) {
               db.rawQuery(`CREATE TABLE ${table}(${tables[table]})`)
-                // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
                     (indexes[table] ? (indexes[table] as string[]) : []).map<
                       Promise<any>
-                      // eslint-disable-next-line @typescript-eslint/promise-function-async
                     >((index) =>
                       db.rawQuery(`CREATE INDEX i_${table}_${index} ON ${table} (${index})`).catch((e) => {
                         /* istanbul ignore next */
@@ -34,7 +31,6 @@ function createTables<T extends string>(
                     ),
                   ),
                 )
-                // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
                     (initializeValues[table]
@@ -42,7 +38,6 @@ function createTables<T extends string>(
                       : []
                     ).map<
                       Promise<any>
-                      // eslint-disable-next-line @typescript-eslint/promise-function-async
                     >((entry) => db.insert(table, entry)),
                   ),
                 )

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -1,6 +1,6 @@
-import { type TwakeLogger } from '@twake/logger'
-import type Pg from './pg'
-import type SQLite from './sqlite'
+import type { TwakeLogger } from "@twake/logger";
+import type Pg from "./pg";
+import type SQLite from "./sqlite";
 
 function createTables<T extends string>(
   db: SQLite<T> | Pg<T>,
@@ -9,10 +9,10 @@ function createTables<T extends string>(
   initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
   logger: TwakeLogger,
   resolve: () => void,
-  reject: (e: Error) => void
+  reject: (e: Error) => void,
 ): void {
-  const promises: Array<Promise<void>> = []
-  ;(Object.keys(tables) as T[]).forEach((table: T) => {
+  const promises: Array<Promise<void>> = [];
+  (Object.keys(tables) as T[]).forEach((table: T) => {
     promises.push(
       new Promise<void>((_resolve, _reject) => {
         db.exists(table)
@@ -23,63 +23,54 @@ function createTables<T extends string>(
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
-                    ((indexes[table] as string[]) != null
-                      ? (indexes[table] as string[])
-                      : []
-                    ).map<
+                    ((indexes[table] as string[]) != null ? (indexes[table] as string[]) : []).map<
                       Promise<any>
                       // eslint-disable-next-line @typescript-eslint/promise-function-async
                     >((index) =>
-                      db
-                        .rawQuery(
-                          `CREATE INDEX i_${table}_${index} ON ${table} (${index})`
-                        )
-                        .catch((e) => {
-                          /* istanbul ignore next */
-                          logger.error(`Index ${index}`, e)
-                        })
-                    )
-                  )
+                      db.rawQuery(`CREATE INDEX i_${table}_${index} ON ${table} (${index})`).catch((e) => {
+                        /* istanbul ignore next */
+                        logger.error(`Index ${index}`, e);
+                      }),
+                    ),
+                  ),
                 )
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
                     (initializeValues[table] != null
-                      ? (initializeValues[table] as Array<
-                          Record<string, string | number>
-                        >)
+                      ? (initializeValues[table] as Array<Record<string, string | number>>)
                       : []
                     ).map<
                       Promise<any>
                       // eslint-disable-next-line @typescript-eslint/promise-function-async
-                    >((entry) => db.insert(table, entry))
-                  )
+                    >((entry) => db.insert(table, entry)),
+                  ),
                 )
                 .then(() => {
-                  _resolve()
+                  _resolve();
                 })
                 // istanbul ignore next
                 .catch((e) => {
-                  _reject(e)
-                })
+                  _reject(e);
+                });
             } else {
-              _resolve()
+              _resolve();
             }
           })
           /* istanbul ignore next */
-          .catch(_reject)
-      })
-    )
-  })
+          .catch(_reject);
+      }),
+    );
+  });
   Promise.all(promises)
     .then(() => {
-      resolve()
+      resolve();
     })
     // istanbul ignore next
     .catch((e) => {
-      logger.error('Unable to create tables', e)
-      reject(e)
-    })
+      logger.error("Unable to create tables", e);
+      reject(e);
+    });
 }
 
-export default createTables
+export default createTables;

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -21,9 +21,7 @@ function createTables<T extends string>(
               db.rawQuery(`CREATE TABLE ${table}(${tables[table]})`)
                 .then(() =>
                   Promise.all(
-                    (indexes[table] ? (indexes[table] as string[]) : []).map<
-                      Promise<any>
-                    >((index) =>
+                    (indexes[table] ? (indexes[table] as string[]) : []).map<Promise<any>>((index) =>
                       db.rawQuery(`CREATE INDEX i_${table}_${index} ON ${table} (${index})`).catch((e) => {
                         /* istanbul ignore next */
                         logger.error(`Index ${index}`, e);
@@ -36,9 +34,7 @@ function createTables<T extends string>(
                     (initializeValues[table]
                       ? (initializeValues[table] as Array<Record<string, string | number>>)
                       : []
-                    ).map<
-                      Promise<any>
-                    >((entry) => db.insert(table, entry)),
+                    ).map<Promise<any>>((entry) => db.insert(table, entry)),
                   ),
                 )
                 .then(() => {

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -23,7 +23,7 @@ function createTables<T extends string>(
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
-                    ((indexes[table] as string[]) !== null ? (indexes[table] as string[]) : []).map<
+                    (indexes[table] ? (indexes[table] as string[]) : []).map<
                       Promise<any>
                       // eslint-disable-next-line @typescript-eslint/promise-function-async
                     >((index) =>
@@ -37,7 +37,7 @@ function createTables<T extends string>(
                 // eslint-disable-next-line @typescript-eslint/promise-function-async
                 .then(() =>
                   Promise.all(
-                    (initializeValues[table] !== null
+                    (initializeValues[table]
                       ? (initializeValues[table] as Array<Record<string, string | number>>)
                       : []
                     ).map<

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -284,7 +284,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key] !== undefined && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -518,7 +518,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key] !== undefined && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -24,12 +24,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           .then((pg) => {
             // @ts-expect-error
             if (!pg.Database) pg = pg.default;
-            if (
-              !conf.database_host ||
-              !conf.database_user ||
-              !conf.database_password ||
-              !conf.database_name
-            ) {
+            if (!conf.database_host || !conf.database_user || !conf.database_password || !conf.database_name) {
               throw new Error("database_name, database_user and database_password are required when using Postgres");
             }
             const opts: ClientConfig = {
@@ -310,9 +305,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 && filterFields1 && Object.keys(filterFields1).length > 0
-            ? buildCondition(op1, filterFields1)
-            : "";
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0 ? buildCondition(op1, filterFields1) : "";
         const condition2 =
           op2 && linkop1 && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
@@ -323,14 +316,8 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
             : "";
 
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
-        condition +=
-          condition2 !== ""
-              (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
-            : "";
-        condition +=
-          condition3 !== ""
-              (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
-            : "";
+        condition += condition2 !== "" ? (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2 : "";
+        condition += condition3 !== "" ? (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3 : "";
 
         if (joinFields) {
           let joinCondition = "";
@@ -552,19 +539,14 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 && filterFields1 && Object.keys(filterFields1).length > 0
-            ? buildCondition(op1, filterFields1)
-            : "";
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0 ? buildCondition(op1, filterFields1) : "";
         const condition2 =
           op2 && linkop && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
 
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
-        condition +=
-          condition2 !== ""
-              (condition ? ` ${linkop} ` : "WHERE ") + condition2
-            : "";
+        condition += condition2 !== "" ? (condition ? ` ${linkop} ` : "WHERE ") + condition2 : "";
 
         if (joinFields) {
           let joinCondition = "";

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
-/* eslint-disable @typescript-eslint/promise-function-async */
 /* istanbul ignore file */
 import type { TwakeLogger } from "@twake/logger";
 import type { ClientConfig, Pool as PgPool } from "pg";
@@ -24,7 +22,6 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
       } else {
         import("pg")
           .then((pg) => {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
             if (!pg.Database) pg = pg.default;
             if (
@@ -42,7 +39,6 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
               database: conf.database_name,
               ssl: conf.database_ssl,
             };
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (conf.database_host.match(/^(.*):(\d+)/)) {
               opts.host = RegExp.$1;
               opts.port = parseInt(RegExp.$2, 10);
@@ -329,12 +325,10 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
             : "";
         condition +=
           condition3 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
             : "";
 
@@ -569,7 +563,6 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition ? ` ${linkop} ` : "WHERE ") + condition2
             : "";
 
@@ -843,7 +836,6 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           });
           reject(
             new Error(
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               `Bad deleteAnd call, conditions: ${condition1.field}=${condition1.value}, ${condition2.field}=${condition2.value}`,
             ),
           );

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -19,7 +19,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db !== null) {
+      if (this.db) {
         createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
         import("pg")
@@ -293,7 +293,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -350,7 +350,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           condition += joinCondition;
         }
 
-        if (order !== null) condition += ` ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(",")} FROM ${tables.join(",")} ${condition}`;
         this.logger.debug("[Pg][_get] Executing SELECT", {
@@ -537,7 +537,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -1,289 +1,253 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 /* eslint-disable @typescript-eslint/promise-function-async */
 /* istanbul ignore file */
-import { type TwakeLogger } from '@twake/logger'
-import { type ClientConfig, type Pool as PgPool } from 'pg'
-import {
-  type DatabaseConfig,
-  type DbGetResult,
-  type DbBackend,
-  type ISQLCondition,
-  type ColumnDefinition,
-  type ColumnInfo
-} from '../types'
-import createTables from './_createTables'
-import SQL from './sql'
+import type { TwakeLogger } from "@twake/logger";
+import type { ClientConfig, Pool as PgPool } from "pg";
+import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "../types";
+import createTables from "./_createTables";
+import SQL from "./sql";
 
-export type PgDatabase = PgPool
+export type PgDatabase = PgPool;
 
 class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
-  declare db?: PgDatabase
+  declare db?: PgDatabase;
   createDatabases(
     conf: DatabaseConfig,
     tables: Record<T, string>,
     indexes: Partial<Record<T, string[]>>,
-    initializeValues: Partial<
-      Record<T, Array<Record<string, string | number>>>
-    >,
-    logger: TwakeLogger
+    initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
+    logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db != null) {
-        createTables(
-          this,
-          tables,
-          indexes,
-          initializeValues,
-          logger,
-          resolve,
-          reject
-        )
+        createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
-        import('pg')
+        import("pg")
           .then((pg) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-            // @ts-ignore
-            if (pg.Database == null) pg = pg.default
+            // @ts-expect-error
+            if (pg.Database == null) pg = pg.default;
             if (
               conf.database_host == null ||
               conf.database_user == null ||
               conf.database_password == null ||
               conf.database_name == null
             ) {
-              throw new Error(
-                'database_name, database_user and database_password are required when using Postgres'
-              )
+              throw new Error("database_name, database_user and database_password are required when using Postgres");
             }
             const opts: ClientConfig = {
               host: conf.database_host,
               user: conf.database_user,
               password: conf.database_password,
               database: conf.database_name,
-              ssl: conf.database_ssl
-            }
+              ssl: conf.database_ssl,
+            };
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (conf.database_host.match(/^(.*):(\d+)/)) {
-              opts.host = RegExp.$1
-              opts.port = parseInt(RegExp.$2)
+              opts.host = RegExp.$1;
+              opts.port = parseInt(RegExp.$2);
             }
             try {
-              this.db = new pg.Pool(opts)
-              logger.info('[Db:Pg] connected.')
-              createTables(
-                this,
-                tables,
-                indexes,
-                initializeValues,
-                logger,
-                resolve,
-                reject
-              )
+              this.db = new pg.Pool(opts);
+              logger.info("[Db:Pg] connected.");
+              createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
             } catch (e) {
-              logger.error('Unable to connect to Pg database')
-              reject(e)
+              logger.error("Unable to connect to Pg database");
+              reject(e);
             }
           })
           .catch((e) => {
-            logger.error('Unable to load pg module', e)
-            reject(e)
-          })
+            logger.error("Unable to load pg module", e);
+            reject(e);
+          });
       }
-    })
+    });
   }
 
   rawQuery(query: string): Promise<any> {
     if (this.db == null) {
-      this.logger.error('[Pg][rawQuery] DB not ready')
-      return Promise.reject(new Error('DB not ready'))
+      this.logger.error("[Pg][rawQuery] DB not ready");
+      return Promise.reject(new Error("DB not ready"));
     }
-    this.logger.debug('[Pg][rawQuery] Executing query', { query })
+    this.logger.debug("[Pg][rawQuery] Executing query", { query });
     return this.db.query(query).catch((err) => {
-      this.logger.error('[Pg][rawQuery] Query failed', { query, error: err })
-      throw err
-    })
+      this.logger.error("[Pg][rawQuery] Query failed", { query, error: err });
+      throw err;
+    });
   }
 
   exists(table: T): Promise<boolean> {
     return new Promise((resolve, reject) => {
       if (this.db != null) {
-        const query = `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename='${table.toLowerCase()}')`
-        this.logger.debug('[Pg][exists] Checking table', { table })
+        const query = `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename='${table.toLowerCase()}')`;
+        this.logger.debug("[Pg][exists] Checking table", { table });
         this.db.query(query, (err, res) => {
           if (err == null) {
-            this.logger.debug('[Pg][exists] Check completed', {
+            this.logger.debug("[Pg][exists] Check completed", {
               table,
-              exists: res.rows[0].exists
-            })
-            resolve(res.rows[0].exists)
+              exists: res.rows[0].exists,
+            });
+            resolve(res.rows[0].exists);
           } else {
-            this.logger.warn('[Pg][exists] Check error, assuming false', {
+            this.logger.warn("[Pg][exists] Check error, assuming false", {
               table,
-              error: err
-            })
-            resolve(false)
+              error: err,
+            });
+            resolve(false);
           }
-        })
+        });
       } else {
-        this.logger.error('[Pg][exists] DB not ready', { table })
-        reject(new Error('DB not ready'))
+        this.logger.error("[Pg][exists] DB not ready", { table });
+        reject(new Error("DB not ready"));
       }
-    })
+    });
   }
 
-  insert(
-    table: T,
-    values: Record<string, string | number>
-  ): Promise<DbGetResult> {
+  insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[Pg][insert] DB not ready', { table })
-        throw new Error('Wait for database to be ready')
+        this.logger.error("[Pg][insert] DB not ready", { table });
+        throw new Error("Wait for database to be ready");
       }
-      const names: string[] = []
-      const vals:
-        | (string[] & Array<string | number>)
-        | (number[] & Array<string | number>) = []
+      const names: string[] = [];
+      const vals: (string[] & Array<string | number>) | (number[] & Array<string | number>) = [];
       Object.keys(values).forEach((k) => {
-        names.push(k)
-        vals.push(values[k])
-      })
-      const query = `INSERT INTO ${table}(${names.join(',')}) VALUES(${names
+        names.push(k);
+        vals.push(values[k]);
+      });
+      const query = `INSERT INTO ${table}(${names.join(",")}) VALUES(${names
         .map((v, i) => `$${i + 1}`)
-        .join(',')}) RETURNING *;`
-      this.logger.debug('[Pg][insert] Executing', {
+        .join(",")}) RETURNING *;`;
+      this.logger.debug("[Pg][insert] Executing", {
         table,
         fields: names,
-        query
-      })
+        query,
+      });
       this.db.query(query, vals, (err, rows) => {
         if (err) {
-          this.logger.error('[Pg][insert] Failed', {
+          this.logger.error("[Pg][insert] Failed", {
             table,
             fields: names,
             values: vals,
             query,
-            error: err
-          })
-          reject(err)
+            error: err,
+          });
+          reject(err);
         } else {
-          this.logger.debug('[Pg][insert] Successful', {
+          this.logger.debug("[Pg][insert] Successful", {
             table,
-            rowCount: rows.rows.length
-          })
-          resolve(rows.rows)
+            rowCount: rows.rows.length,
+          });
+          resolve(rows.rows);
         }
-      })
-    })
+      });
+    });
   }
 
   update(
     table: string,
     values: Record<string, string | number>,
     field: string,
-    value: string | number
+    value: string | number,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[Pg][update] DB not ready', { table, field })
-        reject(new Error('Wait for database to be ready'))
+        this.logger.error("[Pg][update] DB not ready", { table, field });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        const names: string[] = []
-        const vals:
-          | (string[] & Array<string | number>)
-          | (number[] & Array<string | number>) = []
+        const names: string[] = [];
+        const vals: (string[] & Array<string | number>) | (number[] & Array<string | number>) = [];
         Object.keys(values).forEach((k) => {
-          names.push(k)
-          vals.push(values[k])
-        })
-        vals.push(value)
+          names.push(k);
+          vals.push(values[k]);
+        });
+        vals.push(value);
         const query = `UPDATE ${table} SET ${names
           .map((name, i) => `${name}=$${i + 1}`)
-          .join(',')} WHERE ${field}=$${vals.length} RETURNING *;`
-        this.logger.debug('[Pg][update] Executing', {
+          .join(",")} WHERE ${field}=$${vals.length} RETURNING *;`;
+        this.logger.debug("[Pg][update] Executing", {
           table,
           fields: names,
           whereField: field,
-          query
-        })
+          query,
+        });
         this.db.query(query, vals, (err, rows) => {
           if (err) {
-            this.logger.error('[Pg][update] Failed', {
+            this.logger.error("[Pg][update] Failed", {
               table,
               fields: names,
               whereField: field,
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[Pg][update] Successful', {
+            this.logger.debug("[Pg][update] Successful", {
               table,
-              rowCount: rows.rows.length
-            })
-            resolve(rows.rows)
+              rowCount: rows.rows.length,
+            });
+            resolve(rows.rows);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   updateAnd(
     table: T,
     values: Record<string, string | number>,
     condition1: { field: string; value: string | number },
-    condition2: { field: string; value: string | number }
+    condition2: { field: string; value: string | number },
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[Pg][updateAnd] DB not ready', {
+        this.logger.error("[Pg][updateAnd] DB not ready", {
           table,
-          conditions: [condition1.field, condition2.field]
-        })
-        reject(new Error('Wait for database to be ready'))
+          conditions: [condition1.field, condition2.field],
+        });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        const names: string[] = []
-        const vals:
-          | (string[] & Array<string | number>)
-          | (number[] & Array<string | number>) = []
+        const names: string[] = [];
+        const vals: (string[] & Array<string | number>) | (number[] & Array<string | number>) = [];
         Object.keys(values).forEach((k) => {
-          names.push(k)
-          vals.push(values[k])
-        })
-        vals.push(condition1.value, condition2.value)
+          names.push(k);
+          vals.push(values[k]);
+        });
+        vals.push(condition1.value, condition2.value);
         const query = `UPDATE ${table} SET ${names
           .map((name, i) => `${name}=$${i + 1}`)
-          .join(',')} WHERE ${condition1.field}=$${vals.length - 1} AND ${
+          .join(",")} WHERE ${condition1.field}=$${vals.length - 1} AND ${
           condition2.field
-        }=$${vals.length} RETURNING *;`
-        this.logger.debug('[Pg][updateAnd] Executing', {
+        }=$${vals.length} RETURNING *;`;
+        this.logger.debug("[Pg][updateAnd] Executing", {
           table,
           fields: names,
           whereFields: [condition1.field, condition2.field],
-          query
-        })
+          query,
+        });
         this.db.query(query, vals, (err, rows) => {
           if (err) {
-            this.logger.error('[Pg][updateAnd] Failed', {
+            this.logger.error("[Pg][updateAnd] Failed", {
               table,
               fields: names,
               whereFields: [condition1.field, condition2.field],
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[Pg][updateAnd] Successful', {
+            this.logger.debug("[Pg][updateAnd] Successful", {
               table,
-              rowCount: rows.rows.length
-            })
-            resolve(rows.rows)
+              rowCount: rows.rows.length,
+            });
+            resolve(rows.rows);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   _get(
@@ -298,155 +262,135 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     linkop2?: string,
     filterFields3?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        reject(new Error('Wait for database to be ready'))
+        reject(new Error("Wait for database to be ready"));
       } else {
-        let condition: string = ''
-        const values: string[] = []
+        let condition: string = "";
+        const values: string[] = [];
         if (fields == null || fields.length === 0) {
-          fields = ['*']
+          fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
           fields = fields.map((field) => {
-            if (field.includes('.')) {
-              const alias = field.replace(/\./g, '_')
-              return `${field} AS ${alias}`
+            if (field.includes(".")) {
+              const alias = field.replace(/\./g, "_");
+              return `${field} AS ${alias}`;
             }
-            return field
-          })
+            return field;
+          });
         }
 
-        let index: number = 0
+        let index: number = 0;
 
         const buildCondition = (
           op: string,
-          filterFields: Record<string, string | number | Array<string | number>>
+          filterFields: Record<string, string | number | Array<string | number>>,
         ): string => {
-          let localCondition = ''
+          let localCondition = "";
 
           Object.keys(filterFields)
-            .filter(
-              (key) =>
-                filterFields[key] != null &&
-                filterFields[key].toString() !== [].toString()
-            )
+            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
-              localCondition += localCondition !== '' ? ' AND ' : ''
+              localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
-                localCondition += `(${(
-                  filterFields[key] as Array<string | number>
-                )
+                localCondition += `(${(filterFields[key] as Array<string | number>)
                   .map((val) => {
-                    index++
-                    values.push(val.toString())
-                    return `${key}${op}$${index}`
+                    index++;
+                    values.push(val.toString());
+                    return `${key}${op}$${index}`;
                   })
-                  .join(' OR ')})`
+                  .join(" OR ")})`;
               } else {
-                index++
-                values.push(filterFields[key].toString())
-                localCondition += `${key}${op}$${index}`
+                index++;
+                values.push(filterFields[key].toString());
+                localCondition += `${key}${op}$${index}`;
               }
-            })
-          return localCondition
-        }
+            });
+          return localCondition;
+        };
 
         const condition1 =
-          op1 != null &&
-          filterFields1 != null &&
-          Object.keys(filterFields1).length > 0
+          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
-            : ''
+            : "";
         const condition2 =
-          op2 != null &&
-          linkop1 != null &&
-          filterFields2 != null &&
-          Object.keys(filterFields2).length > 0
+          op2 != null && linkop1 != null && filterFields2 != null && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
-            : ''
+            : "";
         const condition3 =
-          op3 != null &&
-          linkop2 != null &&
-          filterFields3 != null &&
-          Object.keys(filterFields3).length > 0
+          op3 != null && linkop2 != null && filterFields3 != null && Object.keys(filterFields3).length > 0
             ? buildCondition(op3, filterFields3)
-            : ''
+            : "";
 
-        condition += condition1 !== '' ? 'WHERE ' + condition1 : ''
+        condition += condition1 !== "" ? "WHERE " + condition1 : "";
         condition +=
-          condition2 !== ''
+          condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition !== '' ? ` ${linkop1} ` : 'WHERE ') + condition2
-            : ''
+              (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
+            : "";
         condition +=
-          condition3 !== ''
+          condition3 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition !== '' ? ` ${linkop2} ` : 'WHERE ') + condition3
-            : ''
+              (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
+            : "";
 
         if (joinFields != null) {
-          let joinCondition = ''
+          let joinCondition = "";
           Object.keys(joinFields)
-            .filter(
-              (key) =>
-                joinFields[key] != null &&
-                joinFields[key].toString() !== [].toString()
-            )
+            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
-              joinCondition += joinCondition !== '' ? ' AND ' : ''
-              joinCondition += `${key}=${joinFields[key]}`
-            })
-          condition += condition !== '' ? ' AND ' : 'WHERE '
-          condition += joinCondition
+              joinCondition += joinCondition !== "" ? " AND " : "";
+              joinCondition += `${key}=${joinFields[key]}`;
+            });
+          condition += condition !== "" ? " AND " : "WHERE ";
+          condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`
+        if (order != null) condition += ` ORDER BY ${order}`;
 
-        const query = `SELECT ${fields.join(',')} FROM ${tables.join(
-          ','
-        )} ${condition}`
-        this.logger.debug('[Pg][_get] Executing SELECT', {
+        const query = `SELECT ${fields.join(",")} FROM ${tables.join(",")} ${condition}`;
+        this.logger.debug("[Pg][_get] Executing SELECT", {
           tables,
           fields,
           condition,
-          query
-        })
+          query,
+        });
         this.db.query(query, values, (err: any, rows: any) => {
           if (err) {
-            this.logger.error('[Pg][_get] SELECT failed', {
+            this.logger.error("[Pg][_get] SELECT failed", {
               tables,
               fields,
               condition,
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[Pg][_get] SELECT successful', {
+            this.logger.debug("[Pg][_get] SELECT successful", {
               tables,
-              rowCount: rows.rows.length
-            })
-            resolve(rows.rows)
+              rowCount: rows.rows.length,
+            });
+            resolve(rows.rows);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   get(
     table: T,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
@@ -455,8 +399,8 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getJoin(
@@ -464,12 +408,12 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       tables,
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
@@ -478,20 +422,20 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       joinFields,
-      order
-    )
+      order,
+    );
   }
 
   getHigherThan(
     table: T,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '>',
+      ">",
       filterFields,
       undefined,
       undefined,
@@ -500,8 +444,8 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getWhereEqualOrDifferent(
@@ -509,22 +453,22 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<>',
-      ' OR ',
+      "<>",
+      " OR ",
       filterFields2,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getWhereEqualAndHigher(
@@ -532,26 +476,26 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields1,
-      '>',
-      ' AND ',
+      ">",
+      " AND ",
       filterFields2,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   _getMinMax(
-    minmax: 'MIN' | 'MAX',
+    minmax: "MIN" | "MAX",
     tables: T[],
     targetField: string,
     fields?: string[],
@@ -561,115 +505,100 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     linkop?: string,
     filterFields2?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        reject(new Error('Wait for database to be ready'))
+        reject(new Error("Wait for database to be ready"));
       } else {
-        let condition: string = ''
-        const values: string[] = []
+        let condition: string = "";
+        const values: string[] = [];
         if (fields == null || fields.length === 0) {
-          fields = ['*']
+          fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
           fields = fields.map((field) => {
-            if (field.includes('.')) {
-              const alias = field.replace(/\./g, '_')
-              return `${field} AS ${alias}`
+            if (field.includes(".")) {
+              const alias = field.replace(/\./g, "_");
+              return `${field} AS ${alias}`;
             }
-            return field
-          })
+            return field;
+          });
         }
-        const targetFieldAlias: string = targetField.replace(/\./g, '_')
+        const targetFieldAlias: string = targetField.replace(/\./g, "_");
 
-        let index = 0
+        let index = 0;
 
         const buildCondition = (
           op: string,
-          filterFields: Record<string, string | number | Array<string | number>>
+          filterFields: Record<string, string | number | Array<string | number>>,
         ): string => {
-          let localCondition = ''
+          let localCondition = "";
 
           Object.keys(filterFields)
-            .filter(
-              (key) =>
-                filterFields[key] != null &&
-                filterFields[key].toString() !== [].toString()
-            )
+            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
-              localCondition += localCondition !== '' ? ' AND ' : ''
+              localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
-                localCondition += `(${(
-                  filterFields[key] as Array<string | number>
-                )
+                localCondition += `(${(filterFields[key] as Array<string | number>)
                   .map((val) => {
-                    index++
-                    values.push(val.toString())
-                    return `${key}${op}$${index}`
+                    index++;
+                    values.push(val.toString());
+                    return `${key}${op}$${index}`;
                   })
-                  .join(' OR ')})`
+                  .join(" OR ")})`;
               } else {
-                index++
-                values.push(filterFields[key].toString())
-                localCondition += `${key}${op}$${index}`
+                index++;
+                values.push(filterFields[key].toString());
+                localCondition += `${key}${op}$${index}`;
               }
-            })
-          return localCondition
-        }
+            });
+          return localCondition;
+        };
 
         const condition1 =
-          op1 != null &&
-          filterFields1 != null &&
-          Object.keys(filterFields1).length > 0
+          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
-            : ''
+            : "";
         const condition2 =
-          op2 != null &&
-          linkop != null &&
-          filterFields2 != null &&
-          Object.keys(filterFields2).length > 0
+          op2 != null && linkop != null && filterFields2 != null && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
-            : ''
+            : "";
 
-        condition += condition1 !== '' ? 'WHERE ' + condition1 : ''
+        condition += condition1 !== "" ? "WHERE " + condition1 : "";
         condition +=
-          condition2 !== ''
+          condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition ? ` ${linkop} ` : 'WHERE ') + condition2
-            : ''
+              (condition ? ` ${linkop} ` : "WHERE ") + condition2
+            : "";
 
         if (joinFields != null) {
-          let joinCondition = ''
+          let joinCondition = "";
           Object.keys(joinFields)
-            .filter(
-              (key) =>
-                joinFields[key] != null &&
-                joinFields[key].toString() !== [].toString()
-            )
+            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
-              joinCondition += joinCondition !== '' ? ' AND ' : ''
-              joinCondition += `${key}=${joinFields[key]}`
-            })
-          condition += condition !== '' ? ' AND ' : 'WHERE '
-          condition += joinCondition
+              joinCondition += joinCondition !== "" ? " AND " : "";
+              joinCondition += `${key}=${joinFields[key]}`;
+            });
+          condition += condition !== "" ? " AND " : "WHERE ";
+          condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`
+        if (order != null) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(
-          ','
+          ",",
         )}, ${minmax}(${targetField}) AS max_${targetFieldAlias} FROM ${tables.join(
-          ','
-        )} ${condition} HAVING COUNT(*) > 0` // HAVING COUNT(*) > 0 is to avoid returning a row with NULL values
+          ",",
+        )} ${condition} HAVING COUNT(*) > 0`; // HAVING COUNT(*) > 0 is to avoid returning a row with NULL values
         this.logger.debug(`[Pg][_getMinMax] Executing ${minmax} query`, {
           tables,
           targetField,
           fields,
           condition,
-          query
-        })
+          query,
+        });
         this.db.query(query, values, (err, rows) => {
           if (err) {
             this.logger.error(`[Pg][_getMinMax] ${minmax} query failed`, {
@@ -678,19 +607,19 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
               fields,
               condition,
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
             this.logger.debug(`[Pg][_getMinMax] ${minmax} query successful`, {
               tables,
-              rowCount: rows.rows.length
-            })
-            resolve(rows.rows)
+              rowCount: rows.rows.length,
+            });
+            resolve(rows.rows);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   getMaxWhereEqual(
@@ -698,21 +627,21 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     targetField: string,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMaxWhereEqualAndLower(
@@ -721,21 +650,21 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<',
-      ' AND ',
+      "<",
+      " AND ",
       filterFields2,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMinWhereEqualAndHigher(
@@ -744,21 +673,21 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MIN',
+      "MIN",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '>',
-      ' AND ',
+      ">",
+      " AND ",
       filterFields2,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMaxWhereEqualAndLowerJoin(
@@ -768,21 +697,21 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       tables,
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<',
-      ' AND ',
+      "<",
+      " AND ",
       filterFields2,
       joinFields,
-      order
-    )
+      order,
+    );
   }
 
   match(
@@ -790,125 +719,112 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     fields: string[],
     searchFields: string[],
     value: string | number,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[Pg][match] DB not ready', { table })
-        reject(new Error('Wait for database to be ready'))
+        this.logger.error("[Pg][match] DB not ready", { table });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        if (typeof searchFields !== 'object') searchFields = [searchFields]
-        if (typeof fields !== 'object') fields = [fields]
-        if (fields.length === 0) fields = ['*']
-        const values = searchFields.map(() => (value ? `%${value}%` : '%'))
-        let condition = searchFields
-          .map((f, i) => `${f} LIKE $${i + 1}`)
-          .join(' OR ')
-        if (order != null) condition += ` ORDER BY ${order}`
+        if (typeof searchFields !== "object") searchFields = [searchFields];
+        if (typeof fields !== "object") fields = [fields];
+        if (fields.length === 0) fields = ["*"];
+        const values = searchFields.map(() => (value ? `%${value}%` : "%"));
+        let condition = searchFields.map((f, i) => `${f} LIKE $${i + 1}`).join(" OR ");
+        if (order != null) condition += ` ORDER BY ${order}`;
 
-        const query = `SELECT ${fields.join(
-          ','
-        )} FROM ${table} WHERE ${condition}`
-        this.logger.debug('[Pg][match] Executing LIKE query', {
+        const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
+        this.logger.debug("[Pg][match] Executing LIKE query", {
           table,
           searchFields,
           value,
           fields,
-          query
-        })
+          query,
+        });
         this.db.query(query, values, (err, rows) => {
           if (err) {
-            this.logger.error('[Pg][match] Query failed', {
+            this.logger.error("[Pg][match] Query failed", {
               table,
               searchFields,
               value,
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[Pg][match] Query successful', {
+            this.logger.debug("[Pg][match] Query successful", {
               table,
-              rowCount: rows.rows.length
-            })
-            resolve(rows.rows)
+              rowCount: rows.rows.length,
+            });
+            resolve(rows.rows);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db == null) {
-        this.logger.error('[Pg][deleteEqual] DB not ready', { table, field })
-        reject(new Error('DB not ready'))
+        this.logger.error("[Pg][deleteEqual] DB not ready", { table, field });
+        reject(new Error("DB not ready"));
       } else {
-        if (
-          !field ||
-          field.length === 0 ||
-          !value ||
-          value.toString().length === 0
-        ) {
-          this.logger.error('[Pg][deleteEqual] Invalid parameters', {
+        if (!field || field.length === 0 || !value || value.toString().length === 0) {
+          this.logger.error("[Pg][deleteEqual] Invalid parameters", {
             table,
             field,
-            value
-          })
-          reject(
-            new Error(`Bad deleteEqual call, field: ${field}, value: ${value}`)
-          )
-          return
+            value,
+          });
+          reject(new Error(`Bad deleteEqual call, field: ${field}, value: ${value}`));
+          return;
         }
-        const query = `DELETE FROM ${table} WHERE ${field}=$1`
-        this.logger.debug('[Pg][deleteEqual] Executing', {
+        const query = `DELETE FROM ${table} WHERE ${field}=$1`;
+        this.logger.debug("[Pg][deleteEqual] Executing", {
           table,
           field,
-          query
-        })
+          query,
+        });
         this.db.query(
           query,
-          [value] as
-            | (string[] & Array<string | number>)
-            | (number[] & Array<string | number>),
+          [value] as (string[] & Array<string | number>) | (number[] & Array<string | number>),
           (err, rows) => {
             if (err) {
-              this.logger.error('[Pg][deleteEqual] Failed', {
+              this.logger.error("[Pg][deleteEqual] Failed", {
                 table,
                 field,
                 query,
-                error: err
-              })
-              reject(err)
+                error: err,
+              });
+              reject(err);
             } else {
-              this.logger.debug('[Pg][deleteEqual] Successful', {
+              this.logger.debug("[Pg][deleteEqual] Successful", {
                 table,
-                field
-              })
-              resolve()
+                field,
+              });
+              resolve();
             }
-          }
-        )
+          },
+        );
       }
-    })
+    });
   }
 
   deleteEqualAnd(
     table: T,
     condition1: {
-      field: string
-      value: string | number | Array<string | number>
+      field: string;
+      value: string | number | Array<string | number>;
     },
     condition2: {
-      field: string
-      value: string | number | Array<string | number>
-    }
+      field: string;
+      value: string | number | Array<string | number>;
+    },
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db == null) {
-        this.logger.error('[Pg][deleteEqualAnd] DB not ready', { table })
-        reject(new Error('DB not ready'))
+        this.logger.error("[Pg][deleteEqualAnd] DB not ready", { table });
+        reject(new Error("DB not ready"));
       } else {
         if (
           !condition1.field ||
@@ -920,25 +836,25 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           !condition2.value ||
           condition2.value.toString().length === 0
         ) {
-          this.logger.error('[Pg][deleteEqualAnd] Invalid parameters', {
+          this.logger.error("[Pg][deleteEqualAnd] Invalid parameters", {
             table,
             condition1: { field: condition1.field, value: condition1.value },
-            condition2: { field: condition2.field, value: condition2.value }
-          })
+            condition2: { field: condition2.field, value: condition2.value },
+          });
           reject(
             new Error(
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              `Bad deleteAnd call, conditions: ${condition1.field}=${condition1.value}, ${condition2.field}=${condition2.value}`
-            )
-          )
-          return
+              `Bad deleteAnd call, conditions: ${condition1.field}=${condition1.value}, ${condition2.field}=${condition2.value}`,
+            ),
+          );
+          return;
         }
-        const query = `DELETE FROM ${table} WHERE ${condition1.field}=$1 AND ${condition2.field}=$2`
-        this.logger.debug('[Pg][deleteEqualAnd] Executing', {
+        const query = `DELETE FROM ${table} WHERE ${condition1.field}=$1 AND ${condition2.field}=$2`;
+        this.logger.debug("[Pg][deleteEqualAnd] Executing", {
           table,
           conditions: [condition1.field, condition2.field],
-          query
-        })
+          query,
+        });
         this.db.query(
           query,
           [condition1.value, condition2.value] as
@@ -946,161 +862,135 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
             | (number[] & Array<string | number>),
           (err) => {
             if (err) {
-              this.logger.error('[Pg][deleteEqualAnd] Failed', {
+              this.logger.error("[Pg][deleteEqualAnd] Failed", {
                 table,
                 conditions: [condition1.field, condition2.field],
                 query,
-                error: err
-              })
-              reject(err)
+                error: err,
+              });
+              reject(err);
             } else {
-              this.logger.debug('[Pg][deleteEqualAnd] Successful', {
-                table
-              })
-              resolve()
+              this.logger.debug("[Pg][deleteEqualAnd] Successful", {
+                table,
+              });
+              resolve();
             }
-          }
-        )
+          },
+        );
       }
-    })
+    });
   }
 
-  deleteLowerThan(
-    table: T,
-    field: string,
-    value: string | number
-  ): Promise<void> {
+  deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db == null) {
-        this.logger.error('[Pg][deleteLowerThan] DB not ready', {
-          table,
-          field
-        })
-        reject(new Error('Database not ready'))
-      } else {
-        if (
-          !field ||
-          field.length === 0 ||
-          !value ||
-          value.toString().length === 0
-        ) {
-          this.logger.error('[Pg][deleteLowerThan] Invalid parameters', {
-            table,
-            field,
-            value
-          })
-          reject(
-            new Error(
-              `Bad deleteLowerThan call, field: ${field}, value: ${value}`
-            )
-          )
-          return
-        }
-        const query = `DELETE FROM ${table} WHERE ${field}<$1`
-        this.logger.debug('[Pg][deleteLowerThan] Executing', {
+        this.logger.error("[Pg][deleteLowerThan] DB not ready", {
           table,
           field,
-          query
-        })
+        });
+        reject(new Error("Database not ready"));
+      } else {
+        if (!field || field.length === 0 || !value || value.toString().length === 0) {
+          this.logger.error("[Pg][deleteLowerThan] Invalid parameters", {
+            table,
+            field,
+            value,
+          });
+          reject(new Error(`Bad deleteLowerThan call, field: ${field}, value: ${value}`));
+          return;
+        }
+        const query = `DELETE FROM ${table} WHERE ${field}<$1`;
+        this.logger.debug("[Pg][deleteLowerThan] Executing", {
+          table,
+          field,
+          query,
+        });
         this.db.query(
           query,
-          [value] as
-            | (string[] & Array<string | number>)
-            | (number[] & Array<string | number>),
+          [value] as (string[] & Array<string | number>) | (number[] & Array<string | number>),
           (err) => {
             if (err) {
-              this.logger.error('[Pg][deleteLowerThan] Failed', {
+              this.logger.error("[Pg][deleteLowerThan] Failed", {
                 table,
                 field,
                 query,
-                error: err
-              })
-              reject(err)
+                error: err,
+              });
+              reject(err);
             } else {
-              this.logger.debug('[Pg][deleteLowerThan] Successful', {
+              this.logger.debug("[Pg][deleteLowerThan] Successful", {
                 table,
-                field
-              })
-              resolve()
+                field,
+              });
+              resolve();
             }
-          }
-        )
+          },
+        );
       }
-    })
+    });
   }
 
-  deleteWhere(
-    table: T,
-    conditions: ISQLCondition | ISQLCondition[]
-  ): Promise<void> {
+  deleteWhere(table: T, conditions: ISQLCondition | ISQLCondition[]): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db == null) {
-        this.logger.error('[Pg][deleteWhere] DB not ready', { table })
-        reject(new Error('Database not ready'))
+        this.logger.error("[Pg][deleteWhere] DB not ready", { table });
+        reject(new Error("Database not ready"));
       } else {
-        if (!Array.isArray(conditions)) conditions = [conditions]
+        if (!Array.isArray(conditions)) conditions = [conditions];
 
-        const values = conditions.map((c) => c.value)
-        const filters = conditions.map((c) => c.field)
-        const operators = conditions.map((c) => c.operator)
+        const values = conditions.map((c) => c.value);
+        const filters = conditions.map((c) => c.field);
+        const operators = conditions.map((c) => c.operator);
 
-        let condition: string = ''
-        if (
-          values != null &&
-          values.length > 0 &&
-          filters.length === values.length
-        ) {
+        let condition: string = "";
+        if (values != null && values.length > 0 && filters.length === values.length) {
           // Verifies that values have at least one element, and as much filter names
-          let i = 0
+          let i = 0;
           condition = filters
             .map((filt, index) => {
-              i++
-              return `${filt}${operators[index] ?? '='}$${i}`
+              i++;
+              return `${filt}${operators[index] ?? "="}$${i}`;
             })
-            .join(' AND ')
+            .join(" AND ");
         }
 
-        const query = `DELETE FROM ${table} WHERE ${condition}`
-        this.logger.debug('[Pg][deleteWhere] Executing', {
+        const query = `DELETE FROM ${table} WHERE ${condition}`;
+        this.logger.debug("[Pg][deleteWhere] Executing", {
           table,
           conditions: filters,
           operators,
-          query
-        })
+          query,
+        });
         this.db.query(
           query,
-          values as
-            | (string[] & Array<string | number>)
-            | (number[] & Array<string | number>),
+          values as (string[] & Array<string | number>) | (number[] & Array<string | number>),
           (err) => {
             if (err) {
-              this.logger.error('[Pg][deleteWhere] Failed', {
+              this.logger.error("[Pg][deleteWhere] Failed", {
                 table,
                 conditions: filters,
                 operators,
                 values,
                 query,
-                error: err
-              })
-              reject(err)
+                error: err,
+              });
+              reject(err);
             } else {
-              this.logger.debug('[Pg][deleteWhere] Successful', {
-                table
-              })
-              resolve()
+              this.logger.debug("[Pg][deleteWhere] Successful", {
+                table,
+              });
+              resolve();
             }
-          }
-        )
+          },
+        );
       }
-    })
+    });
   }
 
   async getTableColumns(table: T): Promise<ColumnInfo[]> {
     if (!this.db) {
-      this.logger.error(
-        `[Pg][getTableColumns] DB not ready for table "${table}"`
-      )
-      throw new Error('DB not ready')
+      this.logger.error(`[Pg][getTableColumns] DB not ready for table "${table}"`);
+      throw new Error("DB not ready");
     }
 
     const query = `
@@ -1108,27 +998,22 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
       FROM information_schema.columns
       WHERE table_schema = current_schema()
         AND table_name = $1
-  	`
+  	`;
 
     try {
-      const result = await this.db.query(query, [table.toLowerCase()])
+      const result = await this.db.query(query, [table.toLowerCase()]);
       const columns: ColumnInfo[] = result.rows.map((row) => ({
         name: row.column_name,
         type: row.data_type,
-        defaultValue: row.column_default
-      }))
+        defaultValue: row.column_default,
+      }));
 
-      this.logger.debug(
-        `[Pg][getTableColumns] Found ${columns.length} column(s) in "${table}"`
-      )
+      this.logger.debug(`[Pg][getTableColumns] Found ${columns.length} column(s) in "${table}"`);
 
-      return columns
+      return columns;
     } catch (err) {
-      this.logger.error(
-        `[Pg][getTableColumns] Failed to get columns for "${table}"`,
-        err
-      )
-      throw err
+      this.logger.error(`[Pg][getTableColumns] Failed to get columns for "${table}"`, err);
+      throw err;
     }
   }
 
@@ -1137,14 +1022,14 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
    * Only allows alphanumeric characters and underscores, must start with letter or underscore.
    */
   #isValidIdentifier(name: string): boolean {
-    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name)
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
   }
 
   /**
    * Quotes an SQL identifier using double quotes, escaping any internal double quotes.
    */
   #quoteIdentifier(name: string): string {
-    return `"${name.replace(/"/g, '""')}"`
+    return `"${name.replace(/"/g, '""')}"`;
   }
 
   /**
@@ -1152,125 +1037,112 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
    */
   #isValidColumnType(type: string): boolean {
     const typePattern =
-      /^(varchar|char|text|int|integer|smallint|bigint|serial|bigserial|boolean|bool|real|double precision|numeric|decimal|date|time|timestamp|timestamptz|json|jsonb|uuid|bytea)(\(\d+\))?$/i
-    return typePattern.test(type.trim())
+      /^(varchar|char|text|int|integer|smallint|bigint|serial|bigserial|boolean|bool|real|double precision|numeric|decimal|date|time|timestamp|timestamptz|json|jsonb|uuid|bytea)(\(\d+\))?$/i;
+    return typePattern.test(type.trim());
   }
 
   /**
    * Escapes a string value for use in SQL by doubling single quotes.
    */
   #escapeString(value: string): string {
-    return value.replace(/'/g, "''")
+    return value.replace(/'/g, "''");
   }
 
   async addColumn(table: T, column: ColumnDefinition): Promise<void> {
     if (!this.db) {
-      this.logger.error('[Pg][addColumn] DB not ready', table, column)
-      throw new Error('DB not ready')
+      this.logger.error("[Pg][addColumn] DB not ready", table, column);
+      throw new Error("DB not ready");
     }
 
     /* Validate identifiers to prevent SQL injection */
     if (!this.#isValidIdentifier(table)) {
-      this.logger.error('[Pg][addColumn] Invalid table name', table, column)
-      throw new Error(`Invalid table name: ${table}`)
+      this.logger.error("[Pg][addColumn] Invalid table name", table, column);
+      throw new Error(`Invalid table name: ${table}`);
     }
 
     if (!this.#isValidIdentifier(column.name)) {
-      this.logger.error('[Pg][addColumn] Invalid column name', table, column)
-      throw new Error(`Invalid column name: ${column.name}`)
+      this.logger.error("[Pg][addColumn] Invalid column name", table, column);
+      throw new Error(`Invalid column name: ${column.name}`);
     }
 
     if (!this.#isValidColumnType(column.type)) {
-      this.logger.error('[Pg][addColumn] Invalid column type', table, column)
-      throw new Error(`Invalid column type: ${column.type}`)
+      this.logger.error("[Pg][addColumn] Invalid column type", table, column);
+      throw new Error(`Invalid column type: ${column.type}`);
     }
 
     /* Build query with quoted identifiers */
-    const quotedTable = this.#quoteIdentifier(table)
-    const quotedColumn = this.#quoteIdentifier(column.name)
-    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${column.type}`
+    const quotedTable = this.#quoteIdentifier(table);
+    const quotedColumn = this.#quoteIdentifier(column.name);
+    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${column.type}`;
 
     /* Handle default value with proper escaping (no params for DDL) */
     if (column.default !== undefined) {
       if (column.default === null) {
-        query += ' DEFAULT NULL'
-      } else if (typeof column.default === 'number') {
-        query += ` DEFAULT ${column.default}`
-      } else if (typeof column.default === 'boolean') {
-        query += ` DEFAULT ${column.default}`
+        query += " DEFAULT NULL";
+      } else if (typeof column.default === "number") {
+        query += ` DEFAULT ${column.default}`;
+      } else if (typeof column.default === "boolean") {
+        query += ` DEFAULT ${column.default}`;
       } else {
         /* Escape string and use literal */
-        query += ` DEFAULT '${this.#escapeString(column.default)}'`
+        query += ` DEFAULT '${this.#escapeString(column.default)}'`;
       }
     }
 
     /* Handle NOT NULL constraint if specified */
     if (column.notNull) {
-      query += ' NOT NULL'
+      query += " NOT NULL";
     }
 
     /* Capture db reference to avoid undefined in callback */
-    const db = this.db
+    const db = this.db;
 
     return new Promise((resolve, reject) => {
       db.query(query, (err) => {
         if (err) {
-          const pgError = err as { code?: string }
-          if (pgError.code === '42701') {
-            this.logger.debug(
-              `[Pg][addColumn] Column "${column.name}" already exists in "${table}"`
-            )
-            resolve()
-            return
+          const pgError = err as { code?: string };
+          if (pgError.code === "42701") {
+            this.logger.debug(`[Pg][addColumn] Column "${column.name}" already exists in "${table}"`);
+            resolve();
+            return;
           }
-          this.logger.error(
-            `[Pg][addColumn] Failed to add column "${column.name}" to "${table}"`,
-            err
-          )
-          reject(err)
+          this.logger.error(`[Pg][addColumn] Failed to add column "${column.name}" to "${table}"`, err);
+          reject(err);
         } else {
-          this.logger.info(
-            `[Pg][addColumn] Added column "${column.name}" to "${table}"`
-          )
-          resolve()
+          this.logger.info(`[Pg][addColumn] Added column "${column.name}" to "${table}"`);
+          resolve();
         }
-      })
-    })
+      });
+    });
   }
 
   async ensureColumns(table: T, columns: ColumnDefinition[]): Promise<void> {
-    const existingColumns = await this.getTableColumns(table)
-    const existingNames = new Set(
-      existingColumns.map((c) => c.name.toLowerCase())
-    )
+    const existingColumns = await this.getTableColumns(table);
+    const existingNames = new Set(existingColumns.map((c) => c.name.toLowerCase()));
 
-    const missingColumns = columns.filter(
-      (col) => !existingNames.has(col.name.toLowerCase())
-    )
+    const missingColumns = columns.filter((col) => !existingNames.has(col.name.toLowerCase()));
 
     if (missingColumns.length === 0) {
-      this.logger.debug(`[Pg][ensureColumns] All columns exist in "${table}"`)
-      return
+      this.logger.debug(`[Pg][ensureColumns] All columns exist in "${table}"`);
+      return;
     }
 
     this.logger.info(
-      `[Pg][ensureColumns] Adding ${
-        missingColumns.length
-      } missing column(s) to "${table}": ${missingColumns
+      `[Pg][ensureColumns] Adding ${missingColumns.length} missing column(s) to "${table}": ${missingColumns
         .map((c) => c.name)
-        .join(', ')}`
-    )
+        .join(", ")}`,
+    );
 
     for (const col of missingColumns) {
-      await this.addColumn(table, col)
+      await this.addColumn(table, col);
     }
 
-    this.logger.info(`[Pg][ensureColumns] Schema updated for "${table}"`)
+    this.logger.info(`[Pg][ensureColumns] Schema updated for "${table}"`);
   }
 
   close(): void {
-    void this.db?.end()
+    void this.db?.end();
   }
 }
 
-export default Pg
+export default Pg;

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -28,10 +28,10 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
             // @ts-expect-error
             if (pg.Database === null) pg = pg.default;
             if (
-              conf.database_host === null ||
-              conf.database_user === null ||
-              conf.database_password === null ||
-              conf.database_name === null
+              !conf.database_host ||
+              !conf.database_user ||
+              !conf.database_password ||
+              !conf.database_name
             ) {
               throw new Error("database_name, database_user and database_password are required when using Postgres");
             }

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -19,19 +19,19 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db != null) {
+      if (this.db !== null) {
         createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
         import("pg")
           .then((pg) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
-            if (pg.Database == null) pg = pg.default;
+            if (pg.Database === null) pg = pg.default;
             if (
-              conf.database_host == null ||
-              conf.database_user == null ||
-              conf.database_password == null ||
-              conf.database_name == null
+              conf.database_host === null ||
+              conf.database_user === null ||
+              conf.database_password === null ||
+              conf.database_name === null
             ) {
               throw new Error("database_name, database_user and database_password are required when using Postgres");
             }
@@ -45,7 +45,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (conf.database_host.match(/^(.*):(\d+)/)) {
               opts.host = RegExp.$1;
-              opts.port = parseInt(RegExp.$2);
+              opts.port = parseInt(RegExp.$2, 10);
             }
             try {
               this.db = new pg.Pool(opts);
@@ -65,7 +65,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   }
 
   rawQuery(query: string): Promise<any> {
-    if (this.db == null) {
+    if (!this.db) {
       this.logger.error("[Pg][rawQuery] DB not ready");
       return Promise.reject(new Error("DB not ready"));
     }
@@ -78,11 +78,11 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
 
   exists(table: T): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      if (this.db != null) {
+      if (this.db) {
         const query = `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename='${table.toLowerCase()}')`;
         this.logger.debug("[Pg][exists] Checking table", { table });
         this.db.query(query, (err, res) => {
-          if (err == null) {
+          if (err === null) {
             this.logger.debug("[Pg][exists] Check completed", {
               table,
               exists: res.rows[0].exists,
@@ -106,7 +106,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][insert] DB not ready", { table });
         throw new Error("Wait for database to be ready");
       }
@@ -117,7 +117,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         vals.push(values[k]);
       });
       const query = `INSERT INTO ${table}(${names.join(",")}) VALUES(${names
-        .map((v, i) => `$${i + 1}`)
+        .map((_v, i) => `$${i + 1}`)
         .join(",")}) RETURNING *;`;
       this.logger.debug("[Pg][insert] Executing", {
         table,
@@ -153,7 +153,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][update] DB not ready", { table, field });
         reject(new Error("Wait for database to be ready"));
       } else {
@@ -203,7 +203,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][updateAnd] DB not ready", {
           table,
           conditions: [condition1.field, condition2.field],
@@ -266,12 +266,12 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         reject(new Error("Wait for database to be ready"));
       } else {
         let condition: string = "";
         const values: string[] = [];
-        if (fields == null || fields.length === 0) {
+        if (!fields || fields.length === 0) {
           fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
@@ -293,7 +293,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -314,19 +314,19 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
             : "";
         const condition2 =
-          op2 != null && linkop1 != null && filterFields2 != null && Object.keys(filterFields2).length > 0
+          op2 && linkop1 && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
         const condition3 =
-          op3 != null && linkop2 != null && filterFields3 != null && Object.keys(filterFields3).length > 0
+          op3 && linkop2 && filterFields3 && Object.keys(filterFields3).length > 0
             ? buildCondition(op3, filterFields3)
             : "";
 
-        condition += condition1 !== "" ? "WHERE " + condition1 : "";
+        condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -338,10 +338,10 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
               (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
             : "";
 
-        if (joinFields != null) {
+        if (joinFields) {
           let joinCondition = "";
           Object.keys(joinFields)
-            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
+            .filter((key) => joinFields[key] && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
               joinCondition += joinCondition !== "" ? " AND " : "";
               joinCondition += `${key}=${joinFields[key]}`;
@@ -350,7 +350,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`;
+        if (order !== null) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(",")} FROM ${tables.join(",")} ${condition}`;
         this.logger.debug("[Pg][_get] Executing SELECT", {
@@ -509,12 +509,12 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         reject(new Error("Wait for database to be ready"));
       } else {
         let condition: string = "";
         const values: string[] = [];
-        if (fields == null || fields.length === 0) {
+        if (!fields || fields.length === 0) {
           fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
@@ -537,7 +537,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -558,25 +558,25 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
             : "";
         const condition2 =
-          op2 != null && linkop != null && filterFields2 != null && Object.keys(filterFields2).length > 0
+          op2 && linkop && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
 
-        condition += condition1 !== "" ? "WHERE " + condition1 : "";
+        condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition ? ` ${linkop} ` : "WHERE ") + condition2
             : "";
 
-        if (joinFields != null) {
+        if (joinFields) {
           let joinCondition = "";
           Object.keys(joinFields)
-            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
+            .filter((key) => joinFields[key] && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
               joinCondition += joinCondition !== "" ? " AND " : "";
               joinCondition += `${key}=${joinFields[key]}`;
@@ -585,7 +585,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(
           ",",
@@ -723,7 +723,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][match] DB not ready", { table });
         reject(new Error("Wait for database to be ready"));
       } else {
@@ -732,7 +732,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         if (fields.length === 0) fields = ["*"];
         const values = searchFields.map(() => (value ? `%${value}%` : "%"));
         let condition = searchFields.map((f, i) => `${f} LIKE $${i + 1}`).join(" OR ");
-        if (order != null) condition += ` ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
         this.logger.debug("[Pg][match] Executing LIKE query", {
@@ -766,7 +766,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
 
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][deleteEqual] DB not ready", { table, field });
         reject(new Error("DB not ready"));
       } else {
@@ -788,7 +788,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         this.db.query(
           query,
           [value] as (string[] & Array<string | number>) | (number[] & Array<string | number>),
-          (err, rows) => {
+          (err, _rows) => {
             if (err) {
               this.logger.error("[Pg][deleteEqual] Failed", {
                 table,
@@ -822,7 +822,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     },
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][deleteEqualAnd] DB not ready", { table });
         reject(new Error("DB not ready"));
       } else {
@@ -883,7 +883,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
 
   deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][deleteLowerThan] DB not ready", {
           table,
           field,
@@ -932,7 +932,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
 
   deleteWhere(table: T, conditions: ISQLCondition | ISQLCondition[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[Pg][deleteWhere] DB not ready", { table });
         reject(new Error("Database not ready"));
       } else {
@@ -943,7 +943,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         const operators = conditions.map((c) => c.operator);
 
         let condition: string = "";
-        if (values != null && values.length > 0 && filters.length === values.length) {
+        if (values && values.length > 0 && filters.length === values.length) {
           // Verifies that values have at least one element, and as much filter names
           let i = 0;
           condition = filters

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -26,7 +26,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           .then((pg) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
-            if (pg.Database === null) pg = pg.default;
+            if (!pg.Database) pg = pg.default;
             if (
               !conf.database_host ||
               !conf.database_user ||
@@ -82,7 +82,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
         const query = `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename='${table.toLowerCase()}')`;
         this.logger.debug("[Pg][exists] Checking table", { table });
         this.db.query(query, (err, res) => {
-          if (err === null) {
+          if (err === null || err === undefined) {
             this.logger.debug("[Pg][exists] Check completed", {
               table,
               exists: res.rows[0].exists,

--- a/packages/db/src/sql/sql.ts
+++ b/packages/db/src/sql/sql.ts
@@ -28,7 +28,6 @@ abstract class SQL<T extends string> {
     this.ready = this.createDatabases(conf, tables, indexes, initializeValues, this.logger);
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return new Promise((resolve, reject) => {
       const args: any[] = [table, [`count(${field}) as count`]];
@@ -45,7 +44,6 @@ abstract class SQL<T extends string> {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getAll(table: T, fields: string[], order?: string): Promise<DbGetResult> {
     // @ts-expect-error implemented later
     return this.get(table, fields, undefined, order);

--- a/packages/db/src/sql/sql.ts
+++ b/packages/db/src/sql/sql.ts
@@ -32,11 +32,11 @@ abstract class SQL<T extends string> {
   getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return new Promise((resolve, reject) => {
       const args: any[] = [table, [`count(${field}) as count`]];
-      if (value != null) args.push({ [field]: value });
+      if (value !== null) args.push({ [field]: value });
       // @ts-expect-error implemented later
       this.get(...args)
         .then((rows: Array<Record<string, string>>) => {
-          resolve(parseInt(rows[0].count));
+          resolve(parseInt(rows[0].count, 10));
         })
         .catch((e: any) => {
           /* istanbul ignore next */

--- a/packages/db/src/sql/sql.ts
+++ b/packages/db/src/sql/sql.ts
@@ -1,67 +1,55 @@
-import { type TwakeLogger } from '@twake/logger'
-import { type DatabaseConfig, type DbGetResult } from '../types'
-import { type PgDatabase } from './pg'
-import { type SQLiteDatabase } from './sqlite'
+import type { TwakeLogger } from "@twake/logger";
+import type { DatabaseConfig, DbGetResult } from "../types";
+import type { PgDatabase } from "./pg";
+import type { SQLiteDatabase } from "./sqlite";
 
 export type CreateDbMethod<T extends string> = (
   conf: DatabaseConfig,
   tables: Record<T, string>,
   indexes: Partial<Record<T, string[]>>,
-  initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>
-) => Promise<void>
+  initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
+) => Promise<void>;
 
 abstract class SQL<T extends string> {
-  db?: SQLiteDatabase | PgDatabase
-  ready: Promise<void>
-  cleanJob?: NodeJS.Timeout
-  protected readonly logger: TwakeLogger
+  db?: SQLiteDatabase | PgDatabase;
+  ready: Promise<void>;
+  cleanJob?: NodeJS.Timeout;
+  protected readonly logger: TwakeLogger;
 
   constructor(
     conf: DatabaseConfig,
     logger: TwakeLogger,
     tables?: Record<T, string>,
     indexes?: Partial<Record<T, string[]>>,
-    initializeValues?: Partial<
-      Record<T, Array<Record<string, string | number>>>
-    >
+    initializeValues?: Partial<Record<T, Array<Record<string, string | number>>>>,
   ) {
-    this.logger = logger
+    this.logger = logger;
     // @ts-expect-error method is defined in child class
-    this.ready = this.createDatabases(
-      conf,
-      tables,
-      indexes,
-      initializeValues,
-      this.logger
-    )
+    this.ready = this.createDatabases(conf, tables, indexes, initializeValues, this.logger);
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  getCount(
-    table: T,
-    field: string,
-    value?: string | number | string[]
-  ): Promise<number> {
+  getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return new Promise((resolve, reject) => {
-      const args: any[] = [table, [`count(${field}) as count`]]
-      if (value != null) args.push({ [field]: value })
+      const args: any[] = [table, [`count(${field}) as count`]];
+      if (value != null) args.push({ [field]: value });
       // @ts-expect-error implemented later
       this.get(...args)
         .then((rows: Array<Record<string, string>>) => {
-          resolve(parseInt(rows[0].count))
+          resolve(parseInt(rows[0].count));
         })
         .catch((e: any) => {
           /* istanbul ignore next */
-          reject(e)
-        })
-    })
+          reject(e);
+        });
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   getAll(table: T, fields: string[], order?: string): Promise<DbGetResult> {
     // @ts-expect-error implemented later
-    return this.get(table, fields, undefined, order)
+    return this.get(table, fields, undefined, order);
   }
 }
 
-export default SQL
+export default SQL;

--- a/packages/db/src/sql/sql.ts
+++ b/packages/db/src/sql/sql.ts
@@ -32,7 +32,7 @@ abstract class SQL<T extends string> {
   getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return new Promise((resolve, reject) => {
       const args: any[] = [table, [`count(${field}) as count`]];
-      if (value !== null) args.push({ [field]: value });
+      if (value !== null && value !== undefined) args.push({ [field]: value });
       // @ts-expect-error implemented later
       this.get(...args)
         .then((rows: Array<Record<string, string>>) => {

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -26,10 +26,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           .then((sqlite3) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
-            if (sqlite3.Database === null) sqlite3 = sqlite3.default;
+            if (!sqlite3.Database) sqlite3 = sqlite3.default;
             const db = (this.db = new sqlite3.Database(conf.database_host));
             /* istanbul ignore if */
-            if (db === null) {
+            if (!db) {
               throw new Error("Database not created");
             }
             logger.info("[Db:SQLite] connected.");
@@ -52,7 +52,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       }
       this.logger.debug("[SQLite][rawQuery] Executing query", { query });
       this.db.run(query, (err) => {
-        if (err === null) {
+        if (err === null || err === undefined) {
           this.logger.debug("[SQLite][rawQuery] Query successful", { query });
           resolve();
         } else {
@@ -1115,7 +1115,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
        * SQLite doesn't support parameterized DEFAULT in ALTER TABLE,
        * so we must use literal values with proper escaping
        */
-      if (column.default === null) {
+      if (column.default === null || column.default === undefined) {
         query += " DEFAULT NULL";
       } else if (typeof column.default === "number") {
         query += ` DEFAULT ${column.default}`;

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -19,17 +19,17 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db != null) {
+      if (this.db !== null) {
         createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
         import("sqlite3")
           .then((sqlite3) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
-            if (sqlite3.Database == null) sqlite3 = sqlite3.default;
+            if (sqlite3.Database === null) sqlite3 = sqlite3.default;
             const db = (this.db = new sqlite3.Database(conf.database_host));
             /* istanbul ignore if */
-            if (db == null) {
+            if (db === null) {
               throw new Error("Database not created");
             }
             logger.info("[Db:SQLite] connected.");
@@ -45,14 +45,14 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
 
   rawQuery(query: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][rawQuery] DB not ready");
         reject(new Error("DB not ready"));
         return;
       }
       this.logger.debug("[SQLite][rawQuery] Executing query", { query });
       this.db.run(query, (err) => {
-        if (err == null) {
+        if (err === null) {
           this.logger.debug("[SQLite][rawQuery] Query successful", { query });
           resolve();
         } else {
@@ -74,7 +74,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][insert] DB not ready", { table });
         throw new Error("Wait for database to be ready");
       }
@@ -84,7 +84,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         names.push(k);
         vals.push(values[k]);
       });
-      const query = `INSERT INTO ${table}(${names.join(",")}) VALUES(${names.map((v) => "?").join(",")}) RETURNING *;`;
+      const query = `INSERT INTO ${table}(${names.join(",")}) VALUES(${names.map((_v) => "?").join(",")}) RETURNING *;`;
       this.logger.debug("[SQLite][insert] Executing", {
         table,
         fields: names,
@@ -93,7 +93,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
         /* istanbul ignore if */
-        if (err != null) {
+        if (err !== null) {
           this.logger.error("[SQLite][insert] Failed", {
             table,
             fields: names,
@@ -130,7 +130,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][update] DB not ready", { table, field });
         throw new Error("Wait for database to be ready");
       }
@@ -151,7 +151,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
         /* istanbul ignore if */
-        if (err != null) {
+        if (err !== null) {
           this.logger.error("[SQLite][update] Failed", {
             table,
             fields: names,
@@ -189,7 +189,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][updateAnd] DB not ready", {
           table,
           conditions: [condition1.field, condition2.field],
@@ -211,7 +211,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
 
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
-        if (err != null) {
+        if (err !== null) {
           this.logger.error("[SQLite][updateAnd] Failed", {
             table,
             fields: names,
@@ -255,12 +255,12 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         reject(new Error("Wait for database to be ready"));
       } else {
         let condition: string = "";
         const values: string[] = [];
-        if (fields == null || fields.length === 0) {
+        if (!fields || fields.length === 0) {
           fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
@@ -282,7 +282,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -303,19 +303,19 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
             : "";
         const condition2 =
-          op2 != null && linkop1 != null && filterFields2 != null && Object.keys(filterFields2).length > 0
+          op2 && linkop1 && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
         const condition3 =
-          op3 != null && linkop2 != null && filterFields3 != null && Object.keys(filterFields3).length > 0
+          op3 && linkop2 && filterFields3 && Object.keys(filterFields3).length > 0
             ? buildCondition(op3, filterFields3)
             : "";
 
-        condition += condition1 !== "" ? "WHERE " + condition1 : "";
+        condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -327,10 +327,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
               (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
             : "";
 
-        if (joinFields != null) {
+        if (joinFields) {
           let joinCondition = "";
           Object.keys(joinFields)
-            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
+            .filter((key) => joinFields[key] && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
               joinCondition += joinCondition !== "" ? " AND " : "";
               joinCondition += `${key}=${joinFields[key]}`;
@@ -339,7 +339,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(",")} FROM ${tables.join(",")} ${condition}`;
         this.logger.debug("[SQLite][_get] Executing SELECT", {
@@ -348,12 +348,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition,
           query,
         });
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-expect-error never undefined
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err != null) {
+          if (err !== null) {
             this.logger.error("[SQLite][_get] SELECT failed", {
               tables,
               fields,
@@ -511,12 +509,12 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         reject(new Error("Wait for database to be ready"));
       } else {
         let condition: string = "";
         const values: string[] = [];
-        if (fields == null || fields.length === 0) {
+        if (!fields || fields.length === 0) {
           fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
@@ -539,7 +537,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -560,25 +558,25 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
             : "";
         const condition2 =
-          op2 != null && linkop != null && filterFields2 != null && Object.keys(filterFields2).length > 0
+          op2 && linkop && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
 
-        condition += condition1 !== "" ? "WHERE " + condition1 : "";
+        condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop} ` : "WHERE ") + condition2
             : "";
 
-        if (joinFields != null) {
+        if (joinFields) {
           let joinCondition = "";
           Object.keys(joinFields)
-            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
+            .filter((key) => joinFields[key] && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
               joinCondition += joinCondition !== "" ? " AND " : "";
               joinCondition += `${key}=${joinFields[key]}`;
@@ -587,7 +585,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(
           ",",
@@ -601,12 +599,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition,
           query,
         });
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-expect-error never undefined
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err != null) {
+          if (err !== null) {
             this.logger.error(`${minmax} query failed`, {
               tables,
               targetField,
@@ -738,7 +734,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][match] DB not ready", { table });
         reject(new Error("Wait for database to be ready"));
       } else {
@@ -747,7 +743,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         if (fields.length === 0) fields = ["*"];
         const values = searchFields.map(() => `%${value}%`);
         let condition = searchFields.map((f) => `${f} LIKE ?`).join(" OR ");
-        if (order != null) condition += `ORDER BY ${order}`;
+        if (order !== null) condition += `ORDER BY ${order}`;
         const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
         this.logger.debug("[SQLite][match] Executing LIKE query", {
           table,
@@ -759,7 +755,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err != null) {
+          if (err !== null) {
             this.logger.error("[SQLite][match] Query failed", {
               table,
               searchFields,
@@ -792,7 +788,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][deleteEqual] DB not ready", {
           table,
           field,
@@ -806,9 +802,9 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           query,
         });
         const stmt = this.db.prepare(query);
-        stmt.all([value], (err, rows) => {
+        stmt.all([value], (err, _rows) => {
           /* istanbul ignore if */
-          if (err != null) {
+          if (err !== null) {
             this.logger.error("DELETE failed", {
               table,
               field,
@@ -850,7 +846,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][deleteEqualAnd] DB not ready", { table });
         reject(new Error("Wait for database to be ready"));
       } else {
@@ -861,9 +857,9 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           query,
         });
         const stmt = this.db.prepare(query);
-        stmt.all([condition1.value, condition2.value], (err, rows) => {
+        stmt.all([condition1.value, condition2.value], (err, _rows) => {
           /* istanbul ignore if */
-          if (err != null) {
+          if (err !== null) {
             this.logger.error("[SQLite][deleteEqualAnd] Failed", {
               table,
               conditions: [condition1.field, condition2.field],
@@ -891,7 +887,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
   deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][deleteLowerThan] DB not ready", {
           table,
           field,
@@ -907,7 +903,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all([value], (err) => {
         /* istanbul ignore if */
-        if (err != null) {
+        if (err !== null) {
           this.logger.error("[SQLite][deleteLowerThan] Failed", {
             table,
             field,
@@ -942,7 +938,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     // Adaptation of the method get, with the delete keyword, 'AND' instead of 'OR', and with filters instead of fields
     return new Promise((resolve, reject) => {
       // istanbul ignore if
-      if (this.db == null) {
+      if (!this.db) {
         this.logger.error("[SQLite][deleteWhere] DB not ready", { table });
         reject(new Error("Wait for database to be ready"));
       } else {
@@ -953,7 +949,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const operators = conditions.map((c) => c.operator);
 
         let condition: string = "";
-        if (values != null && values.length > 0 && filters.length === values.length) {
+        if (values !== null && values.length > 0 && filters.length === values.length) {
           // Verifies that values have at least one element, and as much filter names
           condition = filters.map((filt, i) => `${filt}${operators[i] ?? "="}?`).join(" AND ");
         }
@@ -965,15 +961,13 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           operators,
           query,
         });
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-expect-error never undefined
         const stmt = this.db.prepare(query);
 
         stmt.all(
           values, // The statement fills the values properly.
           (err: string) => {
             /* istanbul ignore if */
-            if (err != null) {
+            if (err !== null) {
               this.logger.error("[SQLite][deleteWhere] Failed", {
                 table,
                 conditions: filters,

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -743,7 +743,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         if (fields.length === 0) fields = ["*"];
         const values = searchFields.map(() => `%${value}%`);
         let condition = searchFields.map((f) => `${f} LIKE ?`).join(" OR ");
-        if (order) condition += `ORDER BY ${order}`;
+        if (order) condition += ` ORDER BY ${order}`;
         const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
         this.logger.debug("[SQLite][match] Executing LIKE query", {
           table,

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/promise-function-async */
 import type { TwakeLogger } from "@twake/logger";
 import type { Database, Statement } from "sqlite3";
 import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "../types";
@@ -24,10 +23,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       } else {
         import("sqlite3")
           .then((sqlite3) => {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
             // @ts-expect-error
             if (!sqlite3.Database) sqlite3 = sqlite3.default;
-            const db = (this.db = new sqlite3.Database(conf.database_host));
+            this.db = new sqlite3.Database(conf.database_host)
+            const db = this.db;
             /* istanbul ignore if */
             if (!db) {
               throw new Error("Database not created");
@@ -230,7 +229,6 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       });
 
       stmt.finalize((err) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (err) {
           this.logger.error("UPDATE with AND conditions statement finalize failed", { table, error: err });
           reject(err);
@@ -318,12 +316,10 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
             : "";
         condition +=
           condition3 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
             : "";
 
@@ -569,7 +565,6 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
         condition +=
           condition2 !== ""
-            ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               (condition !== "" ? ` ${linkop} ` : "WHERE ") + condition2
             : "";
 
@@ -1115,7 +1110,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
        * SQLite doesn't support parameterized DEFAULT in ALTER TABLE,
        * so we must use literal values with proper escaping
        */
-      if (column.default === null || column.default === undefined) {
+      if (column.default === null) {
         query += " DEFAULT NULL";
       } else if (typeof column.default === "number") {
         query += ` DEFAULT ${column.default}`;

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -1,221 +1,183 @@
 /* eslint-disable @typescript-eslint/promise-function-async */
-import { type TwakeLogger } from '@twake/logger'
-import { type Database, type Statement } from 'sqlite3'
-import {
-  type DatabaseConfig,
-  type DbGetResult,
-  type DbBackend,
-  type ISQLCondition,
-  type ColumnDefinition,
-  type ColumnInfo
-} from '../types'
-import createTables from './_createTables'
-import SQL from './sql'
+import type { TwakeLogger } from "@twake/logger";
+import type { Database, Statement } from "sqlite3";
+import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "../types";
+import createTables from "./_createTables";
+import SQL from "./sql";
 
-export type SQLiteDatabase = Database
+export type SQLiteDatabase = Database;
 
-export type SQLiteStatement = Statement
+export type SQLiteStatement = Statement;
 
 class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
-  declare db?: SQLiteDatabase
+  declare db?: SQLiteDatabase;
   createDatabases(
     conf: DatabaseConfig,
     tables: Record<T, string>,
     indexes: Partial<Record<T, string[]>>,
-    initializeValues: Partial<
-      Record<T, Array<Record<string, string | number>>>
-    >,
-    logger: TwakeLogger
+    initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
+    logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db != null) {
-        createTables(
-          this,
-          tables,
-          indexes,
-          initializeValues,
-          logger,
-          resolve,
-          reject
-        )
+        createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
-        import('sqlite3')
+        import("sqlite3")
           .then((sqlite3) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-            // @ts-ignore
-            if (sqlite3.Database == null) sqlite3 = sqlite3.default
-            const db = (this.db = new sqlite3.Database(conf.database_host))
+            // @ts-expect-error
+            if (sqlite3.Database == null) sqlite3 = sqlite3.default;
+            const db = (this.db = new sqlite3.Database(conf.database_host));
             /* istanbul ignore if */
             if (db == null) {
-              throw new Error('Database not created')
+              throw new Error("Database not created");
             }
-            logger.info('[Db:SQLite] connected.')
-            createTables(
-              this,
-              tables,
-              indexes,
-              initializeValues,
-              logger,
-              resolve,
-              reject
-            )
+            logger.info("[Db:SQLite] connected.");
+            createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
           })
           .catch((e) => {
             /* istanbul ignore next */
-            throw e
-          })
+            throw e;
+          });
       }
-    })
+    });
   }
 
   rawQuery(query: string): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.db == null) {
-        this.logger.error('[SQLite][rawQuery] DB not ready')
-        reject(new Error('DB not ready'))
-        return
+        this.logger.error("[SQLite][rawQuery] DB not ready");
+        reject(new Error("DB not ready"));
+        return;
       }
-      this.logger.debug('[SQLite][rawQuery] Executing query', { query })
+      this.logger.debug("[SQLite][rawQuery] Executing query", { query });
       this.db.run(query, (err) => {
         if (err == null) {
-          this.logger.debug('[SQLite][rawQuery] Query successful', { query })
-          resolve()
+          this.logger.debug("[SQLite][rawQuery] Query successful", { query });
+          resolve();
         } else {
-          this.logger.error('[SQLite][rawQuery] Query failed', {
+          this.logger.error("[SQLite][rawQuery] Query failed", {
             query,
-            error: err
-          })
-          reject(err)
+            error: err,
+          });
+          reject(err);
         }
-      })
-    })
+      });
+    });
   }
 
   exists(table: T): Promise<number> {
     // @ts-expect-error sqlite_master not listed in Collections
-    return this.getCount('sqlite_master', 'name', table)
+    return this.getCount("sqlite_master", "name", table);
   }
 
-  insert(
-    table: T,
-    values: Record<string, string | number>
-  ): Promise<DbGetResult> {
+  insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][insert] DB not ready', { table })
-        throw new Error('Wait for database to be ready')
+        this.logger.error("[SQLite][insert] DB not ready", { table });
+        throw new Error("Wait for database to be ready");
       }
-      const names: string[] = []
-      const vals: Array<string | number> = []
+      const names: string[] = [];
+      const vals: Array<string | number> = [];
       Object.keys(values).forEach((k) => {
-        names.push(k)
-        vals.push(values[k])
-      })
-      const query = `INSERT INTO ${table}(${names.join(',')}) VALUES(${names
-        .map((v) => '?')
-        .join(',')}) RETURNING *;`
-      this.logger.debug('[SQLite][insert] Executing', {
+        names.push(k);
+        vals.push(values[k]);
+      });
+      const query = `INSERT INTO ${table}(${names.join(",")}) VALUES(${names.map((v) => "?").join(",")}) RETURNING *;`;
+      this.logger.debug("[SQLite][insert] Executing", {
         table,
         fields: names,
-        query
-      })
-      const stmt = this.db.prepare(query)
-      stmt.all(
-        vals,
-        (err: string, rows: Array<Record<string, string | number>>) => {
-          /* istanbul ignore if */
-          if (err != null) {
-            this.logger.error('[SQLite][insert] Failed', {
-              table,
-              fields: names,
-              values: vals,
-              query,
-              error: err
-            })
-            reject(err)
-          } else {
-            this.logger.debug('[SQLite][insert] Successful', {
-              table,
-              rowCount: rows.length
-            })
-            resolve(rows)
-          }
+        query,
+      });
+      const stmt = this.db.prepare(query);
+      stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
+        /* istanbul ignore if */
+        if (err != null) {
+          this.logger.error("[SQLite][insert] Failed", {
+            table,
+            fields: names,
+            values: vals,
+            query,
+            error: err,
+          });
+          reject(err);
+        } else {
+          this.logger.debug("[SQLite][insert] Successful", {
+            table,
+            rowCount: rows.length,
+          });
+          resolve(rows);
         }
-      )
+      });
       stmt.finalize((err) => {
         if (err) {
-          this.logger.error('[SQLite][insert] Statement finalize failed', {
+          this.logger.error("[SQLite][insert] Statement finalize failed", {
             table,
-            error: err
-          })
-          reject(err)
+            error: err,
+          });
+          reject(err);
         }
-      })
-    })
+      });
+    });
   }
 
   update(
     table: T,
     values: Record<string, string | number>,
     field: string,
-    value: string | number
+    value: string | number,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][update] DB not ready', { table, field })
-        throw new Error('Wait for database to be ready')
+        this.logger.error("[SQLite][update] DB not ready", { table, field });
+        throw new Error("Wait for database to be ready");
       }
-      const names: string[] = []
-      const vals: Array<string | number> = []
+      const names: string[] = [];
+      const vals: Array<string | number> = [];
       Object.keys(values).forEach((k) => {
-        names.push(k)
-        vals.push(values[k])
-      })
-      vals.push(value)
-      const query = `UPDATE ${table} SET ${names.join(
-        '=?,'
-      )}=? WHERE ${field}=? RETURNING *;`
-      this.logger.debug('[SQLite][update] Executing', {
+        names.push(k);
+        vals.push(values[k]);
+      });
+      vals.push(value);
+      const query = `UPDATE ${table} SET ${names.join("=?,")}=? WHERE ${field}=? RETURNING *;`;
+      this.logger.debug("[SQLite][update] Executing", {
         table,
         fields: names,
         whereField: field,
-        query
-      })
-      const stmt = this.db.prepare(query)
-      stmt.all(
-        vals,
-        (err: string, rows: Array<Record<string, string | number>>) => {
-          /* istanbul ignore if */
-          if (err != null) {
-            this.logger.error('[SQLite][update] Failed', {
-              table,
-              fields: names,
-              whereField: field,
-              query,
-              error: err
-            })
-            reject(err)
-          } else {
-            this.logger.debug('[SQLite][update] Successful', {
-              table,
-              rowCount: rows.length
-            })
-            resolve(rows)
-          }
+        query,
+      });
+      const stmt = this.db.prepare(query);
+      stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
+        /* istanbul ignore if */
+        if (err != null) {
+          this.logger.error("[SQLite][update] Failed", {
+            table,
+            fields: names,
+            whereField: field,
+            query,
+            error: err,
+          });
+          reject(err);
+        } else {
+          this.logger.debug("[SQLite][update] Successful", {
+            table,
+            rowCount: rows.length,
+          });
+          resolve(rows);
         }
-      )
+      });
       stmt.finalize((err) => {
         if (err) {
-          this.logger.error('[SQLite][update] Statement finalize failed', {
+          this.logger.error("[SQLite][update] Statement finalize failed", {
             table,
-            error: err
-          })
-          reject(err)
+            error: err,
+          });
+          reject(err);
         }
-      })
-    })
+      });
+    });
   }
 
   // TODO : Merge update and updateAnd into one function that takes an array of conditions as argument
@@ -223,64 +185,58 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     table: T,
     values: Record<string, string | number>,
     condition1: { field: string; value: string | number },
-    condition2: { field: string; value: string | number }
+    condition2: { field: string; value: string | number },
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][updateAnd] DB not ready', {
+        this.logger.error("[SQLite][updateAnd] DB not ready", {
           table,
-          conditions: [condition1.field, condition2.field]
-        })
-        throw new Error('Wait for database to be ready')
+          conditions: [condition1.field, condition2.field],
+        });
+        throw new Error("Wait for database to be ready");
       }
-      const names = Object.keys(values)
-      const vals = Object.values(values)
-      vals.push(condition1.value, condition2.value)
+      const names = Object.keys(values);
+      const vals = Object.values(values);
+      vals.push(condition1.value, condition2.value);
 
-      const setClause = names.map((name) => `${name} = ?`).join(', ')
-      const query = `UPDATE ${table} SET ${setClause} WHERE ${condition1.field} = ? AND ${condition2.field} = ? RETURNING *;`
-      this.logger.debug('[SQLite][updateAnd] Executing', {
+      const setClause = names.map((name) => `${name} = ?`).join(", ");
+      const query = `UPDATE ${table} SET ${setClause} WHERE ${condition1.field} = ? AND ${condition2.field} = ? RETURNING *;`;
+      this.logger.debug("[SQLite][updateAnd] Executing", {
         table,
         fields: names,
         whereFields: [condition1.field, condition2.field],
-        query
-      })
-      const stmt = this.db.prepare(query)
+        query,
+      });
+      const stmt = this.db.prepare(query);
 
-      stmt.all(
-        vals,
-        (err: string, rows: Array<Record<string, string | number>>) => {
-          if (err != null) {
-            this.logger.error('[SQLite][updateAnd] Failed', {
-              table,
-              fields: names,
-              whereFields: [condition1.field, condition2.field],
-              query,
-              error: err
-            })
-            reject(err)
-          } else {
-            this.logger.debug('[SQLite][updateAnd] Successful', {
-              table,
-              rowCount: rows.length
-            })
-            resolve(rows)
-          }
+      stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
+        if (err != null) {
+          this.logger.error("[SQLite][updateAnd] Failed", {
+            table,
+            fields: names,
+            whereFields: [condition1.field, condition2.field],
+            query,
+            error: err,
+          });
+          reject(err);
+        } else {
+          this.logger.debug("[SQLite][updateAnd] Successful", {
+            table,
+            rowCount: rows.length,
+          });
+          resolve(rows);
         }
-      )
+      });
 
       stmt.finalize((err) => {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (err) {
-          this.logger.error(
-            'UPDATE with AND conditions statement finalize failed',
-            { table, error: err }
-          )
-          reject(err)
+          this.logger.error("UPDATE with AND conditions statement finalize failed", { table, error: err });
+          reject(err);
         }
-      })
-    })
+      });
+    });
   }
 
   _get(
@@ -295,171 +251,148 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     linkop2?: string,
     filterFields3?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        reject(new Error('Wait for database to be ready'))
+        reject(new Error("Wait for database to be ready"));
       } else {
-        let condition: string = ''
-        const values: string[] = []
+        let condition: string = "";
+        const values: string[] = [];
         if (fields == null || fields.length === 0) {
-          fields = ['*']
+          fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
           fields = fields.map((field) => {
-            if (field.includes('.')) {
-              const alias = field.replace(/\./g, '_')
-              return `${field} AS ${alias}`
+            if (field.includes(".")) {
+              const alias = field.replace(/\./g, "_");
+              return `${field} AS ${alias}`;
             }
-            return field
-          })
+            return field;
+          });
         }
 
-        let index: number = 0
+        let index: number = 0;
 
         const buildCondition = (
           op: string,
-          filterFields: Record<string, string | number | Array<string | number>>
+          filterFields: Record<string, string | number | Array<string | number>>,
         ): string => {
-          let localCondition = ''
+          let localCondition = "";
 
           Object.keys(filterFields)
-            .filter(
-              (key) =>
-                filterFields[key] != null &&
-                filterFields[key].toString() !== [].toString()
-            )
+            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
-              localCondition += localCondition !== '' ? ' AND ' : ''
+              localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
-                localCondition += `(${(
-                  filterFields[key] as Array<string | number>
-                )
+                localCondition += `(${(filterFields[key] as Array<string | number>)
                   .map((val) => {
-                    index++
-                    values.push(val.toString())
-                    return `${key}${op}$${index}`
+                    index++;
+                    values.push(val.toString());
+                    return `${key}${op}$${index}`;
                   })
-                  .join(' OR ')})`
+                  .join(" OR ")})`;
               } else {
-                index++
-                values.push(filterFields[key].toString())
-                localCondition += `${key}${op}$${index}`
+                index++;
+                values.push(filterFields[key].toString());
+                localCondition += `${key}${op}$${index}`;
               }
-            })
-          return localCondition
-        }
+            });
+          return localCondition;
+        };
 
         const condition1 =
-          op1 != null &&
-          filterFields1 != null &&
-          Object.keys(filterFields1).length > 0
+          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
-            : ''
+            : "";
         const condition2 =
-          op2 != null &&
-          linkop1 != null &&
-          filterFields2 != null &&
-          Object.keys(filterFields2).length > 0
+          op2 != null && linkop1 != null && filterFields2 != null && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
-            : ''
+            : "";
         const condition3 =
-          op3 != null &&
-          linkop2 != null &&
-          filterFields3 != null &&
-          Object.keys(filterFields3).length > 0
+          op3 != null && linkop2 != null && filterFields3 != null && Object.keys(filterFields3).length > 0
             ? buildCondition(op3, filterFields3)
-            : ''
+            : "";
 
-        condition += condition1 !== '' ? 'WHERE ' + condition1 : ''
+        condition += condition1 !== "" ? "WHERE " + condition1 : "";
         condition +=
-          condition2 !== ''
+          condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition !== '' ? ` ${linkop1} ` : 'WHERE ') + condition2
-            : ''
+              (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
+            : "";
         condition +=
-          condition3 !== ''
+          condition3 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition !== '' ? ` ${linkop2} ` : 'WHERE ') + condition3
-            : ''
+              (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
+            : "";
 
         if (joinFields != null) {
-          let joinCondition = ''
+          let joinCondition = "";
           Object.keys(joinFields)
-            .filter(
-              (key) =>
-                joinFields[key] != null &&
-                joinFields[key].toString() !== [].toString()
-            )
+            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
-              joinCondition += joinCondition !== '' ? ' AND ' : ''
-              joinCondition += `${key}=${joinFields[key]}`
-            })
-          condition += condition !== '' ? ' AND ' : 'WHERE '
-          condition += joinCondition
+              joinCondition += joinCondition !== "" ? " AND " : "";
+              joinCondition += `${key}=${joinFields[key]}`;
+            });
+          condition += condition !== "" ? " AND " : "WHERE ";
+          condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`
+        if (order != null) condition += ` ORDER BY ${order}`;
 
-        const query = `SELECT ${fields.join(',')} FROM ${tables.join(
-          ','
-        )} ${condition}`
-        this.logger.debug('[SQLite][_get] Executing SELECT', {
+        const query = `SELECT ${fields.join(",")} FROM ${tables.join(",")} ${condition}`;
+        this.logger.debug("[SQLite][_get] Executing SELECT", {
           tables,
           fields,
           condition,
-          query
-        })
+          query,
+        });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error('[SQLite][_get] SELECT failed', {
-                tables,
-                fields,
-                condition,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug('[SQLite][_get] SELECT successful', {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
-            }
+        // @ts-expect-error never undefined
+        const stmt = this.db.prepare(query);
+        stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
+          /* istanbul ignore if */
+          if (err != null) {
+            this.logger.error("[SQLite][_get] SELECT failed", {
+              tables,
+              fields,
+              condition,
+              query,
+              error: err,
+            });
+            reject(err);
+          } else {
+            this.logger.debug("[SQLite][_get] SELECT successful", {
+              tables,
+              rowCount: rows.length,
+            });
+            resolve(rows);
           }
-        )
+        });
         stmt.finalize((err) => {
           if (err) {
-            this.logger.error('[SQLite][_get] Statement finalize failed', {
+            this.logger.error("[SQLite][_get] Statement finalize failed", {
               tables,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   get(
     table: T,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
@@ -468,8 +401,8 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getJoin(
@@ -477,12 +410,12 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       tables,
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
@@ -491,20 +424,20 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       joinFields,
-      order
-    )
+      order,
+    );
   }
 
   getHigherThan(
     table: T,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '>',
+      ">",
       filterFields,
       undefined,
       undefined,
@@ -513,8 +446,8 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getWhereEqualOrDifferent(
@@ -522,22 +455,22 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<>',
-      ' OR ',
+      "<>",
+      " OR ",
       filterFields2,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getWhereEqualAndHigher(
@@ -545,26 +478,26 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._get(
       [table],
       fields,
-      '=',
+      "=",
       filterFields1,
-      '>',
-      ' AND ',
+      ">",
+      " AND ",
       filterFields2,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   _getMinMax(
-    minmax: 'MIN' | 'MAX',
+    minmax: "MIN" | "MAX",
     tables: T[],
     targetField: string,
     fields?: string[],
@@ -574,152 +507,134 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     linkop?: string,
     filterFields2?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        reject(new Error('Wait for database to be ready'))
+        reject(new Error("Wait for database to be ready"));
       } else {
-        let condition: string = ''
-        const values: string[] = []
+        let condition: string = "";
+        const values: string[] = [];
         if (fields == null || fields.length === 0) {
-          fields = ['*']
+          fields = ["*"];
         } else {
           // Generate aliases for fields containing periods
           fields = fields.map((field) => {
-            if (field.includes('.')) {
-              const alias = field.replace(/\./g, '_')
-              return `${field} AS ${alias}`
+            if (field.includes(".")) {
+              const alias = field.replace(/\./g, "_");
+              return `${field} AS ${alias}`;
             }
-            return field
-          })
+            return field;
+          });
         }
-        const targetFieldAlias: string = targetField.replace(/\./g, '_')
+        const targetFieldAlias: string = targetField.replace(/\./g, "_");
 
-        let index: number = 0
+        let index: number = 0;
 
         const buildCondition = (
           op: string,
-          filterFields: Record<string, string | number | Array<string | number>>
+          filterFields: Record<string, string | number | Array<string | number>>,
         ): string => {
-          let localCondition = ''
+          let localCondition = "";
 
           Object.keys(filterFields)
-            .filter(
-              (key) =>
-                filterFields[key] != null &&
-                filterFields[key].toString() !== [].toString()
-            )
+            .filter((key) => filterFields[key] != null && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
-              localCondition += localCondition !== '' ? ' AND ' : ''
+              localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
-                localCondition += `(${(
-                  filterFields[key] as Array<string | number>
-                )
+                localCondition += `(${(filterFields[key] as Array<string | number>)
                   .map((val) => {
-                    index++
-                    values.push(val.toString())
-                    return `${key}${op}$${index}`
+                    index++;
+                    values.push(val.toString());
+                    return `${key}${op}$${index}`;
                   })
-                  .join(' OR ')})`
+                  .join(" OR ")})`;
               } else {
-                index++
-                values.push(filterFields[key].toString())
-                localCondition += `${key}${op}$${index}`
+                index++;
+                values.push(filterFields[key].toString());
+                localCondition += `${key}${op}$${index}`;
               }
-            })
-          return localCondition
-        }
+            });
+          return localCondition;
+        };
 
         const condition1 =
-          op1 != null &&
-          filterFields1 != null &&
-          Object.keys(filterFields1).length > 0
+          op1 != null && filterFields1 != null && Object.keys(filterFields1).length > 0
             ? buildCondition(op1, filterFields1)
-            : ''
+            : "";
         const condition2 =
-          op2 != null &&
-          linkop != null &&
-          filterFields2 != null &&
-          Object.keys(filterFields2).length > 0
+          op2 != null && linkop != null && filterFields2 != null && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
-            : ''
+            : "";
 
-        condition += condition1 !== '' ? 'WHERE ' + condition1 : ''
+        condition += condition1 !== "" ? "WHERE " + condition1 : "";
         condition +=
-          condition2 !== ''
+          condition2 !== ""
             ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              (condition !== '' ? ` ${linkop} ` : 'WHERE ') + condition2
-            : ''
+              (condition !== "" ? ` ${linkop} ` : "WHERE ") + condition2
+            : "";
 
         if (joinFields != null) {
-          let joinCondition = ''
+          let joinCondition = "";
           Object.keys(joinFields)
-            .filter(
-              (key) =>
-                joinFields[key] != null &&
-                joinFields[key].toString() !== [].toString()
-            )
+            .filter((key) => joinFields[key] != null && joinFields[key].toString() !== [].toString())
             .forEach((key) => {
-              joinCondition += joinCondition !== '' ? ' AND ' : ''
-              joinCondition += `${key}=${joinFields[key]}`
-            })
-          condition += condition !== '' ? ' AND ' : 'WHERE '
-          condition += joinCondition
+              joinCondition += joinCondition !== "" ? " AND " : "";
+              joinCondition += `${key}=${joinFields[key]}`;
+            });
+          condition += condition !== "" ? " AND " : "WHERE ";
+          condition += joinCondition;
         }
 
-        if (order != null) condition += ` ORDER BY ${order}`
+        if (order != null) condition += ` ORDER BY ${order}`;
 
         const query = `SELECT ${fields.join(
-          ','
+          ",",
         )}, ${minmax}(${targetField}) AS max_${targetFieldAlias} FROM ${tables.join(
-          ','
-        )} ${condition} HAVING COUNT(*) > 0` // HAVING COUNT(*) > 0 is to avoid returning a row with NULL values
+          ",",
+        )} ${condition} HAVING COUNT(*) > 0`; // HAVING COUNT(*) > 0 is to avoid returning a row with NULL values
         this.logger.debug(`Executing ${minmax} query`, {
           tables,
           targetField,
           fields,
           condition,
-          query
-        })
+          query,
+        });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error(`${minmax} query failed`, {
-                tables,
-                targetField,
-                fields,
-                condition,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug(`${minmax} query successful`, {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
-            }
+        // @ts-expect-error never undefined
+        const stmt = this.db.prepare(query);
+        stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
+          /* istanbul ignore if */
+          if (err != null) {
+            this.logger.error(`${minmax} query failed`, {
+              tables,
+              targetField,
+              fields,
+              condition,
+              query,
+              error: err,
+            });
+            reject(err);
+          } else {
+            this.logger.debug(`${minmax} query successful`, {
+              tables,
+              rowCount: rows.length,
+            });
+            resolve(rows);
           }
-        )
+        });
         stmt.finalize((err) => {
           if (err) {
             this.logger.error(`${minmax} statement finalize failed`, {
               tables,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   getMaxWhereEqual(
@@ -727,21 +642,21 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     targetField: string,
     fields?: string[],
     filterFields?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields,
       undefined,
       undefined,
       undefined,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMaxWhereEqualAndLower(
@@ -750,21 +665,21 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<',
-      ' AND ',
+      "<",
+      " AND ",
       filterFields2,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMinWhereEqualAndHigher(
@@ -773,21 +688,21 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields?: string[],
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MIN',
+      "MIN",
       [table],
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '>',
-      ' AND ',
+      ">",
+      " AND ",
       filterFields2,
       undefined,
-      order
-    )
+      order,
+    );
   }
 
   getMaxWhereEqualAndLowerJoin(
@@ -797,21 +712,21 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     filterFields1?: Record<string, string | number | Array<string | number>>,
     filterFields2?: Record<string, string | number | Array<string | number>>,
     joinFields?: Record<string, string>,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return this._getMinMax(
-      'MAX',
+      "MAX",
       tables,
       targetField,
       fields,
-      '=',
+      "=",
       filterFields1,
-      '<',
-      ' AND ',
+      "<",
+      " AND ",
       filterFields2,
       joinFields,
-      order
-    )
+      order,
+    );
   }
 
   match(
@@ -819,220 +734,202 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     fields: string[],
     searchFields: string[],
     value: string | number,
-    order?: string
+    order?: string,
   ): Promise<DbGetResult> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][match] DB not ready', { table })
-        reject(new Error('Wait for database to be ready'))
+        this.logger.error("[SQLite][match] DB not ready", { table });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        if (typeof searchFields !== 'object') searchFields = [searchFields]
-        if (typeof fields !== 'object') fields = [fields]
-        if (fields.length === 0) fields = ['*']
-        const values = searchFields.map(() => `%${value}%`)
-        let condition = searchFields.map((f) => `${f} LIKE ?`).join(' OR ')
-        if (order != null) condition += `ORDER BY ${order}`
-        const query = `SELECT ${fields.join(
-          ','
-        )} FROM ${table} WHERE ${condition}`
-        this.logger.debug('[SQLite][match] Executing LIKE query', {
+        if (typeof searchFields !== "object") searchFields = [searchFields];
+        if (typeof fields !== "object") fields = [fields];
+        if (fields.length === 0) fields = ["*"];
+        const values = searchFields.map(() => `%${value}%`);
+        let condition = searchFields.map((f) => `${f} LIKE ?`).join(" OR ");
+        if (order != null) condition += `ORDER BY ${order}`;
+        const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
+        this.logger.debug("[SQLite][match] Executing LIKE query", {
           table,
           searchFields,
           value,
           fields,
-          query
-        })
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error('[SQLite][match] Query failed', {
-                table,
-                searchFields,
-                value,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug('[SQLite][match] Query successful', {
-                table,
-                rowCount: rows.length
-              })
-              resolve(rows)
-            }
+          query,
+        });
+        const stmt = this.db.prepare(query);
+        stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
+          /* istanbul ignore if */
+          if (err != null) {
+            this.logger.error("[SQLite][match] Query failed", {
+              table,
+              searchFields,
+              value,
+              query,
+              error: err,
+            });
+            reject(err);
+          } else {
+            this.logger.debug("[SQLite][match] Query successful", {
+              table,
+              rowCount: rows.length,
+            });
+            resolve(rows);
           }
-        )
+        });
         stmt.finalize((err) => {
           if (err) {
-            this.logger.error('[SQLite][match] Statement finalize failed', {
+            this.logger.error("[SQLite][match] Statement finalize failed", {
               table,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   deleteEqual(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][deleteEqual] DB not ready', {
-          table,
-          field
-        })
-        reject(new Error('Wait for database to be ready'))
-      } else {
-        const query = `DELETE FROM ${table} WHERE ${field}=?`
-        this.logger.debug('[SQLite][deleteEqual] Executing', {
+        this.logger.error("[SQLite][deleteEqual] DB not ready", {
           table,
           field,
-          query
-        })
-        const stmt = this.db.prepare(query)
+        });
+        reject(new Error("Wait for database to be ready"));
+      } else {
+        const query = `DELETE FROM ${table} WHERE ${field}=?`;
+        this.logger.debug("[SQLite][deleteEqual] Executing", {
+          table,
+          field,
+          query,
+        });
+        const stmt = this.db.prepare(query);
         stmt.all([value], (err, rows) => {
           /* istanbul ignore if */
           if (err != null) {
-            this.logger.error('DELETE failed', {
+            this.logger.error("DELETE failed", {
               table,
               field,
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[SQLite][deleteEqual] Successful', {
+            this.logger.debug("[SQLite][deleteEqual] Successful", {
               table,
-              field
-            })
-            resolve()
+              field,
+            });
+            resolve();
           }
-        })
+        });
         stmt.finalize((err) => {
           if (err) {
-            this.logger.error(
-              '[SQLite][deleteEqual] Statement finalize failed',
-              {
-                table,
-                error: err
-              }
-            )
-            reject(err)
+            this.logger.error("[SQLite][deleteEqual] Statement finalize failed", {
+              table,
+              error: err,
+            });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   deleteEqualAnd(
     table: T,
     condition1: {
-      field: string
-      value: string | number | Array<string | number>
+      field: string;
+      value: string | number | Array<string | number>;
     },
     condition2: {
-      field: string
-      value: string | number | Array<string | number>
-    }
+      field: string;
+      value: string | number | Array<string | number>;
+    },
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][deleteEqualAnd] DB not ready', { table })
-        reject(new Error('Wait for database to be ready'))
+        this.logger.error("[SQLite][deleteEqualAnd] DB not ready", { table });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        const query = `DELETE FROM ${table} WHERE ${condition1.field}=? AND ${condition2.field}=?`
-        this.logger.debug('[SQLite][deleteEqualAnd] Executing', {
+        const query = `DELETE FROM ${table} WHERE ${condition1.field}=? AND ${condition2.field}=?`;
+        this.logger.debug("[SQLite][deleteEqualAnd] Executing", {
           table,
           conditions: [condition1.field, condition2.field],
-          query
-        })
-        const stmt = this.db.prepare(query)
+          query,
+        });
+        const stmt = this.db.prepare(query);
         stmt.all([condition1.value, condition2.value], (err, rows) => {
           /* istanbul ignore if */
           if (err != null) {
-            this.logger.error('[SQLite][deleteEqualAnd] Failed', {
+            this.logger.error("[SQLite][deleteEqualAnd] Failed", {
               table,
               conditions: [condition1.field, condition2.field],
               query,
-              error: err
-            })
-            reject(err)
+              error: err,
+            });
+            reject(err);
           } else {
-            this.logger.debug('[SQLite][deleteEqualAnd] Successful', {
-              table
-            })
-            resolve()
+            this.logger.debug("[SQLite][deleteEqualAnd] Successful", {
+              table,
+            });
+            resolve();
           }
-        })
+        });
         stmt.finalize((err) => {
           if (err) {
-            this.logger.error(
-              'DELETE with AND conditions statement finalize failed',
-              { table, error: err }
-            )
-            reject(err)
+            this.logger.error("DELETE with AND conditions statement finalize failed", { table, error: err });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
-  deleteLowerThan(
-    table: T,
-    field: string,
-    value: string | number
-  ): Promise<void> {
+  deleteLowerThan(table: T, field: string, value: string | number): Promise<void> {
     return new Promise((resolve, reject) => {
       /* istanbul ignore if */
       if (this.db == null) {
-        this.logger.error('[SQLite][deleteLowerThan] DB not ready', {
+        this.logger.error("[SQLite][deleteLowerThan] DB not ready", {
           table,
-          field
-        })
-        throw new Error('Wait for database to be ready')
+          field,
+        });
+        throw new Error("Wait for database to be ready");
       }
-      const query = `DELETE FROM ${table} WHERE ${field}<?`
-      this.logger.debug('[SQLite][deleteLowerThan] Executing', {
+      const query = `DELETE FROM ${table} WHERE ${field}<?`;
+      this.logger.debug("[SQLite][deleteLowerThan] Executing", {
         table,
         field,
-        query
-      })
-      const stmt = this.db.prepare(query)
+        query,
+      });
+      const stmt = this.db.prepare(query);
       stmt.all([value], (err) => {
         /* istanbul ignore if */
         if (err != null) {
-          this.logger.error('[SQLite][deleteLowerThan] Failed', {
+          this.logger.error("[SQLite][deleteLowerThan] Failed", {
             table,
             field,
             query,
-            error: err
-          })
-          reject(err)
+            error: err,
+          });
+          reject(err);
         } else {
-          this.logger.debug('[SQLite][deleteLowerThan] Successful', {
+          this.logger.debug("[SQLite][deleteLowerThan] Successful", {
             table,
-            field
-          })
-          resolve()
+            field,
+          });
+          resolve();
         }
-      })
+      });
       stmt.finalize((err) => {
         if (err) {
-          this.logger.error(
-            'DELETE with < condition statement finalize failed',
-            { table, error: err }
-          )
-          reject(err)
+          this.logger.error("DELETE with < condition statement finalize failed", { table, error: err });
+          reject(err);
         }
-      })
-    })
+      });
+    });
   }
 
   /**
@@ -1041,92 +938,80 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
    * @param {string} table - the table to delete from
    * @param {ISQLCondition | ISQLCondition[]} conditions - the list of filters, operators and values for sql conditions
    */
-  deleteWhere(
-    table: T,
-    conditions: ISQLCondition | ISQLCondition[]
-  ): Promise<void> {
+  deleteWhere(table: T, conditions: ISQLCondition | ISQLCondition[]): Promise<void> {
     // Adaptation of the method get, with the delete keyword, 'AND' instead of 'OR', and with filters instead of fields
     return new Promise((resolve, reject) => {
       // istanbul ignore if
       if (this.db == null) {
-        this.logger.error('[SQLite][deleteWhere] DB not ready', { table })
-        reject(new Error('Wait for database to be ready'))
+        this.logger.error("[SQLite][deleteWhere] DB not ready", { table });
+        reject(new Error("Wait for database to be ready"));
       } else {
-        if (!Array.isArray(conditions)) conditions = [conditions]
+        if (!Array.isArray(conditions)) conditions = [conditions];
 
-        const values = conditions.map((c) => c.value)
-        const filters = conditions.map((c) => c.field)
-        const operators = conditions.map((c) => c.operator)
+        const values = conditions.map((c) => c.value);
+        const filters = conditions.map((c) => c.field);
+        const operators = conditions.map((c) => c.operator);
 
-        let condition: string = ''
-        if (
-          values != null &&
-          values.length > 0 &&
-          filters.length === values.length
-        ) {
+        let condition: string = "";
+        if (values != null && values.length > 0 && filters.length === values.length) {
           // Verifies that values have at least one element, and as much filter names
-          condition = filters
-            .map((filt, i) => `${filt}${operators[i] ?? '='}?`)
-            .join(' AND ')
+          condition = filters.map((filt, i) => `${filt}${operators[i] ?? "="}?`).join(" AND ");
         }
 
-        const query = `DELETE FROM ${table} WHERE ${condition}`
-        this.logger.debug('[SQLite][deleteWhere] Executing', {
+        const query = `DELETE FROM ${table} WHERE ${condition}`;
+        this.logger.debug("[SQLite][deleteWhere] Executing", {
           table,
           conditions: filters,
           operators,
-          query
-        })
+          query,
+        });
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
+        // @ts-expect-error never undefined
+        const stmt = this.db.prepare(query);
 
         stmt.all(
           values, // The statement fills the values properly.
           (err: string) => {
             /* istanbul ignore if */
             if (err != null) {
-              this.logger.error('[SQLite][deleteWhere] Failed', {
+              this.logger.error("[SQLite][deleteWhere] Failed", {
                 table,
                 conditions: filters,
                 operators,
                 values,
                 query,
-                error: err
-              })
-              reject(err)
+                error: err,
+              });
+              reject(err);
             } else {
-              this.logger.debug('[SQLite][deleteWhere] Successful', {
-                table
-              })
-              resolve()
+              this.logger.debug("[SQLite][deleteWhere] Successful", {
+                table,
+              });
+              resolve();
             }
-          }
-        )
+          },
+        );
         stmt.finalize((err) => {
           if (err) {
-            this.logger.error(
-              'DELETE with WHERE conditions statement finalize failed',
-              { table, error: err }
-            )
-            reject(err)
+            this.logger.error("DELETE with WHERE conditions statement finalize failed", { table, error: err });
+            reject(err);
           }
-        })
+        });
       }
-    })
+    });
   }
 
   async getTableColumns(table: T): Promise<ColumnInfo[]> {
     if (!this.db) {
-      this.logger.error('[SQLite][getTableColumns] DB not ready', { table })
-      throw new Error('DB not ready')
+      this.logger.error("[SQLite][getTableColumns] DB not ready", { table });
+      throw new Error("DB not ready");
     }
 
-    const query = `PRAGMA table_info(${table})`
-    this.logger.debug('[SQLite][getTableColumns] Executing', { table, query })
+    const query = `PRAGMA table_info(${table})`;
+    this.logger.debug("[SQLite][getTableColumns] Executing", { table, query });
 
     /* Capture db reference to avoid undefined in callback */
-    const db = this.db
+    const db = this.db;
 
     return new Promise((resolve, reject) => {
       db.all(
@@ -1134,39 +1019,39 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         (
           err: Error | null,
           rows: Array<{
-            cid: number
-            name: string
-            type: string
-            notnull: number
-            dflt_value: string | null
-            pk: number
-          }>
+            cid: number;
+            name: string;
+            type: string;
+            notnull: number;
+            dflt_value: string | null;
+            pk: number;
+          }>,
         ) => {
           if (err) {
-            this.logger.error('[SQLite][getTableColumns] Failed', {
+            this.logger.error("[SQLite][getTableColumns] Failed", {
               table,
               query,
-              error: err
-            })
-            reject(err)
-            return
+              error: err,
+            });
+            reject(err);
+            return;
           }
 
           const columns: ColumnInfo[] = rows.map((row) => ({
             name: row.name,
             type: row.type,
-            defaultValue: row.dflt_value
-          }))
+            defaultValue: row.dflt_value,
+          }));
 
-          this.logger.debug('[SQLite][getTableColumns] Successful', {
+          this.logger.debug("[SQLite][getTableColumns] Successful", {
             table,
-            columnCount: columns.length
-          })
+            columnCount: columns.length,
+          });
 
-          resolve(columns)
-        }
-      )
-    })
+          resolve(columns);
+        },
+      );
+    });
   }
 
   /**
@@ -1174,14 +1059,14 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
    * Only allows alphanumeric characters and underscores, must start with letter or underscore.
    */
   #isValidIdentifier(name: string): boolean {
-    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name)
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
   }
 
   /**
    * Quotes an SQL identifier using double quotes, escaping any internal double quotes.
    */
   #quoteIdentifier(name: string): string {
-    return `"${name.replace(/"/g, '""')}"`
+    return `"${name.replace(/"/g, '""')}"`;
   }
 
   /**
@@ -1189,80 +1074,80 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
    */
   #isValidColumnType(type: string): boolean {
     const typePattern =
-      /^(varchar|char|text|int|integer|smallint|bigint|real|numeric|decimal|boolean|bool|date|time|timestamp|blob|json|jsonb)(\(\d+\))?$/i
-    return typePattern.test(type.trim())
+      /^(varchar|char|text|int|integer|smallint|bigint|real|numeric|decimal|boolean|bool|date|time|timestamp|blob|json|jsonb)(\(\d+\))?$/i;
+    return typePattern.test(type.trim());
   }
 
   async addColumn(table: T, column: ColumnDefinition): Promise<void> {
     if (!this.db) {
-      this.logger.error('[SQLite][addColumn] DB not ready', { table, column })
-      throw new Error('DB not ready')
+      this.logger.error("[SQLite][addColumn] DB not ready", { table, column });
+      throw new Error("DB not ready");
     }
 
     /* Validate identifiers to prevent SQL injection */
     if (!this.#isValidIdentifier(table)) {
-      this.logger.error('[SQLite][addColumn] Invalid table name', {
+      this.logger.error("[SQLite][addColumn] Invalid table name", {
         table,
-        column
-      })
-      throw new Error(`Invalid table name: ${table}`)
+        column,
+      });
+      throw new Error(`Invalid table name: ${table}`);
     }
 
     if (!this.#isValidIdentifier(column.name)) {
-      this.logger.error('[SQLite][addColumn] Invalid column name', {
+      this.logger.error("[SQLite][addColumn] Invalid column name", {
         table,
-        column
-      })
-      throw new Error(`Invalid column name: ${column.name}`)
+        column,
+      });
+      throw new Error(`Invalid column name: ${column.name}`);
     }
 
     if (!this.#isValidColumnType(column.type)) {
-      this.logger.error('[SQLite][addColumn] Invalid column type', {
+      this.logger.error("[SQLite][addColumn] Invalid column type", {
         table,
-        column
-      })
-      throw new Error(`Invalid column type: ${column.type}`)
+        column,
+      });
+      throw new Error(`Invalid column type: ${column.type}`);
     }
 
     /* Build query with quoted identifiers */
-    const quotedTable = this.#quoteIdentifier(table)
-    const quotedColumn = this.#quoteIdentifier(column.name)
-    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${column.type}`
+    const quotedTable = this.#quoteIdentifier(table);
+    const quotedColumn = this.#quoteIdentifier(column.name);
+    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${column.type}`;
 
     /* Handle default value - use parameterized query for safety */
-    const params: Array<string | number | null> = []
+    const params: Array<string | number | null> = [];
     if (column.default !== undefined) {
       /*
        * SQLite doesn't support parameterized DEFAULT in ALTER TABLE,
        * so we must use literal values with proper escaping
        */
       if (column.default === null) {
-        query += ' DEFAULT NULL'
-      } else if (typeof column.default === 'number') {
-        query += ` DEFAULT ${column.default}`
-      } else if (typeof column.default === 'boolean') {
-        query += ` DEFAULT ${column.default ? 1 : 0}`
+        query += " DEFAULT NULL";
+      } else if (typeof column.default === "number") {
+        query += ` DEFAULT ${column.default}`;
+      } else if (typeof column.default === "boolean") {
+        query += ` DEFAULT ${column.default ? 1 : 0}`;
       } else {
         /* For strings, use parameterized query via prepared statement */
-        params.push(column.default)
-        query += ' DEFAULT ?'
+        params.push(column.default);
+        query += " DEFAULT ?";
       }
     }
 
     /* Handle NOT NULL constraint if specified */
     if (column.notNull) {
-      query += ' NOT NULL'
+      query += " NOT NULL";
     }
 
-    this.logger.debug('[SQLite][addColumn] Executing', {
+    this.logger.debug("[SQLite][addColumn] Executing", {
       table,
       column,
       query,
-      params
-    })
+      params,
+    });
 
     /* Capture db reference to avoid undefined in callback */
-    const db = this.db
+    const db = this.db;
 
     return new Promise((resolve, reject) => {
       /*
@@ -1270,78 +1155,71 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
        * If we have params, we need to use a workaround or fall back to escaping.
        * For now, we'll escape the string properly.
        */
-      let finalQuery = query
-      if (params.length > 0 && typeof params[0] === 'string') {
+      let finalQuery = query;
+      if (params.length > 0 && typeof params[0] === "string") {
         /* Replace ? with properly escaped string literal */
-        const escapedValue = params[0].replace(/'/g, "''")
-        finalQuery = query.replace('?', `'${escapedValue}'`)
+        const escapedValue = params[0].replace(/'/g, "''");
+        finalQuery = query.replace("?", `'${escapedValue}'`);
       }
 
       db.run(finalQuery, (err) => {
         if (err) {
           /* Check for duplicate column error - make idempotent */
-          const errMessage = err.message?.toLowerCase() ?? ''
-          if (errMessage.includes('duplicate column name')) {
-            this.logger.debug(
-              '[SQLite][addColumn] Column already exists (idempotent)',
-              {
-                table,
-                column: column.name
-              }
-            )
-            resolve()
-            return
+          const errMessage = err.message?.toLowerCase() ?? "";
+          if (errMessage.includes("duplicate column name")) {
+            this.logger.debug("[SQLite][addColumn] Column already exists (idempotent)", {
+              table,
+              column: column.name,
+            });
+            resolve();
+            return;
           }
 
-          this.logger.error('[SQLite][addColumn] Failed', {
+          this.logger.error("[SQLite][addColumn] Failed", {
             table,
             column,
             query: finalQuery,
-            error: err
-          })
-          reject(err)
-          return
+            error: err,
+          });
+          reject(err);
+          return;
         }
 
-        this.logger.info('[SQLite][addColumn] Column added successfully', {
+        this.logger.info("[SQLite][addColumn] Column added successfully", {
           table,
-          column: column.name
-        })
-        resolve()
-      })
-    })
+          column: column.name,
+        });
+        resolve();
+      });
+    });
   }
 
   async ensureColumns(table: T, columns: ColumnDefinition[]): Promise<void> {
-    const existingColumns = await this.getTableColumns(table)
-    const existingNames = new Set(
-      existingColumns.map((c) => c.name.toLowerCase())
-    )
+    const existingColumns = await this.getTableColumns(table);
+    const existingNames = new Set(existingColumns.map((c) => c.name.toLowerCase()));
 
-    const missingColumns = columns.filter(
-      (col) => !existingNames.has(col.name.toLowerCase())
-    )
+    const missingColumns = columns.filter((col) => !existingNames.has(col.name.toLowerCase()));
 
     if (missingColumns.length === 0) {
-      this.logger.debug('[SQLite][ensureColumns] All columns exist', { table })
-      return
+      this.logger.debug("[SQLite][ensureColumns] All columns exist", { table });
+      return;
     }
 
-    this.logger.info('[SQLite][ensureColumns] Adding missing columns', {
+    this.logger.info("[SQLite][ensureColumns] Adding missing columns", {
       table,
-      columns: missingColumns.map((c) => c.name)
-    })
+      columns: missingColumns.map((c) => c.name),
+    });
 
     for (const col of missingColumns) {
-      await this.addColumn(table, col)
+      await this.addColumn(table, col);
     }
 
-    this.logger.info('[SQLite][ensureColumns] All columns ensured', { table })
+    this.logger.info("[SQLite][ensureColumns] All columns ensured", { table });
   }
 
   close(): void {
-    this.db?.close()
+    this.db?.close();
   }
 }
 
-export default SQLite
+export default SQLite;

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -19,7 +19,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     logger: TwakeLogger,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (this.db !== null) {
+      if (this.db) {
         createTables(this, tables, indexes, initializeValues, logger, resolve, reject);
       } else {
         import("sqlite3")
@@ -93,7 +93,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
         /* istanbul ignore if */
-        if (err !== null) {
+        if (err !== null && err !== undefined) {
           this.logger.error("[SQLite][insert] Failed", {
             table,
             fields: names,
@@ -151,7 +151,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
         /* istanbul ignore if */
-        if (err !== null) {
+        if (err !== null && err !== undefined) {
           this.logger.error("[SQLite][update] Failed", {
             table,
             fields: names,
@@ -211,7 +211,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
 
       stmt.all(vals, (err: string, rows: Array<Record<string, string | number>>) => {
-        if (err !== null) {
+        if (err !== null && err !== undefined) {
           this.logger.error("[SQLite][updateAnd] Failed", {
             table,
             fields: names,
@@ -282,7 +282,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -351,7 +351,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err !== null) {
+          if (err !== null && err !== undefined) {
             this.logger.error("[SQLite][_get] SELECT failed", {
               tables,
               fields,
@@ -537,7 +537,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] !== null && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -602,7 +602,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err !== null) {
+          if (err !== null && err !== undefined) {
             this.logger.error(`${minmax} query failed`, {
               tables,
               targetField,
@@ -743,7 +743,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         if (fields.length === 0) fields = ["*"];
         const values = searchFields.map(() => `%${value}%`);
         let condition = searchFields.map((f) => `${f} LIKE ?`).join(" OR ");
-        if (order !== null) condition += `ORDER BY ${order}`;
+        if (order) condition += `ORDER BY ${order}`;
         const query = `SELECT ${fields.join(",")} FROM ${table} WHERE ${condition}`;
         this.logger.debug("[SQLite][match] Executing LIKE query", {
           table,
@@ -755,7 +755,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all(values, (err: string, rows: Array<Record<string, string | number>>) => {
           /* istanbul ignore if */
-          if (err !== null) {
+          if (err !== null && err !== undefined) {
             this.logger.error("[SQLite][match] Query failed", {
               table,
               searchFields,
@@ -804,7 +804,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all([value], (err, _rows) => {
           /* istanbul ignore if */
-          if (err !== null) {
+          if (err !== null && err !== undefined) {
             this.logger.error("DELETE failed", {
               table,
               field,
@@ -859,7 +859,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const stmt = this.db.prepare(query);
         stmt.all([condition1.value, condition2.value], (err, _rows) => {
           /* istanbul ignore if */
-          if (err !== null) {
+          if (err !== null && err !== undefined) {
             this.logger.error("[SQLite][deleteEqualAnd] Failed", {
               table,
               conditions: [condition1.field, condition2.field],
@@ -903,7 +903,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
       const stmt = this.db.prepare(query);
       stmt.all([value], (err) => {
         /* istanbul ignore if */
-        if (err !== null) {
+        if (err !== null && err !== undefined) {
           this.logger.error("[SQLite][deleteLowerThan] Failed", {
             table,
             field,
@@ -949,7 +949,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         const operators = conditions.map((c) => c.operator);
 
         let condition: string = "";
-        if (values !== null && values.length > 0 && filters.length === values.length) {
+        if (values && values.length > 0 && filters.length === values.length) {
           // Verifies that values have at least one element, and as much filter names
           condition = filters.map((filt, i) => `${filt}${operators[i] ?? "="}?`).join(" AND ");
         }
@@ -967,7 +967,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           values, // The statement fills the values properly.
           (err: string) => {
             /* istanbul ignore if */
-            if (err !== null) {
+            if (err !== null && err !== undefined) {
               this.logger.error("[SQLite][deleteWhere] Failed", {
                 table,
                 conditions: filters,

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -280,7 +280,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key] !== undefined && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {
@@ -525,7 +525,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           let localCondition = "";
 
           Object.keys(filterFields)
-            .filter((key) => filterFields[key] && filterFields[key].toString() !== [].toString())
+            .filter((key) => filterFields[key] !== null && filterFields[key] !== undefined && filterFields[key].toString() !== [].toString())
             .forEach((key) => {
               localCondition += localCondition !== "" ? " AND " : "";
               if (Array.isArray(filterFields[key])) {

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -25,7 +25,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           .then((sqlite3) => {
             // @ts-expect-error
             if (!sqlite3.Database) sqlite3 = sqlite3.default;
-            this.db = new sqlite3.Database(conf.database_host)
+            this.db = new sqlite3.Database(conf.database_host);
             const db = this.db;
             /* istanbul ignore if */
             if (!db) {
@@ -301,9 +301,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 && filterFields1 && Object.keys(filterFields1).length > 0
-            ? buildCondition(op1, filterFields1)
-            : "";
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0 ? buildCondition(op1, filterFields1) : "";
         const condition2 =
           op2 && linkop1 && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
@@ -314,14 +312,8 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
             : "";
 
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
-        condition +=
-          condition2 !== ""
-              (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2
-            : "";
-        condition +=
-          condition3 !== ""
-              (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3
-            : "";
+        condition += condition2 !== "" ? (condition !== "" ? ` ${linkop1} ` : "WHERE ") + condition2 : "";
+        condition += condition3 !== "" ? (condition !== "" ? ` ${linkop2} ` : "WHERE ") + condition3 : "";
 
         if (joinFields) {
           let joinCondition = "";
@@ -554,19 +546,14 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
         };
 
         const condition1 =
-          op1 && filterFields1 && Object.keys(filterFields1).length > 0
-            ? buildCondition(op1, filterFields1)
-            : "";
+          op1 && filterFields1 && Object.keys(filterFields1).length > 0 ? buildCondition(op1, filterFields1) : "";
         const condition2 =
           op2 && linkop && filterFields2 && Object.keys(filterFields2).length > 0
             ? buildCondition(op2, filterFields2)
             : "";
 
         condition += condition1 !== "" ? `WHERE ${condition1}` : "";
-        condition +=
-          condition2 !== ""
-              (condition !== "" ? ` ${linkop} ` : "WHERE ") + condition2
-            : "";
+        condition += condition2 !== "" ? (condition !== "" ? ` ${linkop} ` : "WHERE ") + condition2 : "";
 
         if (joinFields) {
           let joinCondition = "";

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,27 +1,25 @@
-import { type ConnectionOptions } from 'tls'
+import type { ConnectionOptions } from "tls";
 
-export type SupportedDatabases = 'sqlite' | 'pg'
+export type SupportedDatabases = "sqlite" | "pg";
 
 export interface DatabaseConfig {
-  database_engine: SupportedDatabases
-  database_host: string
-  database_name?: string
-  database_user?: string
-  database_password?: string
-  database_ssl?: boolean | ConnectionOptions
-  database_vacuum_delay: number
+  database_engine: SupportedDatabases;
+  database_host: string;
+  database_name?: string;
+  database_user?: string;
+  database_password?: string;
+  database_ssl?: boolean | ConnectionOptions;
+  database_vacuum_delay: number;
 }
 
-export type DbGetResult = Array<
-  Record<string, string | number | Array<string | number>>
->
+export type DbGetResult = Array<Record<string, string | number | Array<string | number>>>;
 
-export type SqlComparaisonOperator = '=' | '!=' | '>' | '<' | '>=' | '<=' | '<>'
+export type SqlComparaisonOperator = "=" | "!=" | ">" | "<" | ">=" | "<=" | "<>";
 
 export interface ISQLCondition {
-  field: string
-  operator: SqlComparaisonOperator
-  value: string | number
+  field: string;
+  operator: SqlComparaisonOperator;
+  value: string | number;
 }
 
 /**
@@ -29,10 +27,10 @@ export interface ISQLCondition {
  * Used by ensureColumns() to add missing columns.
  */
 export interface ColumnDefinition {
-  name: string
-  type: string
-  default?: string | number | null
-  notNull?: boolean
+  name: string;
+  type: string;
+  default?: string | number | null;
+  notNull?: boolean;
 }
 
 /**
@@ -40,60 +38,57 @@ export interface ColumnDefinition {
  * Returned by getTableColumns().
  */
 export interface ColumnInfo {
-  name: string
-  type: string
-  defaultValue: string | null
+  name: string;
+  type: string;
+  defaultValue: string | null;
 }
 
-type Insert<T> = (
-  table: T,
-  values: Record<string, string | number>
-) => Promise<DbGetResult>
+type Insert<T> = (table: T, values: Record<string, string | number>) => Promise<DbGetResult>;
 
 type Update<T> = (
   table: T,
   values: Record<string, string | number>,
   field: string,
-  value: string | number
-) => Promise<DbGetResult>
+  value: string | number,
+) => Promise<DbGetResult>;
 
 type UpdateAnd<T> = (
   table: T,
   values: Record<string, string | number>,
   condition1: { field: string; value: string | number },
-  condition2: { field: string; value: string | number }
-) => Promise<DbGetResult>
+  condition2: { field: string; value: string | number },
+) => Promise<DbGetResult>;
 
 type Get<T> = (
   table: T,
   fields: string[],
   filterFields: Record<string, string | number | Array<string | number>>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
 type Get2<T> = (
   table: T,
   fields: string[],
   filterFields1: Record<string, string | number | Array<string | number>>,
   filterFields2: Record<string, string | number | Array<string | number>>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
 type GetJoin<T> = (
   tables: T[],
   fields: string[],
   filterFields: Record<string, string | number | Array<string | number>>,
   joinFields: Record<string, string>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
 type GetMinMax<T> = (
   table: T,
   targetField: string,
   fields: string[],
   filterFields: Record<string, string | number | Array<string | number>>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
 type GetMinMax2<T> = (
   table: T,
@@ -101,8 +96,8 @@ type GetMinMax2<T> = (
   fields: string[],
   filterFields1: Record<string, string | number | Array<string | number>>,
   filterFields2: Record<string, string | number | Array<string | number>>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
 type GetMinMaxJoin2<T> = (
   tables: T[],
@@ -111,84 +106,60 @@ type GetMinMaxJoin2<T> = (
   filterFields1: Record<string, string | number | Array<string | number>>,
   filterFields2: Record<string, string | number | Array<string | number>>,
   joinFields: Record<string, string>,
-  order?: string
-) => Promise<DbGetResult>
+  order?: string,
+) => Promise<DbGetResult>;
 
-type GetCount<T> = (
-  table: T,
-  field: string,
-  value?: string | number | string[]
-) => Promise<number>
+type GetCount<T> = (table: T, field: string, value?: string | number | string[]) => Promise<number>;
 
-type GetAll<T> = (
-  table: T,
-  fields: string[],
-  order?: string
-) => Promise<DbGetResult>
+type GetAll<T> = (table: T, fields: string[], order?: string) => Promise<DbGetResult>;
 
-type Match<T> = (
-  table: T,
-  fields: string[],
-  searchFields: string[],
-  value: string | number
-) => Promise<DbGetResult>
+type Match<T> = (table: T, fields: string[], searchFields: string[], value: string | number) => Promise<DbGetResult>;
 
-type DeleteEqual<T> = (
-  table: T,
-  field: string,
-  value: string | number
-) => Promise<void>
+type DeleteEqual<T> = (table: T, field: string, value: string | number) => Promise<void>;
 
 type DeleteEqualAnd<T> = (
   table: T,
   condition1: {
-    field: string
-    value: string | number | Array<string | number>
+    field: string;
+    value: string | number | Array<string | number>;
   },
-  condition2: { field: string; value: string | number | Array<string | number> }
-) => Promise<void>
+  condition2: { field: string; value: string | number | Array<string | number> },
+) => Promise<void>;
 
-type DeleteLowerThan<T> = (
-  table: T,
-  field: string,
-  value: string | number
-) => Promise<void>
+type DeleteLowerThan<T> = (table: T, field: string, value: string | number) => Promise<void>;
 
-type DeleteWhere<T> = (
-  table: T,
-  conditions: ISQLCondition | ISQLCondition[]
-) => Promise<void>
+type DeleteWhere<T> = (table: T, conditions: ISQLCondition | ISQLCondition[]) => Promise<void>;
 
-type GetTableColumns<T> = (table: T) => Promise<ColumnInfo[]>
+type GetTableColumns<T> = (table: T) => Promise<ColumnInfo[]>;
 
-type AddColumn<T> = (table: T, column: ColumnDefinition) => Promise<void>
+type AddColumn<T> = (table: T, column: ColumnDefinition) => Promise<void>;
 
-type EnsureColumns<T> = (table: T, columns: ColumnDefinition[]) => Promise<void>
+type EnsureColumns<T> = (table: T, columns: ColumnDefinition[]) => Promise<void>;
 
 export interface DbBackend<T> {
-  ready: Promise<void>
-  createDatabases: (conf: DatabaseConfig, ...args: any) => Promise<void>
-  insert: Insert<T>
-  get: Get<T>
-  getJoin: GetJoin<T>
-  getWhereEqualOrDifferent: Get2<T>
-  getWhereEqualAndHigher: Get2<T>
-  getMaxWhereEqual: GetMinMax<T>
-  getMaxWhereEqualAndLower: GetMinMax2<T>
-  getMinWhereEqualAndHigher: GetMinMax2<T>
-  getMaxWhereEqualAndLowerJoin: GetMinMaxJoin2<T>
-  getCount: GetCount<T>
-  getAll: GetAll<T>
-  getHigherThan: Get<T>
-  match: Match<T>
-  update: Update<T>
-  updateAnd: UpdateAnd<T>
-  deleteEqual: DeleteEqual<T>
-  deleteEqualAnd: DeleteEqualAnd<T>
-  deleteLowerThan: DeleteLowerThan<T>
-  deleteWhere: DeleteWhere<T>
-  getTableColumns: GetTableColumns<T>
-  addColumn: AddColumn<T>
-  ensureColumns: EnsureColumns<T>
-  close: () => void
+  ready: Promise<void>;
+  createDatabases: (conf: DatabaseConfig, ...args: any) => Promise<void>;
+  insert: Insert<T>;
+  get: Get<T>;
+  getJoin: GetJoin<T>;
+  getWhereEqualOrDifferent: Get2<T>;
+  getWhereEqualAndHigher: Get2<T>;
+  getMaxWhereEqual: GetMinMax<T>;
+  getMaxWhereEqualAndLower: GetMinMax2<T>;
+  getMinWhereEqualAndHigher: GetMinMax2<T>;
+  getMaxWhereEqualAndLowerJoin: GetMinMaxJoin2<T>;
+  getCount: GetCount<T>;
+  getAll: GetAll<T>;
+  getHigherThan: Get<T>;
+  match: Match<T>;
+  update: Update<T>;
+  updateAnd: UpdateAnd<T>;
+  deleteEqual: DeleteEqual<T>;
+  deleteEqualAnd: DeleteEqualAnd<T>;
+  deleteLowerThan: DeleteLowerThan<T>;
+  deleteWhere: DeleteWhere<T>;
+  getTableColumns: GetTableColumns<T>;
+  addColumn: AddColumn<T>;
+  ensureColumns: EnsureColumns<T>;
+  close: () => void;
 }

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,4 +1,4 @@
-import type { ConnectionOptions } from "tls";
+import type { ConnectionOptions } from "node:tls";
 
 export type SupportedDatabases = "sqlite" | "pg";
 


### PR DESCRIPTION
## What

A simple PR that runs biomejs against db JS/TS files to auto fix what can be, in accordance with the new coding style.

## Why

The update of the coding style and the CI now makes the "lint" job fail due to legacy files.
This PR fixes what can be autofixed and serves as an excuse to run RabbitAI against the code base to gather some overall review and comments for future fixes.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fundamental flaw being fixed
CI/lint failures caused by legacy formatting and style mismatches (value imports used where type-only imports were appropriate, loose null-equality checks, inconsistent quoting/terminators). This is an automated BiomeJS autofix pass to make the DB package pass linting — not a behavioral bugfix.

## Systemic data-flow / core algorithm changes
None intended. No redesign of data flow or algorithms. Only narrow defensive tightenings that may affect behavior in edge cases:
- strict null/undefined checks replacing loose ==/!= and truthiness guards (pg/sqlite/sql).
- parseInt(rows[0].count, 10) to enforce base-10 parsing.
- SQLite addColumn tightened: identifier validation/quoting, column-type validation, safer DEFAULT handling while preserving idempotency on duplicate-column errors.

## Notable edits (concise)
- Project style normalization: double quotes, semicolons, trailing commas, reflowed arrays/exports.
- Convert many imports to type-only (import type) and consolidate exports in packages/db/src/index.ts; added explicit type re-exports (ColumnDefinition, ColumnInfo, DbBackend, adapter types).
- Replace loose equality (==/!=) with strict checks or explicit truthiness (e.g., !this.db; err === null || err === undefined).
- Use cross-env in packages/db/package.json test script.
- Large formatting-only diffs in src/sql/pg.ts and src/sql/sqlite.ts (high churn) plus removal of ESLint-disable comments.
- TODO.md gains a DB section listing manual refactors and lint items left for follow-up.

## Deprecated/removed APIs or legacy code
None. Public export shapes, class names, and function signatures are preserved.

## Explicitly ignored technical debt
Left for manual follow-up: non-autofixable lint failures and deeper refactors noted in TODO.md (extracting logic out of .then(), removing redundant async, replacing forEach loops, correcting DbBackend typing, etc.). CodeRabbit review planned to surface further human-required changes.

## Impact on public surface
No intended runtime API changes. Export ordering and added explicit type re-exports changed module surface ordering but not signatures; any behavioral differences should be incidental and limited to the defensive strictness noted above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->