### PR TITLE
chore(utils): pass biome lint

### DIFF
--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -1,7 +1,10 @@
 import type http from "node:http";
 import querystring from "node:querystring";
-import type { TwakeLogger } from "@twake/logger";
+
 import type { Request, Response } from "express";
+
+import type { TwakeLogger } from "@twake/logger";
+
 import { epoch, isMatrixId, isValidUrl, jsonContent, send, toMatrixId, validateParameters } from "./index";
 
 describe("Utility Functions", () => {
@@ -43,7 +46,7 @@ describe("Utility Functions", () => {
       const req = {
         headers: { "content-type": "application/json" },
         body: { key: "value" },
-        on: (event: string, callback: any) => {
+        on: (event: string, callback: (data?: string) => void) => {
           if (event === "data") {
             callback(JSON.stringify({ key: "value" }));
           }
@@ -62,7 +65,7 @@ describe("Utility Functions", () => {
     it("should handle form-urlencoded content", (done) => {
       const req = {
         headers: { "content-type": "application/x-www-form-urlencoded" },
-        on: (event: string, callback: any) => {
+        on: (event: string, callback: (data?: string) => void) => {
           if (event === "data") {
             callback(querystring.encode({ key: "value" }));
           }
@@ -81,7 +84,7 @@ describe("Utility Functions", () => {
     it("should handle JSON parsing errors", () => {
       const req = {
         headers: { "content-type": "application/json" },
-        on: (event: string, callback: any) => {
+        on: (event: string, callback: (data?: string) => void) => {
           if (event === "data") {
             callback("invalid json");
           }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -2,8 +2,11 @@
 
 import type http from "node:http";
 import querystring from "node:querystring";
-import type { TwakeLogger } from "@twake/logger";
+
 import type { NextFunction, Request, Response } from "express";
+
+import type { TwakeLogger } from "@twake/logger";
+
 import { errMsg } from "./errors";
 
 export const hostnameRe =
@@ -38,7 +41,7 @@ export const jsonContent = (
   let content = "";
   let accept = true;
   const end = (): void => {
-    let obj;
+    let obj: unknown;
     try {
       if (typeof content === "string") {
         // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
@@ -56,7 +59,7 @@ export const jsonContent = (
       send(res, 400, errMsg("unknown", err as string));
       accept = false;
     }
-    if (accept) callback(obj);
+    if (accept) callback(obj as Record<string, string>);
   };
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
   /* istanbul ignore if */ // @ts-expect-error


### PR DESCRIPTION
## Summary

Types the local `obj` in `jsonContent` and casts at the callback boundary so the broader-than-needed `Record<string, string>` contract callers expect is preserved without `any`. Tightens the `req.on(event, callback)` mock typing in the tests so `noExplicitAny` no longer fires.