### PR TITLE
chore(db): pass biome lint

### DIFF
--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,4 +1,5 @@
 import type { TwakeLogger } from "@twake/logger";
+
 import Pg from "./sql/pg";
 import SQLite from "./sql/sqlite";
 import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "./types";
@@ -53,8 +54,15 @@ class Database<T extends string> implements DbBackend<T> {
     });
   }
 
-  createDatabases(conf: DatabaseConfig, ...args: any): Promise<void> {
-    return this.db.createDatabases(conf, ...args);
+  // biome-ignore lint/complexity/useMaxParams: forwards to the DbBackend interface
+  createDatabases(
+    conf: DatabaseConfig,
+    tables: Record<T, string>,
+    indexes: Partial<Record<T, string[]>>,
+    initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
+    logger: import("@twake/logger").TwakeLogger,
+  ): Promise<void> {
+    return this.db.createDatabases(conf, tables, indexes, initializeValues, logger);
   }
 
   insert(table: T, values: Record<string, string | number>): Promise<DbGetResult> {
@@ -128,6 +136,7 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMaxWhereEqual(table, targetField, fields, filterFields, order);
   }
 
+  // biome-ignore lint/complexity/useMaxParams: existing public Database API shape, consumed by all downstream packages
   getMaxWhereEqualAndLower(
     table: T,
     targetField: string,
@@ -139,6 +148,7 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMaxWhereEqualAndLower(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
+  // biome-ignore lint/complexity/useMaxParams: existing public Database API shape, consumed by all downstream packages
   getMinWhereEqualAndHigher(
     table: T,
     targetField: string,
@@ -150,6 +160,7 @@ class Database<T extends string> implements DbBackend<T> {
     return this.db.getMinWhereEqualAndHigher(table, targetField, fields, filterFields1, filterFields2, order);
   }
 
+  // biome-ignore lint/complexity/useMaxParams: existing public Database API shape, consumed by all downstream packages
   getMaxWhereEqualAndLowerJoin(
     tables: T[],
     targetField: string,

--- a/packages/db/src/sql/_createTables.ts
+++ b/packages/db/src/sql/_createTables.ts
@@ -1,7 +1,9 @@
 import type { TwakeLogger } from "@twake/logger";
+
 import type Pg from "./pg";
 import type SQLite from "./sqlite";
 
+// biome-ignore lint/complexity/useMaxParams: signature is the existing internal contract used by both pg and sqlite backends
 function createTables<T extends string>(
   db: SQLite<T> | Pg<T>,
   tables: Record<T, string>,
@@ -21,7 +23,7 @@ function createTables<T extends string>(
               db.rawQuery(`CREATE TABLE ${table}(${tables[table]})`)
                 .then(() =>
                   Promise.all(
-                    (indexes[table] ? (indexes[table] as string[]) : []).map<Promise<any>>((index) =>
+                    (indexes[table] ? (indexes[table] as string[]) : []).map<Promise<unknown>>((index) =>
                       db.rawQuery(`CREATE INDEX i_${table}_${index} ON ${table} (${index})`).catch((e) => {
                         /* istanbul ignore next */
                         logger.error(`Index ${index}`, e);
@@ -34,7 +36,7 @@ function createTables<T extends string>(
                     (initializeValues[table]
                       ? (initializeValues[table] as Array<Record<string, string | number>>)
                       : []
-                    ).map<Promise<any>>((entry) => db.insert(table, entry)),
+                    ).map<Promise<unknown>>((entry) => db.insert(table, entry)),
                   ),
                 )
                 .then(() => {

--- a/packages/db/src/sql/pg.ts
+++ b/packages/db/src/sql/pg.ts
@@ -1,6 +1,9 @@
 /* istanbul ignore file */
+
+import type { ClientConfig, Pool as PgPool, QueryResult } from "pg";
+
 import type { TwakeLogger } from "@twake/logger";
-import type { ClientConfig, Pool as PgPool } from "pg";
+
 import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "../types";
 import createTables from "./_createTables";
 import SQL from "./sql";
@@ -55,7 +58,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     });
   }
 
-  rawQuery(query: string): Promise<any> {
+  rawQuery(query: string): Promise<unknown> {
     if (!this.db) {
       this.logger.error("[Pg][rawQuery] DB not ready");
       return Promise.reject(new Error("DB not ready"));
@@ -241,6 +244,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     });
   }
 
+  // biome-ignore lint/complexity/useMaxParams: internal SQL query builder, parameters represent successive WHERE clauses with their join operators
   _get(
     tables: T[],
     fields?: string[],
@@ -345,7 +349,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
           condition,
           query,
         });
-        this.db.query(query, values, (err: any, rows: any) => {
+        this.db.query(query, values, (err: Error | null, rows: QueryResult) => {
           if (err) {
             this.logger.error("[Pg][_get] SELECT failed", {
               tables,
@@ -480,6 +484,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: internal MIN/MAX query builder, parameters represent successive WHERE clauses
   _getMinMax(
     minmax: "MIN" | "MAX",
     tables: T[],
@@ -629,6 +634,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMaxWhereEqualAndLower(
     table: T,
     targetField: string,
@@ -652,6 +658,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMinWhereEqualAndHigher(
     table: T,
     targetField: string,
@@ -675,6 +682,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMaxWhereEqualAndLowerJoin(
     tables: T[],
     targetField: string,
@@ -1032,6 +1040,7 @@ class Pg<T extends string> extends SQL<T> implements DbBackend<T> {
     return value.replace(/'/g, "''");
   }
 
+  // biome-ignore lint/suspicious/useAwait: `async` makes the early `throw` reject the returned promise consistently with the wrapped callback-style query
   async addColumn(table: T, column: ColumnDefinition): Promise<void> {
     if (!this.db) {
       this.logger.error("[Pg][addColumn] DB not ready", table, column);

--- a/packages/db/src/sql/sql.ts
+++ b/packages/db/src/sql/sql.ts
@@ -1,4 +1,5 @@
 import type { TwakeLogger } from "@twake/logger";
+
 import type { DatabaseConfig, DbGetResult } from "../types";
 import type { PgDatabase } from "./pg";
 import type { SQLiteDatabase } from "./sqlite";
@@ -30,14 +31,14 @@ abstract class SQL<T extends string> {
 
   getCount(table: T, field: string, value?: string | number | string[]): Promise<number> {
     return new Promise((resolve, reject) => {
-      const args: any[] = [table, [`count(${field}) as count`]];
+      const args: unknown[] = [table, [`count(${field}) as count`]];
       if (value !== null && value !== undefined) args.push({ [field]: value });
       // @ts-expect-error implemented later
       this.get(...args)
         .then((rows: Array<Record<string, string>>) => {
           resolve(parseInt(rows[0].count, 10));
         })
-        .catch((e: any) => {
+        .catch((e: unknown) => {
           /* istanbul ignore next */
           reject(e);
         });

--- a/packages/db/src/sql/sqlite.ts
+++ b/packages/db/src/sql/sqlite.ts
@@ -1,5 +1,7 @@
-import type { TwakeLogger } from "@twake/logger";
 import type { Database, Statement } from "sqlite3";
+
+import type { TwakeLogger } from "@twake/logger";
+
 import type { ColumnDefinition, ColumnInfo, DatabaseConfig, DbBackend, DbGetResult, ISQLCondition } from "../types";
 import createTables from "./_createTables";
 import SQL from "./sql";
@@ -237,6 +239,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     });
   }
 
+  // biome-ignore lint/complexity/useMaxParams: internal SQL query builder, parameters represent successive WHERE clauses with their join operators
   _get(
     tables: T[],
     fields?: string[],
@@ -487,6 +490,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: internal MIN/MAX query builder, parameters represent successive WHERE clauses
   _getMinMax(
     minmax: "MIN" | "MAX",
     tables: T[],
@@ -647,6 +651,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMaxWhereEqualAndLower(
     table: T,
     targetField: string,
@@ -670,6 +675,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMinWhereEqualAndHigher(
     table: T,
     targetField: string,
@@ -693,6 +699,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     );
   }
 
+  // biome-ignore lint/complexity/useMaxParams: implements the public Database API shape
   getMaxWhereEqualAndLowerJoin(
     tables: T[],
     targetField: string,
@@ -987,6 +994,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     });
   }
 
+  // biome-ignore lint/suspicious/useAwait: `async` makes the early `throw` reject the returned promise consistently with the wrapped callback-style query
   async getTableColumns(table: T): Promise<ColumnInfo[]> {
     if (!this.db) {
       this.logger.error("[SQLite][getTableColumns] DB not ready", { table });
@@ -1064,6 +1072,7 @@ class SQLite<T extends string> extends SQL<T> implements DbBackend<T> {
     return typePattern.test(type.trim());
   }
 
+  // biome-ignore lint/suspicious/useAwait: `async` makes the early `throw` reject the returned promise consistently with the wrapped callback-style query
   async addColumn(table: T, column: ColumnDefinition): Promise<void> {
     if (!this.db) {
       this.logger.error("[SQLite][addColumn] DB not ready", { table, column });

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -90,6 +90,7 @@ type GetMinMax<T> = (
   order?: string,
 ) => Promise<DbGetResult>;
 
+// biome-ignore lint/complexity/useMaxParams: existing public Database API shape
 type GetMinMax2<T> = (
   table: T,
   targetField: string,
@@ -99,6 +100,7 @@ type GetMinMax2<T> = (
   order?: string,
 ) => Promise<DbGetResult>;
 
+// biome-ignore lint/complexity/useMaxParams: existing public Database API shape
 type GetMinMaxJoin2<T> = (
   tables: T[],
   targetField: string,
@@ -136,9 +138,16 @@ type AddColumn<T> = (table: T, column: ColumnDefinition) => Promise<void>;
 
 type EnsureColumns<T> = (table: T, columns: ColumnDefinition[]) => Promise<void>;
 
-export interface DbBackend<T> {
+export interface DbBackend<T extends string> {
   ready: Promise<void>;
-  createDatabases: (conf: DatabaseConfig, ...args: any) => Promise<void>;
+  // biome-ignore lint/complexity/useMaxParams: shared by pg/sqlite backends; each tables/indexes/values argument is a distinct concept
+  createDatabases: (
+    conf: DatabaseConfig,
+    tables: Record<T, string>,
+    indexes: Partial<Record<T, string[]>>,
+    initializeValues: Partial<Record<T, Array<Record<string, string | number>>>>,
+    logger: import("@twake/logger").TwakeLogger,
+  ) => Promise<void>;
   insert: Insert<T>;
   get: Get<T>;
   getJoin: GetJoin<T>;


### PR DESCRIPTION
## Summary

Replaces `any` with `unknown` in `sql/sql.ts` and `_createTables.ts`, types the pg query callback with `QueryResult` instead of `any`, narrows the `createDatabases` signature on `DbBackend` so the interface actually reflects what the implementations accept (now constrained as `T extends string` to match the rest of the package), and annotates the multi-parameter helpers (`_get`, `_getMinMax`, the `WhereEqualAnd*` family, `createTables`) with `biome-ignore` for `useMaxParams` because changing those signatures would break every downstream caller.