### PR TITLE
Implements Dynamic CORS Origin Policy with Regex Support

### DIFF
--- a/.compose/traefik/dynamic/deploy.yml
+++ b/.compose/traefik/dynamic/deploy.yml
@@ -9,25 +9,25 @@ tls:
         keyFile: "/certs/docker.internal+1-key.pem"
 
 http:
-  middlewares:
-    cors-policy:
-      headers:
-        accessControlAllowMethods:
-          - "GET"
-          - "OPTIONS"
-          - "POST"
-          - "PUT"
-          - "DELETE"
-          - "PATCH"
-        accessControlAllowOriginList:
-          - "https://app.element.io"
-          - "https://chat.docker.internal"
-          - "https://tom.docker.internal"
-          - "https://matrix.docker.internal"
-          - "https://auth.docker.internal"
-          - "https://fed.docker.internal"
-        accessControlAllowHeaders:
-          - "*"
-        accessControlAllowCredentials: true
-        accessControlMaxAge: 100
-        addVaryHeader: true
+  # middlewares:
+  #   cors-policy:
+  #     headers:
+  #       accessControlAllowMethods:
+  #         - "GET"
+  #         - "OPTIONS"
+  #         - "POST"
+  #         - "PUT"
+  #         - "DELETE"
+  #         - "PATCH"
+  #       accessControlAllowOriginList:
+  #         - "https://app.element.io"
+  #         - "https://chat.docker.internal"
+  #         - "https://tom.docker.internal"
+  #         - "https://matrix.docker.internal"
+  #         - "https://auth.docker.internal"
+  #         - "https://fed.docker.internal"
+  #       accessControlAllowHeaders:
+  #         - "*"
+  #       accessControlAllowCredentials: true
+  #       accessControlMaxAge: 100
+  #       addVaryHeader: true

--- a/.compose/traefik/dynamic/dev.yml
+++ b/.compose/traefik/dynamic/dev.yml
@@ -9,28 +9,28 @@ tls:
         keyFile: "/certs/docker.internal+1-key.pem"
 
 http:
-  middlewares:
-    cors-policy:
-      headers:
-        accessControlAllowMethods:
-          - "GET"
-          - "OPTIONS"
-          - "POST"
-          - "PUT"
-          - "DELETE"
-          - "PATCH"
-        accessControlAllowOriginList:
-          - "https://app.element.io"
-          - "https://chat.docker.internal"
-          - "https://tom.docker.internal"
-          - "https://matrix.docker.internal"
-          - "https://auth.docker.internal"
-          - "https://fed.docker.internal"
-        accessControlAllowHeaders:
-          - "*"
-        accessControlAllowCredentials: true
-        accessControlMaxAge: 100
-        addVaryHeader: true
+  # middlewares:
+  #   cors-policy:
+  #     headers:
+  #       accessControlAllowMethods:
+  #         - "GET"
+  #         - "OPTIONS"
+  #         - "POST"
+  #         - "PUT"
+  #         - "DELETE"
+  #         - "PATCH"
+  #       accessControlAllowOriginList:
+  #         - "https://app.element.io"
+  #         - "https://chat.docker.internal"
+  #         - "https://tom.docker.internal"
+  #         - "https://matrix.docker.internal"
+  #         - "https://auth.docker.internal"
+  #         - "https://fed.docker.internal"
+  #       accessControlAllowHeaders:
+  #         - "*"
+  #       accessControlAllowCredentials: true
+  #       accessControlMaxAge: 100
+  #       addVaryHeader: true
 
   routers:
     tom-direct:
@@ -38,7 +38,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 110
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: tom-local
 
     tom-direct-http:
@@ -52,7 +52,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 100
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: tom-local
 
     tom-identity:
@@ -60,7 +60,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 90
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: tom-local
 
     tom-matrix-client:
@@ -68,7 +68,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 80
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: tom-local
 
     # Federation service routes (when running on port 3001)
@@ -77,7 +77,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 110
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: fed-local
 
     fed-direct-http:
@@ -91,7 +91,7 @@ http:
       entrypoints: ["websecure"]
       tls: {}
       priority: 90
-      middlewares: ["cors-policy@file"]
+      # middlewares: ["cors-policy@file"]
       service: fed-local
 
   services:

--- a/apps/tom-server/src/config/schema.ts
+++ b/apps/tom-server/src/config/schema.ts
@@ -62,8 +62,9 @@ const DEFAULT_CREATEROOM_PROXY_IS_DIRECT_MASK = {
 
 const DEFAULT_CORS_ENABLED = true;
 const DEFAULT_CORS_CREDENTIALS = false; // Wildcard in origin is not compatible with this being true by specs.
+const DEFAULT_CORS_ALLOW_NO_ORIGIN: boolean = true; // Control whether or not to block requests without origin (e.g. mobile apps)
 const DEFAULT_CORS_ORIGINS: string[] = ["*"];
-const DEFAULT_CORS_METHODS: string[] = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"];
+const DEFAULT_CORS_METHODS: string[] = ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"];
 const DEFAULT_CORS_ALLOWED_HEADERS: string[] = [
   "Origin",
   "X-Requested-With",
@@ -317,23 +318,26 @@ const createroomProxySchema = z.object({
 });
 
 // biome-ignore lint/nursery/useExplicitType: Zod type is fragile to write by hand, we let TS infer it
-const corsSettingsSchema = z.object({
-  enabled: z.boolean().default(DEFAULT_CORS_ENABLED),
-  origins: z.array(z.string()).default(DEFAULT_CORS_ORIGINS),
-  credentials: z.boolean().default(DEFAULT_CORS_CREDENTIALS),
-  methods: z.array(z.string()).default(DEFAULT_CORS_METHODS),
-  allowed_headers: z.array(z.string()).default(DEFAULT_CORS_ALLOWED_HEADERS),
-  exposed_headers: z.array(z.string()).optional(),
-  max_age: z.number().int().min(0).optional(),
-}).superRefine((value, ctx) => {
-  if (value.credentials && value.origins.includes("*")) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["origins"],
-      message: "cors.credentials cannot be enabled when cors.origin contains '*'",
-    });
-  }
-});
+const corsSettingsSchema = z
+  .object({
+    enabled: z.boolean().default(DEFAULT_CORS_ENABLED),
+    allow_no_origin: z.boolean().default(DEFAULT_CORS_ALLOW_NO_ORIGIN),
+    origins: z.array(z.string()).default(DEFAULT_CORS_ORIGINS),
+    credentials: z.boolean().default(DEFAULT_CORS_CREDENTIALS),
+    methods: z.array(z.string()).default(DEFAULT_CORS_METHODS),
+    allowed_headers: z.array(z.string()).default(DEFAULT_CORS_ALLOWED_HEADERS),
+    exposed_headers: z.array(z.string()).optional(),
+    max_age: z.number().int().min(0).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.credentials && value.origins.includes("*")) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["origins"],
+        message: "cors.credentials cannot be enabled when cors.origin contains '*'",
+      });
+    }
+  });
 
 // biome-ignore lint/nursery/useExplicitType: Zod type is fragile to write by hand, we let TS infer it
 const serverSettingsSchema = z.object({

--- a/apps/tom-server/src/config/schema.ts
+++ b/apps/tom-server/src/config/schema.ts
@@ -62,7 +62,7 @@ const DEFAULT_CREATEROOM_PROXY_IS_DIRECT_MASK = {
 
 const DEFAULT_CORS_ENABLED = true;
 const DEFAULT_CORS_CREDENTIALS = false; // Wildcard in origin is not compatible with this being true by specs.
-const DEFAULT_CORS_ALLOW_NO_ORIGIN: boolean = true; // Control whether or not to block requests without origin (e.g. mobile apps)
+const DEFAULT_CORS_ALLOW_NO_ORIGIN: boolean = false; // Control whether or not to block requests without origin (e.g. mobile apps)
 const DEFAULT_CORS_ORIGINS: string[] = ["*"];
 const DEFAULT_CORS_METHODS: string[] = ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"];
 const DEFAULT_CORS_ALLOWED_HEADERS: string[] = [

--- a/apps/tom-server/src/config/schema.ts
+++ b/apps/tom-server/src/config/schema.ts
@@ -337,6 +337,22 @@ const corsSettingsSchema = z
         message: "cors.credentials cannot be enabled when cors.origin contains '*'",
       });
     }
+
+    for (const [index, origin] of value.origins.entries()) {
+      if (!origin.startsWith("~")) {
+        continue;
+      }
+
+      try {
+        new RegExp(origin.slice(1));
+      } catch {
+        ctx.addIssue({
+          code: "custom",
+          path: ["origins", index],
+          message: "cors.origins regex rules must be valid regular expressions",
+        });
+      }
+    }
   });
 
 // biome-ignore lint/nursery/useExplicitType: Zod type is fragile to write by hand, we let TS infer it

--- a/apps/tom-server/src/middleware/cors.ts
+++ b/apps/tom-server/src/middleware/cors.ts
@@ -14,16 +14,6 @@ import type { NextFunction, Request, RequestHandler, Response } from "express";
 
 import type { Config } from "../config/types";
 
-// type CorsOptions = {
-//   origin: string[] | ((origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => void);
-//   methods: string;
-//   allowedHeaders: string[];
-//   exposedHeaders?: string[];
-//   credentials: boolean;
-//   maxAge?: number;
-//   optionsSuccessStatus: number;
-// };
-
 /**
  * Creates CORS middleware configured from application settings.
  *
@@ -37,20 +27,38 @@ export function createCorsMiddleware(corsConfig: Config["cors"]): RequestHandler
     };
   }
 
+  let allow_all = false;
+  const exacts = new Set<string>();
+  const regexes: RegExp[] = [];
+
+  for (const rule of corsConfig.origins) {
+    if (rule === "*") {
+      allow_all = true;
+      break;
+    }
+
+    if (rule.startsWith("~")) {
+      regexes.push(new RegExp(rule.slice(1)));
+    } else {
+      exacts.add(rule);
+    }
+  }
+
   const options: CorsOptions = {
-    origin: corsConfig.origins,
+    // biome-ignore lint/nursery/useExplicitType: cors types does not export CustomOrigin type
+    origin: (o, cb) => {
+      if (allow_all) return cb(null, true);
+      if (!o && corsConfig.allow_no_origin) return cb(null, true);
+      if (o && (exacts.has(o) || regexes.some((rx) => rx.test(o)))) return cb(null, true);
+
+      cb(new Error(`${o} blocked by server CORS policy`));
+    },
     methods: corsConfig.methods,
     allowedHeaders: corsConfig.allowed_headers,
     credentials: corsConfig.credentials,
+    exposedHeaders: corsConfig.exposed_headers,
+    maxAge: corsConfig.max_age,
   };
-
-  if (corsConfig.exposed_headers !== undefined && corsConfig.exposed_headers.length > 0) {
-    options.exposedHeaders = corsConfig.exposed_headers;
-  }
-
-  if (corsConfig.max_age !== undefined) {
-    options.maxAge = corsConfig.max_age;
-  }
 
   return cors(options);
 }

--- a/compose.deploy.yml
+++ b/compose.deploy.yml
@@ -58,28 +58,28 @@ services:
       - "traefik.http.routers.tom-direct.entrypoints=websecure"
       - "traefik.http.routers.tom-direct.tls=true"
       - "traefik.http.routers.tom-direct.priority=110"
-      - "traefik.http.routers.tom-direct.middlewares=cors-policy@file"
+      # - "traefik.http.routers.tom-direct.middlewares=cors-policy@file"
 
       # .well-known endpoints on the matrix domain
       - "traefik.http.routers.tom-wellknown.rule=(Host(`matrix.docker.internal`) || Host(`docker.internal`)) && PathPrefix(`/.well-known/matrix/client`)"
       - "traefik.http.routers.tom-wellknown.entrypoints=websecure"
       - "traefik.http.routers.tom-wellknown.tls=true"
       - "traefik.http.routers.tom-wellknown.priority=100"
-      - "traefik.http.routers.tom-wellknown.middlewares=cors-policy@file"
+      # - "traefik.http.routers.tom-wellknown.middlewares=cors-policy@file"
 
       # Matrix Identity Server API
       - "traefik.http.routers.tom-identity.rule=Host(`matrix.docker.internal`) && PathPrefix(`/_matrix/identity/v2`)"
       - "traefik.http.routers.tom-identity.entrypoints=websecure"
       - "traefik.http.routers.tom-identity.tls=true"
       - "traefik.http.routers.tom-identity.priority=90"
-      - "traefik.http.routers.tom-identity.middlewares=cors-policy@file"
+      # - "traefik.http.routers.tom-identity.middlewares=cors-policy@file"
 
       # createRoom proxy
       - "traefik.http.routers.tom-matrix-client.rule=Host(`matrix.docker.internal`) && PathPrefix(`/_matrix/client/v3/createRoom`)"
       - "traefik.http.routers.tom-matrix-client.entrypoints=websecure"
       - "traefik.http.routers.tom-matrix-client.tls=true"
       - "traefik.http.routers.tom-matrix-client.priority=80"
-      - "traefik.http.routers.tom-matrix-client.middlewares=cors-policy@file"
+      # - "traefik.http.routers.tom-matrix-client.middlewares=cors-policy@file"
 
       - "traefik.http.services.tom.loadbalancer.server.port=3000"
 
@@ -111,13 +111,13 @@ services:
       - "traefik.http.routers.fed-direct.entrypoints=websecure"
       - "traefik.http.routers.fed-direct.tls=true"
       - "traefik.http.routers.fed-direct.priority=110"
-      - "traefik.http.routers.fed-direct.middlewares=cors-policy@file"
+      # - "traefik.http.routers.fed-direct.middlewares=cors-policy@file"
 
       # Federation Identity Server API
       - "traefik.http.routers.fed-identity.rule=Host(`fed.docker.internal`) && PathPrefix(`/_matrix/identity/v2`)"
       - "traefik.http.routers.fed-identity.entrypoints=websecure"
       - "traefik.http.routers.fed-identity.tls=true"
       - "traefik.http.routers.fed-identity.priority=90"
-      - "traefik.http.routers.fed-identity.middlewares=cors-policy@file"
+      # - "traefik.http.routers.fed-identity.middlewares=cors-policy@file"
 
       - "traefik.http.services.fed.loadbalancer.server.port=3000"

--- a/compose.yml
+++ b/compose.yml
@@ -297,6 +297,7 @@ services:
       - "traefik.http.routers.chat.entrypoints=websecure"
       - "traefik.http.routers.chat.tls=true"
       # - "traefik.http.routers.chat.middlewares=chat-redirect,cors-policy@file"
+      - "traefik.http.routers.chat.middlewares=chat-redirect"
       - "traefik.http.services.chat.loadbalancer.server.port=80"
       - "traefik.http.middlewares.chat-redirect.redirectregex.regex=^https://([^/]+)/?$$"
       - "traefik.http.middlewares.chat-redirect.redirectregex.replacement=https://$$1/web/"

--- a/compose.yml
+++ b/compose.yml
@@ -114,7 +114,7 @@ services:
       - "traefik.http.routers.smtp.rule=Host(`smtp.docker.internal`)"
       - "traefik.http.routers.smtp.entrypoints=websecure"
       - "traefik.http.routers.smtp.tls=true"
-      - "traefik.http.routers.smtp.middlewares=cors-policy@file"
+      # - "traefik.http.routers.smtp.middlewares=cors-policy@file"
       - "traefik.http.services.smtp.loadbalancer.server.port=37408"
 
   # ---------------------------------------------------------------------------
@@ -174,7 +174,7 @@ services:
       - "traefik.http.routers.auth.entrypoints=websecure"
       - "traefik.http.routers.auth.tls=true"
       - "traefik.http.routers.auth.priority=10"
-      - "traefik.http.routers.auth.middlewares=cors-policy@file"
+      # - "traefik.http.routers.auth.middlewares=cors-policy@file"
       - "traefik.http.services.auth.loadbalancer.server.port=80"
 
   # ---------------------------------------------------------------------------
@@ -203,7 +203,7 @@ services:
       - "traefik.http.routers.synapse.entrypoints=websecure"
       - "traefik.http.routers.synapse.tls=true"
       - "traefik.http.routers.synapse.priority=10"
-      - "traefik.http.routers.synapse.middlewares=cors-policy@file"
+      # - "traefik.http.routers.synapse.middlewares=cors-policy@file"
       - "traefik.http.services.synapse.loadbalancer.server.port=8008"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8008/_matrix/client/versions || exit 1"]
@@ -284,7 +284,7 @@ services:
   # Twake Chat frontend
   # ---------------------------------------------------------------------------
   twake-chat:
-    image: linagora/twake-web:v2.21.17
+    image: linagora/twake-web:v2.22.0
     restart: unless-stopped
     depends_on:
       synapse: { condition: service_healthy }
@@ -296,7 +296,7 @@ services:
       - "traefik.http.routers.chat.rule=Host(`chat.docker.internal`)"
       - "traefik.http.routers.chat.entrypoints=websecure"
       - "traefik.http.routers.chat.tls=true"
-      - "traefik.http.routers.chat.middlewares=chat-redirect,cors-policy@file"
+      # - "traefik.http.routers.chat.middlewares=chat-redirect,cors-policy@file"
       - "traefik.http.services.chat.loadbalancer.server.port=80"
       - "traefik.http.middlewares.chat-redirect.redirectregex.regex=^https://([^/]+)/?$$"
       - "traefik.http.middlewares.chat-redirect.redirectregex.replacement=https://$$1/web/"


### PR DESCRIPTION
## What

Implements a dynamic origin CORS Policy allowing server administrators to precisely control which origins to accept.

## Why

The current CORS configuration was assuming the `cors()` middleware was able to take an array of allowed origins in its build options. The local traefik cors middleware was taking precedence over the custom new express middleware, leading to a falty true deployment.

In certain cases a server administrator must be able to tell ToM to allow requests coming from multiple domains. Twake Workplace is using subdomains as a way to keep alive multiple users connections on one browser for example.

## How

This implementation adds two key changes:

1. a new `allow_no_origin` boolean: allowing some misconstructed mobile app requests to pass but at the expense of security
2. a regexp `~` prefix for `origins` array items: allowing administrators to setup a dynamic policy based on regular expression based on NGINX config format

The final dynamic policy is built at server start and injected as a lambda function in the cors middleware `origin` CorsOption key.