### PR TITLE
Matrix-Resolve - Just a BiomeJS Pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -441,3 +441,31 @@ Biome flags functions exceeding a reasonable parameter count, and a 6-parameter
 signature is error-prone and hard to call correctly. This is pre-existing API surface,
 so it is out of scope for a formatting pass, but should be addressed as dedicated
 technical debt: consolidate into a single typed options object.
+
+## Matrix Resolve
+
+### `index.test.ts` — Remove Unused `DnsResolve` Type Import
+
+The `DnsResolve` type is imported but never referenced — likely left over from a
+previous iteration. Biome flags it as dead code. Either delete the import, or wire
+the type up if it was dropped by mistake.
+
+### `index.ts` — Wire Up or Delete `_prioritySort` (RFC 2782 Compliance)
+
+`_prioritySort` is defined but never called — the underscore prefix is silencing the
+linter without fixing the underlying issue. SRV records are not currently being sorted
+by priority, which violates RFC 2782: records with lower priority values must be
+preferred over higher ones.
+
+Two valid resolutions:
+
+1. **Use it** — sort records before mapping them to results:
+   ```typescript
+   records.sort(_prioritySort).map(...)
+   ```
+2. **Delete it** — if priority ordering is genuinely out of scope, remove the function
+   and document the deviation from RFC 2782 so future maintainers understand the
+   intentional trade-off.
+
+Leaving it as dead code is not a valid option: it gives a false impression that
+priority sorting is handled when it is not.

--- a/packages/matrix-resolve/jest.config.js
+++ b/packages/matrix-resolve/jest.config.js
@@ -1,8 +1,8 @@
-import jestConfigBase from '../../jest-base.config.js'
+import jestConfigBase from "../../jest-base.config.js";
 
 export default {
   ...jestConfigBase,
   moduleNameMapper: {
-    "node-fetch": "<rootDir>/../../node_modules/node-fetch-jest"
-  }
-}
+    "node-fetch": "<rootDir>/../../node_modules/node-fetch-jest",
+  },
+};

--- a/packages/matrix-resolve/rollup.config.js
+++ b/packages/matrix-resolve/rollup.config.js
@@ -1,3 +1,3 @@
-import config from '../../rollup-template.js'
+import config from "../../rollup-template.js";
 
-export default config(['node-fetch', 'node:dns', 'toad-cache'])
+export default config(["node-fetch", "node:dns", "toad-cache"]);

--- a/packages/matrix-resolve/src/index.test.ts
+++ b/packages/matrix-resolve/src/index.test.ts
@@ -1,4 +1,3 @@
-import { resolve as dnsResolve, lookup } from "node:dns";
 import fetch from "node-fetch";
 import { MatrixResolve, matrixResolve, type WellKnownMatrixServer } from "./index";
 

--- a/packages/matrix-resolve/src/index.test.ts
+++ b/packages/matrix-resolve/src/index.test.ts
@@ -1,153 +1,141 @@
-import fetch from 'node-fetch'
-import { resolve as dnsResolve, lookup } from 'node:dns'
-import { matrixResolve, MatrixResolve } from './index'
-import { type WellKnownMatrixServer } from './index'
+import { resolve as dnsResolve, lookup } from "node:dns";
+import fetch from "node-fetch";
+import { MatrixResolve, matrixResolve, type WellKnownMatrixServer } from "./index";
 
 type DnsResolve = (
   name: string,
   type: string,
-  callback: (
-    err: null | Error,
-    records: null | Record<string, string | number>
-  ) => void
-) => void
+  callback: (err: null | Error, records: null | Record<string, string | number>) => void,
+) => void;
 
-jest.mock('node-fetch', () => jest.fn())
+jest.mock("node-fetch", () => jest.fn());
 
-afterEach(() => jest.clearAllMocks())
+afterEach(() => jest.clearAllMocks());
 
-describe('matrixResolve', () => {
-  it('should accept ip with port', async () => {
-    expect(await matrixResolve('1.2.3.4:567')).toBe('https://1.2.3.4:567/')
-  })
+describe("matrixResolve", () => {
+  it("should accept ip with port", async () => {
+    expect(await matrixResolve("1.2.3.4:567")).toBe("https://1.2.3.4:567/");
+  });
 
-  it('should accept ip without port', async () => {
-    expect(await matrixResolve('1.2.3.4')).toBe('https://1.2.3.4:8448/')
-  })
+  it("should accept ip without port", async () => {
+    expect(await matrixResolve("1.2.3.4")).toBe("https://1.2.3.4:8448/");
+  });
 
-  it('should accept a hostname with port', async () => {
-    expect(await matrixResolve('example.com:1234')).toBe(
-      'https://example.com:1234/'
-    )
-  })
+  it("should accept a hostname with port", async () => {
+    expect(await matrixResolve("example.com:1234")).toBe("https://example.com:1234/");
+  });
 
-  it('should reject non fqdn names without port', (done) => {
-    matrixResolve('{}')
+  it("should reject non fqdn names without port", (done) => {
+    matrixResolve("{}")
       .then((m) => {
-        done(`Receive ${m} instead of error`)
+        done(`Receive ${m} instead of error`);
       })
       .catch((e) => {
-        expect(e instanceof Error)
-        done()
-      })
-  })
+        expect(e instanceof Error);
+        done();
+      });
+  });
 
-  it('should reject non fqdn names with port', (done) => {
-    matrixResolve('{}:234')
+  it("should reject non fqdn names with port", (done) => {
+    matrixResolve("{}:234")
       .then((m) => {
-        done(`Receive ${m} instead of error`)
+        done(`Receive ${m} instead of error`);
       })
       .catch((e) => {
-        expect(e instanceof Error)
-        done()
-      })
-  })
+        expect(e instanceof Error);
+        done();
+      });
+  });
 
-  describe('when hostname has no port', () => {
-    describe('when .well-knwon/matrix/server#m.server is available', () => {
-      it('should accept IP address with port', async () => {
+  describe("when hostname has no port", () => {
+    describe("when .well-knwon/matrix/server#m.server is available", () => {
+      it("should accept IP address with port", async () => {
         const wellKnown: WellKnownMatrixServer = {
-          'm.server': '1.2.3.5:678'
-        }
-        ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-          json: jest.fn().mockResolvedValue(wellKnown)
-        })
-        expect(await matrixResolve('matrix.org')).toBe('https://1.2.3.5:678/')
-      })
+          "m.server": "1.2.3.5:678",
+        };
+        (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+          json: jest.fn().mockResolvedValue(wellKnown),
+        });
+        expect(await matrixResolve("matrix.org")).toBe("https://1.2.3.5:678/");
+      });
 
-      it('should accept IP address without port', async () => {
+      it("should accept IP address without port", async () => {
         const wellKnown: WellKnownMatrixServer = {
-          'm.server': '1.2.3.5'
-        }
-        ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-          json: jest.fn().mockResolvedValue(wellKnown)
-        })
-        expect(await matrixResolve('matrix.org')).toBe('https://1.2.3.5:8448/')
-      })
+          "m.server": "1.2.3.5",
+        };
+        (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+          json: jest.fn().mockResolvedValue(wellKnown),
+        });
+        expect(await matrixResolve("matrix.org")).toBe("https://1.2.3.5:8448/");
+      });
 
-      it('should accept hostname with port', async () => {
+      it("should accept hostname with port", async () => {
         const wellKnown: WellKnownMatrixServer = {
-          'm.server': 'matrix-federation.matrix.org:443'
-        }
-        ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-          json: jest.fn().mockResolvedValue(wellKnown)
-        })
-        expect(await matrixResolve('matrix.org')).toBe(
-          'https://matrix-federation.matrix.org:443/'
-        )
-      })
-    })
+          "m.server": "matrix-federation.matrix.org:443",
+        };
+        (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+          json: jest.fn().mockResolvedValue(wellKnown),
+        });
+        expect(await matrixResolve("matrix.org")).toBe("https://matrix-federation.matrix.org:443/");
+      });
+    });
 
-    describe('when .well-knwon/matrix/server#m.server is not available', () => {
+    describe("when .well-knwon/matrix/server#m.server is not available", () => {
       beforeEach(() => {
-        ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-          json: Promise.reject
-        })
-      })
+        (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+          json: Promise.reject,
+        });
+      });
 
-      it('should try _matrix-fed._tcp when no .well-knwon', async () => {
-        expect(await matrixResolve('matrix.org')).toBe(
-          'https://matrix-federation.matrix.org.cdn.cloudflare.net:8443/'
-        )
-      })
+      it("should try _matrix-fed._tcp when no .well-knwon", async () => {
+        expect(await matrixResolve("matrix.org")).toBe("https://matrix-federation.matrix.org.cdn.cloudflare.net:8443/");
+      });
 
-      it('should return name:8448 when SRV fields not available but host exists', async () => {
-        expect(await matrixResolve('goodtech.info')).toBe(
-          'https://goodtech.info:8448/'
-        )
-      })
+      it("should return name:8448 when SRV fields not available but host exists", async () => {
+        expect(await matrixResolve("goodtech.info")).toBe("https://goodtech.info:8448/");
+      });
 
-      it('should fail when SRV fields not available and host does not exist', (done) => {
-        matrixResolve('matrix.noexist')
+      it("should fail when SRV fields not available and host does not exist", (done) => {
+        matrixResolve("matrix.noexist")
           .then((res) => {
-            done(`matrix.noexist should not have a value, get ${res}`)
+            done(`matrix.noexist should not have a value, get ${res}`);
           })
           .catch((e) => {
-            expect(e instanceof Error)
-            done()
-          })
-      })
-    })
-  })
-})
+            expect(e instanceof Error);
+            done();
+          });
+      });
+    });
+  });
+});
 
-describe('MatrixResolve', () => {
-  it('should work without cache', async () => {
+describe("MatrixResolve", () => {
+  it("should work without cache", async () => {
     const wellKnown: WellKnownMatrixServer = {
-      'm.server': '1.2.3.5'
-    }
-    ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-      json: jest.fn().mockResolvedValue(wellKnown)
-    })
-    const m = new MatrixResolve()
-    expect(await m.resolve('matrix.noexist')).toBe('https://1.2.3.5:8448/')
-  })
+      "m.server": "1.2.3.5",
+    };
+    (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+      json: jest.fn().mockResolvedValue(wellKnown),
+    });
+    const m = new MatrixResolve();
+    expect(await m.resolve("matrix.noexist")).toBe("https://1.2.3.5:8448/");
+  });
 
-  it('should work with cache', async () => {
+  it("should work with cache", async () => {
     const wellKnown: WellKnownMatrixServer = {
-      'm.server': '1.2.3.5'
-    }
-    ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-      json: jest.fn().mockResolvedValue(wellKnown)
-    })
+      "m.server": "1.2.3.5",
+    };
+    (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+      json: jest.fn().mockResolvedValue(wellKnown),
+    });
     const m = new MatrixResolve({
-      cache: 'toad-cache'
-    })
-    await m.cacheReady
-    expect(await m.resolve('matrix.noexist')).toBe('https://1.2.3.5:8448/')
-    ;(fetch as jest.Mock<any, any, any>).mockResolvedValue({
-      json: jest.fn().mockResolvedValue({})
-    })
-    expect(await m.resolve('matrix.noexist')).toBe('https://1.2.3.5:8448/')
-  })
-})
+      cache: "toad-cache",
+    });
+    await m.cacheReady;
+    expect(await m.resolve("matrix.noexist")).toBe("https://1.2.3.5:8448/");
+    (fetch as jest.Mock<any, any, any>).mockResolvedValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+    expect(await m.resolve("matrix.noexist")).toBe("https://1.2.3.5:8448/");
+  });
+});

--- a/packages/matrix-resolve/src/index.ts
+++ b/packages/matrix-resolve/src/index.ts
@@ -32,13 +32,13 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
     /* If the hostname is an IP literal, then that IP address should be used,
      * together with the given port number, or 8448 if no port is given. */
     let m = name.match(isIpLiteral);
-    if (m != null) {
+    if (m) {
       resolve(m[2] ? `https://${name}/` : `https://${name}:8448/`);
       return;
     }
 
     m = name.match(isHostname);
-    if (m == null) {
+    if (!m) {
       reject(new Error(`${name} isn't a valid hostname`));
       return;
     }
@@ -71,7 +71,7 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
         try {
           matrixServer = (res as WellKnownMatrixServer)["m.server"];
           m = matrixServer.match(isIpLiteral);
-          if (m != null) {
+          if (m) {
             resolve(m[2] ? `https://${matrixServer}/` : `https://${matrixServer}:8448/`);
             return;
           }
@@ -80,7 +80,7 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
              is present, an IP address is discovered by looking up CNAME, AAAA
              or A records for <delegated_hostname>. */
           m = matrixServer.match(isHostname);
-          if (m && m[2] != null) {
+          if (m && m[2]) {
             resolve(`https://${matrixServer}/`);
             return;
           }
@@ -103,12 +103,12 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
 
           // istanbul ignore next
           dnsResolve(matrixServer, resolve, reject);
-        } catch (e) {
+        } catch {
           // istanbul ignore next
           dnsResolve(name, resolve, reject);
         }
       })
-      .catch((e) => {
+      .catch((_e) => {
         dnsResolve(name, resolve, reject);
       });
   });
@@ -139,7 +139,7 @@ const dnsResolve = (
            * AAAA and A records. Requests are made to the resolved IP address
            * using port 8448 and a Host header containing the <hostname> */
           dns.lookup(name, (err) => {
-            if (err == null) {
+            if (!err) {
               resolve(`https://${name}:8448/`);
             } else {
               reject(new Error(`Unable to resolve ${name}: ${JSON.stringify(err)}`));
@@ -150,13 +150,13 @@ const dnsResolve = (
 };
 
 const dnsSrvResolve = (name: string): Promise<string | string[]> => {
-  const prioritySort = (a: SrvRecord, b: SrvRecord) => {
+  const _prioritySort = (a: SrvRecord, b: SrvRecord) => {
     // istanbul ignore next
     return b.priority - a.priority;
   };
   return new Promise((resolve, reject) => {
     dns.resolve(name, "SRV", (err, records) => {
-      if (err == null && records.length > 0) {
+      if (!err && records.length > 0) {
         const res = records.map((entry) => `https://${entry.name}:${entry.port}/`);
         resolve(res.length > 1 ? res : res[0]);
       } else {
@@ -172,7 +172,7 @@ export class MatrixResolve {
 
   constructor(args?: MatrixResolveArgs) {
     this.cacheReady = new Promise((resolve, reject) => {
-      if (args && args.cache) {
+      if (args?.cache) {
         args.cacheTtl ||= 600;
         args.cacheSize ||= 500;
         switch (args.cache) {

--- a/packages/matrix-resolve/src/index.ts
+++ b/packages/matrix-resolve/src/index.ts
@@ -1,29 +1,28 @@
-import fetch from 'node-fetch'
-import dns from 'node:dns'
-import { type SrvRecord } from 'node:dns'
-import { type ToadCache } from 'toad-cache'
+import dns, { type SrvRecord } from "node:dns";
+import fetch from "node-fetch";
+import type { ToadCache } from "toad-cache";
 
 // Imported form Perl modules (Regex::Common::*)
 const ipv4 =
-  '(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))'
+  "(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))";
 // Imported from is-ipv6-node
 const ipv6 =
-  '(?:(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?:(?::[0-9a-fA-F]{1,4}){1,6})|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(?::[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(?:ffff(?::0{1,4}){0,1}:){0,1}(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])|(?:[0-9a-fA-F]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9]))'
-const isIpLiteral = new RegExp(`^(${ipv4}|${ipv6})(?:(?<!:):(\\d+))?$`)
+  "(?:(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?:(?::[0-9a-fA-F]{1,4}){1,6})|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(?::[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(?:ffff(?::0{1,4}){0,1}:){0,1}(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])|(?:[0-9a-fA-F]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+const isIpLiteral = new RegExp(`^(${ipv4}|${ipv6})(?:(?<!:):(\\d+))?$`);
 const isHostname =
-  /^((?:(?:(?:[a-zA-Z0-9][-a-zA-Z0-9]*)?[a-zA-Z0-9])[.])*(?:[a-zA-Z][-a-zA-Z0-9]*[a-zA-Z0-9]|[a-zA-Z])[.]?)(?::(\d+))?$/
+  /^((?:(?:(?:[a-zA-Z0-9][-a-zA-Z0-9]*)?[a-zA-Z0-9])[.])*(?:[a-zA-Z][-a-zA-Z0-9]*[a-zA-Z0-9]|[a-zA-Z])[.]?)(?::(\d+))?$/;
 
 export type WellKnownMatrixServer = {
-  'm.server': string
-}
+  "m.server": string;
+};
 
 export type MatrixResolveArgs = {
-  cache?: CacheType
-  cacheTtl?: number
-  cacheSize?: number
-}
+  cache?: CacheType;
+  cacheTtl?: number;
+  cacheSize?: number;
+};
 
-export type CacheType = 'toad-cache'
+export type CacheType = "toad-cache";
 
 /* From spec 1.8 */
 
@@ -32,24 +31,24 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
   return new Promise((resolve, reject) => {
     /* If the hostname is an IP literal, then that IP address should be used,
      * together with the given port number, or 8448 if no port is given. */
-    let m = name.match(isIpLiteral)
+    let m = name.match(isIpLiteral);
     if (m != null) {
-      resolve(m[2] ? `https://${name}/` : `https://${name}:8448/`)
-      return
+      resolve(m[2] ? `https://${name}/` : `https://${name}:8448/`);
+      return;
     }
 
-    m = name.match(isHostname)
+    m = name.match(isHostname);
     if (m == null) {
-      reject(new Error(`${name} isn't a valid hostname`))
-      return
+      reject(new Error(`${name} isn't a valid hostname`));
+      return;
     }
 
     /* If the hostname is not an IP literal, and the server name includes an
      * explicit port, resolve the hostname to an IP address using CNAME, AAAA
      * or A records. */
     if (m[2]) {
-      resolve(`https://${name}/`)
-      return
+      resolve(`https://${name}/`);
+      return;
     }
 
     /* If the hostname is not an IP literal, a regular HTTPS request is made
@@ -60,34 +59,30 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
       .then((res) => res.json())
       .then((res) => {
         // istanbul ignore if
-        if (!(res as WellKnownMatrixServer)['m.server']) {
-          dnsResolve(name, resolve, reject)
-          return
+        if (!(res as WellKnownMatrixServer)["m.server"]) {
+          dnsResolve(name, resolve, reject);
+          return;
         }
 
         /* If <delegated_hostname> is an IP literal, then that IP address should
          * be used together with the <delegated_port> or 8448 if no port is
          * provided. */
-        let matrixServer: string
+        let matrixServer: string;
         try {
-          matrixServer = (res as WellKnownMatrixServer)['m.server']
-          m = matrixServer.match(isIpLiteral)
+          matrixServer = (res as WellKnownMatrixServer)["m.server"];
+          m = matrixServer.match(isIpLiteral);
           if (m != null) {
-            resolve(
-              m[2]
-                ? `https://${matrixServer}/`
-                : `https://${matrixServer}:8448/`
-            )
-            return
+            resolve(m[2] ? `https://${matrixServer}/` : `https://${matrixServer}:8448/`);
+            return;
           }
 
           /* If <delegated_hostname> is not an IP literal, and <delegated_port>
              is present, an IP address is discovered by looking up CNAME, AAAA
              or A records for <delegated_hostname>. */
-          m = matrixServer.match(isHostname)
+          m = matrixServer.match(isHostname);
           if (m && m[2] != null) {
-            resolve(`https://${matrixServer}/`)
-            return
+            resolve(`https://${matrixServer}/`);
+            return;
           }
 
           /* ALL NEXT CASES ARE EXACTLY THE SAME DNS SEARCH THAN IF NO
@@ -107,23 +102,23 @@ export const matrixResolve = (name: string): Promise<string | string[]> => {
            * and a port of 8448, using a Host header of <delegated_hostname> */
 
           // istanbul ignore next
-          dnsResolve(matrixServer, resolve, reject)
+          dnsResolve(matrixServer, resolve, reject);
         } catch (e) {
           // istanbul ignore next
-          dnsResolve(name, resolve, reject)
+          dnsResolve(name, resolve, reject);
         }
       })
       .catch((e) => {
-        dnsResolve(name, resolve, reject)
-      })
-  })
-}
+        dnsResolve(name, resolve, reject);
+      });
+  });
+};
 
 const dnsResolve = (
   name: string,
   //resolve: (value: string | string[]>) => void,
   resolve: (value: string | string[] | PromiseLike<string | string[]>) => void,
-  reject: (reason?: any) => void
+  reject: (reason?: any) => void,
 ): void => {
   /* If the /.well-known request resulted in an error response, a server is
    * found by resolving an SRV record for _matrix-fed._tcp.<hostname>. This
@@ -145,78 +140,74 @@ const dnsResolve = (
            * using port 8448 and a Host header containing the <hostname> */
           dns.lookup(name, (err) => {
             if (err == null) {
-              resolve(`https://${name}:8448/`)
+              resolve(`https://${name}:8448/`);
             } else {
-              reject(
-                new Error(`Unable to resolve ${name}: ${JSON.stringify(err)}`)
-              )
+              reject(new Error(`Unable to resolve ${name}: ${JSON.stringify(err)}`));
             }
-          })
-        })
-    })
-}
+          });
+        });
+    });
+};
 
 const dnsSrvResolve = (name: string): Promise<string | string[]> => {
   const prioritySort = (a: SrvRecord, b: SrvRecord) => {
     // istanbul ignore next
-    return b.priority - a.priority
-  }
+    return b.priority - a.priority;
+  };
   return new Promise((resolve, reject) => {
-    dns.resolve(name, 'SRV', (err, records) => {
+    dns.resolve(name, "SRV", (err, records) => {
       if (err == null && records.length > 0) {
-        const res = records.map(
-          (entry) => `https://${entry.name}:${entry.port}/`
-        )
-        resolve(res.length > 1 ? res : res[0])
+        const res = records.map((entry) => `https://${entry.name}:${entry.port}/`);
+        resolve(res.length > 1 ? res : res[0]);
       } else {
-        reject(false)
+        reject(false);
       }
-    })
-  })
-}
+    });
+  });
+};
 
 export class MatrixResolve {
-  cache?: ToadCache<string | string[]>
-  cacheReady: Promise<void>
+  cache?: ToadCache<string | string[]>;
+  cacheReady: Promise<void>;
 
   constructor(args?: MatrixResolveArgs) {
     this.cacheReady = new Promise((resolve, reject) => {
       if (args && args.cache) {
-        args.cacheTtl ||= 600
-        args.cacheSize ||= 500
+        args.cacheTtl ||= 600;
+        args.cacheSize ||= 500;
         switch (args.cache) {
-          case 'toad-cache':
-            import('toad-cache')
+          case "toad-cache":
+            import("toad-cache")
               .then((toadCache) => {
-                this.cache = new toadCache.Lru(args.cacheSize)
-                // @ts-ignore: args.cacheTtl is set
-                this.cache.ttl = args.cacheTtl * 1000
-                resolve()
+                this.cache = new toadCache.Lru(args.cacheSize);
+                // @ts-expect-error: args.cacheTtl is set
+                this.cache.ttl = args.cacheTtl * 1000;
+                resolve();
               })
               .catch((e) => {
                 // istanbul ignore next
-                reject(e)
-              })
-            break
+                reject(e);
+              });
+            break;
           default:
             // istanbul ignore next
-            throw new Error(`Unknown cache type ${args.cache}`)
+            throw new Error(`Unknown cache type ${args.cache}`);
         }
       } else {
-        resolve()
+        resolve();
       }
-    })
+    });
   }
 
   async resolve(name: string) {
     if (this.cache) {
-      const cachedValue = this.cache.get(name)
-      if (cachedValue) return cachedValue
+      const cachedValue = this.cache.get(name);
+      if (cachedValue) return cachedValue;
     }
-    const response = await matrixResolve(name)
+    const response = await matrixResolve(name);
     if (this.cache) {
-      this.cache.set(name, response)
+      this.cache.set(name, response);
     }
-    return response
+    return response;
   }
 }


### PR DESCRIPTION
## What

A simple PR that runs biomejs against db JS/TS files to auto fix what can be, in accordance with the new coding style.

## Why

The update of the coding style and the CI now makes the "lint" job fail due to legacy files.
This PR fixes what can be autofixed and serves as an excuse to run RabbitAI against the code base to gather some overall review and comments for future fixes.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fundamental flaw
This PR fixes no runtime bug — it’s a Biome autofix pass. The "flaw" was purely stylistic: code violated the updated org-wide Biome linting rules and caused CI lint failures.

Systemic data flow & core algorithm changes
None. The DNS resolution and caching pipeline (matrixResolve → dnsResolve → dnsSrvResolve), regex-based IP/hostname detection, Promise flow, and public API signatures are unchanged. All edits are syntactic (quotes, semicolons, trailing commas), minor truthiness/guard style changes (e.g., m != null → if (m), err == null → !err, args && args.cache → args?.cache) and renames for unused locals (prioritySort → _prioritySort). No algorithmic refactors, behavioral changes, or reorderings affecting data flow were introduced.

Deprecated APIs / deleted legacy code
None. No public API was removed or deprecated. The only compiler-directive change is @ts-ignore → @ts-expect-error (stricter but non-functional).

Explicitly ignored technical debt
Left intentionally unresolved:
- Dead import/type in index.test.ts (DnsResolve imported but unused) documented in TODO.md but not removed.
- SRV-record helper (_prioritySort) is defined but not applied; TODO.md documents options but the PR does not change SRV record sorting behavior.
These items were noted in TODO.md and left for a manual follow-up.

Files touched (high level)
- packages/matrix-resolve/src/index.ts — formatting, stricter stylistic guards, minor renames; no external-signature changes.
- packages/matrix-resolve/src/index.test.ts — consolidated imports, removed unused DNS imports, quote/formatting changes; no test logic changes.
- packages/matrix-resolve/jest.config.js, rollup.config.js — formatting/quotes/semicolons.
- TODO.md — added notes about dead-code and SRV-sort gap.

Review notes
Low-risk style pass. Focus reviews on the TODO items (dead import and unused SRV sorter) if you want follow-up functional work; otherwise, approve for merge to resolve CI lint failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->