### PR TITLE
fix(sqlite): reject promise on getAll query failure (#180)

### DIFF
--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -412,40 +412,70 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition,
           query
         })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error('[SQLite][_get] SELECT failed', {
-                tables,
-                fields,
-                condition,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug('[SQLite][_get] SELECT successful', {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
+        try {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+          // @ts-ignore never undefined
+          const stmt = this.db.prepare(query, (prepErr: Error | null) => {
+            if (prepErr != null) {
+              this.logger.error(
+                '[SQLite][_get] Failed to prepare statement',
+                {
+                  tables,
+                  fields,
+                  condition,
+                  query,
+                  error: prepErr
+                }
+              )
+              reject(prepErr)
+              return
             }
-          }
-        )
-        stmt.finalize((err) => {
-          if (err) {
-            this.logger.error('[SQLite][_get] Statement finalize failed', {
-              tables,
-              error: err
+            stmt.all(
+              values,
+              (
+                err: string,
+                rows: Array<Record<string, string | number>>
+              ) => {
+                /* istanbul ignore if */
+                if (err != null) {
+                  this.logger.error('[SQLite][_get] SELECT failed', {
+                    tables,
+                    fields,
+                    condition,
+                    query,
+                    error: err
+                  })
+                  reject(err)
+                } else {
+                  this.logger.debug('[SQLite][_get] SELECT successful', {
+                    tables,
+                    rowCount: rows.length
+                  })
+                  resolve(rows)
+                }
+              }
+            )
+            stmt.finalize((err) => {
+              if (err) {
+                this.logger.error(
+                  '[SQLite][_get] Statement finalize failed',
+                  {
+                    tables,
+                    error: err
+                  }
+                )
+                reject(err)
+              }
             })
-            reject(err)
-          }
-        })
+          })
+        } catch (e) {
+          this.logger.error('[SQLite][_get] Failed to prepare statement', {
+            tables,
+            query,
+            error: e
+          })
+          reject(e)
+        }
       }
     })
   }
@@ -683,41 +713,70 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
           condition,
           query
         })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error(`${minmax} query failed`, {
-                tables,
-                targetField,
-                fields,
-                condition,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug(`${minmax} query successful`, {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
+        try {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+          // @ts-ignore never undefined
+          const stmt = this.db.prepare(query, (prepErr: Error | null) => {
+            if (prepErr != null) {
+              this.logger.error(
+                `[SQLite] Failed to prepare ${minmax} statement`,
+                {
+                  tables,
+                  targetField,
+                  query,
+                  error: prepErr
+                }
+              )
+              reject(prepErr)
+              return
             }
-          }
-        )
-        stmt.finalize((err) => {
-          if (err) {
-            this.logger.error(`${minmax} statement finalize failed`, {
-              tables,
-              error: err
+            stmt.all(
+              values,
+              (
+                err: string,
+                rows: Array<Record<string, string | number>>
+              ) => {
+                /* istanbul ignore if */
+                if (err != null) {
+                  this.logger.error(`${minmax} query failed`, {
+                    tables,
+                    targetField,
+                    fields,
+                    condition,
+                    query,
+                    error: err
+                  })
+                  reject(err)
+                } else {
+                  this.logger.debug(`${minmax} query successful`, {
+                    tables,
+                    rowCount: rows.length
+                  })
+                  resolve(rows)
+                }
+              }
+            )
+            stmt.finalize((err) => {
+              if (err) {
+                this.logger.error(`${minmax} statement finalize failed`, {
+                  tables,
+                  error: err
+                })
+                reject(err)
+              }
             })
-            reject(err)
-          }
-        })
+          })
+        } catch (e) {
+          this.logger.error(
+            `[SQLite] Failed to prepare ${minmax} statement`,
+            {
+              tables,
+              query,
+              error: e
+            }
+          )
+          reject(e)
+        }
       }
     })
   }

--- a/packages/matrix-identity-server/src/db/sql/sqlite.ts
+++ b/packages/matrix-identity-server/src/db/sql/sqlite.ts
@@ -406,40 +406,67 @@ class SQLite<T extends string> extends SQL<T> implements IdDbBackend<T> {
           condition,
           query
         })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error('[SQLite][_get] SELECT failed', {
+        try {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+          // @ts-ignore never undefined
+          const stmt = this.db.prepare(query, (prepErr: Error | null) => {
+            if (prepErr != null) {
+              this.logger.error('[SQLite][_get] Failed to prepare statement', {
                 tables,
                 fields,
                 condition,
                 query,
-                error: err
+                error: prepErr
               })
-              reject(err)
-            } else {
-              this.logger.debug('[SQLite][_get] SELECT successful', {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
+              reject(prepErr)
+              return
             }
-          }
-        )
-        stmt.finalize((err) => {
-          if (err) {
-            this.logger.error('[SQLite][_get] Statement finalize failed', {
-              tables,
-              error: err
+            stmt.all(
+              values,
+              (
+                err: string,
+                rows: Array<Record<string, string | number>>
+              ) => {
+                /* istanbul ignore if */
+                if (err != null) {
+                  this.logger.error('[SQLite][_get] SELECT failed', {
+                    tables,
+                    fields,
+                    condition,
+                    query,
+                    error: err
+                  })
+                  reject(err)
+                } else {
+                  this.logger.debug('[SQLite][_get] SELECT successful', {
+                    tables,
+                    rowCount: rows.length
+                  })
+                  resolve(rows)
+                }
+              }
+            )
+            stmt.finalize((err) => {
+              if (err) {
+                this.logger.error(
+                  '[SQLite][_get] Statement finalize failed',
+                  {
+                    tables,
+                    error: err
+                  }
+                )
+                reject(err)
+              }
             })
-            reject(err)
-          }
-        })
+          })
+        } catch (e) {
+          this.logger.error('[SQLite][_get] Failed to prepare statement', {
+            tables,
+            query,
+            error: e
+          })
+          reject(e)
+        }
       }
     })
   }
@@ -677,41 +704,70 @@ class SQLite<T extends string> extends SQL<T> implements IdDbBackend<T> {
           condition,
           query
         })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore never undefined
-        const stmt = this.db.prepare(query)
-        stmt.all(
-          values,
-          (err: string, rows: Array<Record<string, string | number>>) => {
-            /* istanbul ignore if */
-            if (err != null) {
-              this.logger.error(`${minmax} query failed`, {
-                tables,
-                targetField,
-                fields,
-                condition,
-                query,
-                error: err
-              })
-              reject(err)
-            } else {
-              this.logger.debug(`${minmax} query successful`, {
-                tables,
-                rowCount: rows.length
-              })
-              resolve(rows)
+        try {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+          // @ts-ignore never undefined
+          const stmt = this.db.prepare(query, (prepErr: Error | null) => {
+            if (prepErr != null) {
+              this.logger.error(
+                `[SQLite] Failed to prepare ${minmax} statement`,
+                {
+                  tables,
+                  targetField,
+                  query,
+                  error: prepErr
+                }
+              )
+              reject(prepErr)
+              return
             }
-          }
-        )
-        stmt.finalize((err) => {
-          if (err) {
-            this.logger.error(`${minmax} statement finalize failed`, {
-              tables,
-              error: err
+            stmt.all(
+              values,
+              (
+                err: string,
+                rows: Array<Record<string, string | number>>
+              ) => {
+                /* istanbul ignore if */
+                if (err != null) {
+                  this.logger.error(`${minmax} query failed`, {
+                    tables,
+                    targetField,
+                    fields,
+                    condition,
+                    query,
+                    error: err
+                  })
+                  reject(err)
+                } else {
+                  this.logger.debug(`${minmax} query successful`, {
+                    tables,
+                    rowCount: rows.length
+                  })
+                  resolve(rows)
+                }
+              }
+            )
+            stmt.finalize((err) => {
+              if (err) {
+                this.logger.error(`${minmax} statement finalize failed`, {
+                  tables,
+                  error: err
+                })
+                reject(err)
+              }
             })
-            reject(err)
-          }
-        })
+          })
+        } catch (e) {
+          this.logger.error(
+            `[SQLite] Failed to prepare ${minmax} statement`,
+            {
+              tables,
+              query,
+              error: e
+            }
+          )
+          reject(e)
+        }
       }
     })
   }


### PR DESCRIPTION
## What

Add proper error handling for db.prepare() failures in SQLite _get() and _getMinMax() methods. When a SQL statement fails to prepare, the promise now rejects instead of hanging forever.

## Why

When db.prepare(query) fails silently, stmt.all() callback is never called, leaving the promise unresolved indefinitely. This causes the application to hang with no error output, making debugging extremely difficult.

Fixes #180

## How

Changed db.prepare(query) to use the error callback so preparation errors trigger a proper rejection. Added try-catch wrapper as safety net. Applied to both the shared db package and the identity server db.