### PR TITLE
chore(federated-identity-service): pass biome lint

### DIFF
--- a/packages/federated-identity-service/example/federated-identity-service.ts
+++ b/packages/federated-identity-service/example/federated-identity-service.ts
@@ -1,20 +1,21 @@
-import express from 'express'
+import express from "express";
 
-import FederatedIdentityService from '@twake/federated-identity-service'
+import FederatedIdentityService from "@twake/federated-identity-service";
 
 const federatedIdentityService = new FederatedIdentityService({
-  database_host: ':memory:'
-})
+  database_host: ":memory:",
+});
 
-const app = express()
+const app = express();
 
 federatedIdentityService.ready
   .then(() => {
-    app.use(federatedIdentityService.routes)
-    const port = process.argv[2] != null ? parseInt(process.argv[2]) : 3000
-    console.log(`Listening on port ${port}`)
-    app.listen(port)
+    app.use(federatedIdentityService.routes);
+    const port = process.argv[2] !== undefined ? parseInt(process.argv[2], 10) : 3000;
+    // biome-ignore lint/suspicious/noConsole: example script intentionally logs to stdout
+    console.log(`Listening on port ${port}`);
+    app.listen(port);
   })
   .catch((e) => {
-    throw e
-  })
+    throw e;
+  });

--- a/packages/federated-identity-service/jest.config.js
+++ b/packages/federated-identity-service/jest.config.js
@@ -1,4 +1,4 @@
-import jestConfigBase from '../../jest-base.config.js'
+import jestConfigBase from "../../jest-base.config.js";
 
 export default {
   ...jestConfigBase,
@@ -7,5 +7,5 @@ export default {
     ...jestConfigBase.moduleNameMapper,
     "node-fetch": "<rootDir>/../../node_modules/node-fetch-jest",
   },
-  clearMocks: true
-}
+  clearMocks: true,
+};

--- a/packages/federated-identity-service/jest.globals.ts
+++ b/packages/federated-identity-service/jest.globals.ts
@@ -1,3 +1,3 @@
-const JEST_PROCESS_ROOT_PATH = __dirname
+const JEST_PROCESS_ROOT_PATH = __dirname;
 
-export default JEST_PROCESS_ROOT_PATH
+export default JEST_PROCESS_ROOT_PATH;

--- a/packages/federated-identity-service/rollup.config.js
+++ b/packages/federated-identity-service/rollup.config.js
@@ -1,16 +1,16 @@
-import config from '../../rollup-template.js'
+import config from "../../rollup-template.js";
 
 export default config([
-  '@twake/matrix-identity-server',
-  '@twake/logger',
-  '@twake/crypto',
-  '@twake/config-parser',
-  '@twake/utils',
-  'express',
-  'express-validator',
-  'ip-address',
-  'lodash',
-  'sqlite3',
-  'pg',
-  'fs'
-])
+  "@twake/matrix-identity-server",
+  "@twake/logger",
+  "@twake/crypto",
+  "@twake/config-parser",
+  "@twake/utils",
+  "express",
+  "express-validator",
+  "ip-address",
+  "lodash",
+  "sqlite3",
+  "pg",
+  "fs",
+]);

--- a/packages/federated-identity-service/src/__testData__/build-userdb.ts
+++ b/packages/federated-identity-service/src/__testData__/build-userdb.ts
@@ -1,73 +1,79 @@
 /* istanbul ignore file */
-import { getLogger, type TwakeLogger } from '@twake/logger'
-import { UserDB } from '@twake/matrix-identity-server'
-import sqlite3, { type Database } from 'sqlite3'
-import { type Config } from '../types'
 
-let created = false
-let matrixDbCreated = false
+import sqlite3, { type Database } from "sqlite3";
+
+import { getLogger, type TwakeLogger } from "@twake/logger";
+
+import { UserDB } from "@twake/matrix-identity-server";
+
+import type { Config } from "../types";
+
+let created = false;
+let matrixDbCreated = false;
 
 interface UserDBSQLite {
-  db?: Database
+  db?: Database;
 }
 
-const logger: TwakeLogger = getLogger()
+const logger: TwakeLogger = getLogger();
 
-const createUsersTable = 'CREATE TABLE IF NOT EXISTS users (uid varchar(255), mobile text, mail test)'
-const insertLskywalker = "INSERT INTO users VALUES('lskywalker', '', 'lskywalker@example.com')"
-const insertOkenobi = "INSERT INTO users VALUES('okenobi', '', 'okenobi@example.com')"
-const insertAskywalker = "INSERT INTO users VALUES('askywalker', '', 'askywalker@example.com')"
-const insertQjinn = "INSERT INTO users VALUES('qjinn', '', 'qjinn@example.com')"
-const insertChewbacca = "INSERT INTO users VALUES('chewbacca', '', 'chewbacca@example.com')"
+const createUsersTable = "CREATE TABLE IF NOT EXISTS users (uid varchar(255), mobile text, mail test)";
+const insertLskywalker = "INSERT INTO users VALUES('lskywalker', '', 'lskywalker@example.com')";
+const insertOkenobi = "INSERT INTO users VALUES('okenobi', '', 'okenobi@example.com')";
+const insertAskywalker = "INSERT INTO users VALUES('askywalker', '', 'askywalker@example.com')";
+const insertQjinn = "INSERT INTO users VALUES('qjinn', '', 'qjinn@example.com')";
+const insertChewbacca = "INSERT INTO users VALUES('chewbacca', '', 'chewbacca@example.com')";
 
-const mCreateUsersTable = 'CREATE TABLE IF NOT EXISTS users (name text)'
-const mInsertChewbacca = "INSERT INTO users VALUES('@chewbacca:example.com')"
+const mCreateUsersTable = "CREATE TABLE IF NOT EXISTS users (name text)";
+const mInsertChewbacca = "INSERT INTO users VALUES('@chewbacca:example.com')";
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export const buildUserDB = (conf: Config): Promise<void> => {
-  if (created) return Promise.resolve()
-  const userDb = new UserDB(conf, logger)
+  if (created) return Promise.resolve();
+  const userDb = new UserDB(conf, logger);
   return new Promise((resolve, reject) => {
-    userDb.ready.then(() => {
-      (userDb.db as UserDBSQLite).db?.run(createUsersTable, () => {
-        (userDb.db as UserDBSQLite).db?.run(insertLskywalker, () => {
-          (userDb.db as UserDBSQLite).db?.run(insertAskywalker, () => {
-            (userDb.db as UserDBSQLite).db?.run(insertQjinn, () => {
-              (userDb.db as UserDBSQLite).db?.run(insertChewbacca, () => {
-                (userDb.db as UserDBSQLite).db?.run(insertOkenobi).close((err) => {
-                  /* istanbul ignore if */
-                  if(err != null) {
-                    reject(err)
-                  } else {
-                    logger.close()
-                    created = true
-                    resolve()
-                  }
-                })
-              })
-            })
-          })
-        })
+    userDb.ready
+      .then(() => {
+        (userDb.db as UserDBSQLite).db?.run(createUsersTable, () => {
+          (userDb.db as UserDBSQLite).db?.run(insertLskywalker, () => {
+            (userDb.db as UserDBSQLite).db?.run(insertAskywalker, () => {
+              (userDb.db as UserDBSQLite).db?.run(insertQjinn, () => {
+                (userDb.db as UserDBSQLite).db?.run(insertChewbacca, () => {
+                  (userDb.db as UserDBSQLite).db?.run(insertOkenobi).close((err) => {
+                    /* istanbul ignore if */
+                    if (err !== undefined && err !== null) {
+                      reject(err);
+                    } else {
+                      logger.close();
+                      created = true;
+                      resolve();
+                    }
+                  });
+                });
+              });
+            });
+          });
+        });
       })
-    }).catch(reject)
-  })
-}
+      .catch(reject);
+  });
+};
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export const buildMatrixDb = (conf: Config): Promise<void> => {
-  if (matrixDbCreated) return Promise.resolve()
-  const matrixDb = new sqlite3.Database(conf.matrix_database_host as string)
+  if (matrixDbCreated) return Promise.resolve();
+  const matrixDb = new sqlite3.Database(conf.matrix_database_host as string);
   return new Promise((resolve, reject) => {
     matrixDb.run(mCreateUsersTable, () => {
       matrixDb.run(mInsertChewbacca).close((err) => {
         /* istanbul ignore if */
-        if(err != null) {
-          reject(err)
+        if (err !== undefined && err !== null) {
+          reject(err);
         } else {
-          matrixDbCreated = true
-          resolve()
+          matrixDbCreated = true;
+          resolve();
         }
-      })
-    })
-  })
-}
+      });
+    });
+  });
+};

--- a/packages/federated-identity-service/src/controllers/controllers.ts
+++ b/packages/federated-identity-service/src/controllers/controllers.ts
@@ -1,25 +1,26 @@
-import { supportedHashes } from '@twake/crypto'
-import { type TwakeLogger } from '@twake/logger'
-import { type DbGetResult } from '@twake/matrix-identity-server'
-import { errCodes } from '@twake/utils'
-import lodash from 'lodash'
-import {
-  FederatedIdentityServiceError,
-  validationErrorHandler
-} from '../middlewares/errors'
-import { type Config, type FdServerDb, type expressAppHandler } from '../types'
-const { groupBy, mapValues } = lodash
+import lodash from "lodash";
 
-export const hashByServer = 'hashByServer'
+import { supportedHashes } from "@twake/crypto";
+import type { TwakeLogger } from "@twake/logger";
+import { errCodes } from "@twake/utils";
+
+import type { DbGetResult } from "@twake/matrix-identity-server";
+
+import { FederatedIdentityServiceError, validationErrorHandler } from "../middlewares/errors";
+import type { Config, expressAppHandler, FdServerDb } from "../types";
+
+const { groupBy, mapValues } = lodash;
+
+export const hashByServer = "hashByServer";
 
 export const lookup = (conf: Config, db: FdServerDb): expressAppHandler => {
   return (req, res, next) => {
-    const mappings: Record<string, string> = {}
-    const inactives: Record<string, string> = {}
-    let thirdPartyMappings: Record<string, string[]> = {}
-    validationErrorHandler(req)
-    db.get('hashes', ['value', 'hash', 'active'], {
-      hash: (req.body as { addresses: string[] }).addresses
+    const mappings: Record<string, string> = {};
+    const inactives: Record<string, string> = {};
+    let thirdPartyMappings: Record<string, string[]> = {};
+    validationErrorHandler(req);
+    db.get("hashes", ["value", "hash", "active"], {
+      hash: (req.body as { addresses: string[] }).addresses,
     })
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       .then((rows) => {
@@ -27,71 +28,69 @@ export const lookup = (conf: Config, db: FdServerDb): expressAppHandler => {
           // istanbul ignore else
           if (row.active === 1) {
             // @ts-expect-error row.hash is not null
-            mappings[row.hash] = row.value
+            mappings[row.hash] = row.value;
           } else {
             // @ts-expect-error row.hash is not null
-            inactives[row.hash] = row.value
+            inactives[row.hash] = row.value;
           }
-        })
-        const allMatchingHashes = Object.keys(mappings)
+        });
+        const allMatchingHashes = Object.keys(mappings);
         if (conf.additional_features === true) {
-          allMatchingHashes.concat(Object.keys(inactives))
+          allMatchingHashes.concat(Object.keys(inactives));
         }
-        const thirdPartyHashes = (
-          req.body as { addresses: string[] }
-        ).addresses.filter((hash) => !allMatchingHashes.includes(hash))
+        const thirdPartyHashes = (req.body as { addresses: string[] }).addresses.filter(
+          (hash) => !allMatchingHashes.includes(hash),
+        );
         return thirdPartyHashes.length > 0
-          ? db.get(hashByServer, ['hash', 'server'], {
-              hash: thirdPartyHashes
+          ? db.get(hashByServer, ["hash", "server"], {
+              hash: thirdPartyHashes,
             })
-          : Promise.resolve([])
+          : Promise.resolve([]);
       })
       .then((rows: DbGetResult) => {
-        thirdPartyMappings = mapValues(groupBy(rows, 'server'), (items) =>
-          items.map((item) => item.hash as string)
-        )
+        thirdPartyMappings = mapValues(groupBy(rows, "server"), (items) => items.map((item) => item.hash as string));
         let responseBody: Record<string, Record<string, string | string[]>> = {
           mappings,
-          third_party_mappings: thirdPartyMappings
-        }
+          third_party_mappings: thirdPartyMappings,
+        };
         if (conf.additional_features ?? false) {
           responseBody = {
             ...responseBody,
-            inactive_mappings: inactives
-          }
+            inactive_mappings: inactives,
+          };
         }
-        res.json(responseBody)
+        res.json(responseBody);
       })
       .catch((e) => {
         next(
           new FederatedIdentityServiceError({
             message: e,
-            code: errCodes.unknown
-          })
-        )
-      })
-  }
-}
+            code: errCodes.unknown,
+          }),
+        );
+      });
+  };
+};
 
 export const lookups = (db: FdServerDb): expressAppHandler => {
   return (req, res, next) => {
-    validationErrorHandler(req)
-    const pepper = req.body.pepper
-    const serverAddress = Object.keys(req.body.mappings)[0]
-    const hashes = req.body.mappings[serverAddress] as string[]
+    validationErrorHandler(req);
+    const pepper = req.body.pepper;
+    const serverAddress = Object.keys(req.body.mappings)[0];
+    const hashes = req.body.mappings[serverAddress] as string[];
 
-    db.get('keys', ['data'], { name: ['pepper', 'previousPepper'] })
+    db.get("keys", ["data"], { name: ["pepper", "previousPepper"] })
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       .then((rows: DbGetResult) => {
-        const currentFedServerPeppers = rows.map((r) => r.data as string)
+        const currentFedServerPeppers = rows.map((r) => r.data as string);
         return db.deleteWhere(hashByServer, [
-          { field: 'server', operator: '=', value: serverAddress },
+          { field: "server", operator: "=", value: serverAddress },
           ...currentFedServerPeppers.map((p) => ({
-            field: 'pepper',
-            operator: '!=' as const,
-            value: p
-          }))
-        ])
+            field: "pepper",
+            operator: "!=" as const,
+            value: p,
+          })),
+        ]);
       })
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       .then((_) => {
@@ -101,60 +100,57 @@ export const lookups = (db: FdServerDb): expressAppHandler => {
             db.insert(hashByServer, {
               hash,
               server: serverAddress,
-              pepper
-            })
-          )
-        )
+              pepper,
+            }),
+          ),
+        );
       })
       .then(() => {
-        res.status(201).json({})
+        res.status(201).json({});
       })
       .catch((e) => {
         next(
           new FederatedIdentityServiceError({
             message: e,
-            code: errCodes.unknown
-          })
-        )
-      })
-  }
-}
+            code: errCodes.unknown,
+          }),
+        );
+      });
+  };
+};
 
 interface HashDetailsObject {
-  algorithms: string[]
-  lookup_pepper: string
-  alt_lookup_peppers?: string[]
+  algorithms: string[];
+  lookup_pepper: string;
+  alt_lookup_peppers?: string[];
 }
 
-export const hashDetails = (
-  db: FdServerDb,
-  logger: TwakeLogger
-): expressAppHandler => {
+export const hashDetails = (db: FdServerDb, logger: TwakeLogger): expressAppHandler => {
   return (req, res, next) => {
-    db.get('keys', ['data'], { name: 'pepper' })
+    db.get("keys", ["data"], { name: "pepper" })
       .then((rows) => {
         const resp: HashDetailsObject = {
           algorithms: supportedHashes,
-          lookup_pepper: rows[0].data as string
-        }
-        db.get('keys', ['data'], { name: 'previousPepper' })
+          lookup_pepper: rows[0].data as string,
+        };
+        db.get("keys", ["data"], { name: "previousPepper" })
           .then((rows2) => {
-            if (rows2 != null && rows2.length > 0)
-              resp.alt_lookup_peppers = [rows2[0].data as string]
-            res.json(resp)
+            if (rows2 !== undefined && rows2 !== null && rows2.length > 0)
+              resp.alt_lookup_peppers = [rows2[0].data as string];
+            res.json(resp);
           })
           .catch((e) => {
-            logger.debug('No previous pepper')
-            res.json(resp)
-          })
+            logger.debug("No previous pepper");
+            res.json(resp);
+          });
       })
       .catch((e) => {
         next(
           new FederatedIdentityServiceError({
             message: e,
-            code: errCodes.unknown
-          })
-        )
-      })
-  }
-}
+            code: errCodes.unknown,
+          }),
+        );
+      });
+  };
+};

--- a/packages/federated-identity-service/src/index.test.ts
+++ b/packages/federated-identity-service/src/index.test.ts
@@ -1,59 +1,47 @@
-import { Hash } from '@twake/crypto'
-import express from 'express'
-import fs from 'fs'
-import type * as http from 'http'
-import * as fetch from 'node-fetch'
-import { execFileSync } from 'node:child_process'
-import { createServer } from 'node:https'
-import os from 'os'
-import path from 'path'
-import request, { type Response } from 'supertest'
-import {
-  DockerComposeEnvironment,
-  Wait,
-  type StartedDockerComposeEnvironment,
-  type StartedTestContainer
-} from 'testcontainers'
-import FederatedIdentityService from '.'
-import JEST_PROCESS_ROOT_PATH from '../jest.globals'
-import { buildMatrixDb, buildUserDB } from './__testData__/build-userdb'
-import defaultConfig from './__testData__/config.json'
-import { hashByServer } from './controllers/controllers'
-import { type Config } from './types'
+import fs from "node:fs";
+import type * as http from "node:http";
+import path from "node:path";
+
+import express from "express";
+import request, { type Response } from "supertest";
+
+import { Hash } from "@twake/crypto";
+
+import JEST_PROCESS_ROOT_PATH from "../jest.globals";
+import FederatedIdentityService from ".";
+import { buildMatrixDb, buildUserDB } from "./__testData__/build-userdb";
+import defaultConfig from "./__testData__/config.json";
+import { hashByServer } from "./controllers/controllers";
+import type { Config } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const syswideCas = require('@small-tech/syswide-cas')
+const _syswideCas = require("@small-tech/syswide-cas");
 
-const pathToTestDataFolder = path.join(
-  JEST_PROCESS_ROOT_PATH,
-  'src',
-  '__testData__'
-)
-const pathToSynapseDataFolder = path.join(pathToTestDataFolder, 'synapse-data')
+const pathToTestDataFolder = path.join(JEST_PROCESS_ROOT_PATH, "src", "__testData__");
+const _pathToSynapseDataFolder = path.join(pathToTestDataFolder, "synapse-data");
 
-const authToken =
-  'authTokenddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+const authToken = "authTokenddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
-jest.unmock('node-fetch')
+jest.unmock("node-fetch");
 
 interface IHashDetails {
-  algorithms: ['sha256']
-  lookup_pepper: string
-  alt_lookup_peppers?: string[]
+  algorithms: ["sha256"];
+  lookup_pepper: string;
+  alt_lookup_peppers?: string[];
 }
 
-describe('Federated identity service', () => {
-  const hash = new Hash()
+describe("Federated identity service", () => {
+  const hash = new Hash();
 
   beforeAll((done) => {
     hash.ready
       .then(() => {
-        done()
+        done();
       })
       .catch((e) => {
-        done(e)
-      })
-  })
+        done(e);
+      });
+  });
 
   // TODO: enable these tests after resolving issues with DNS resolution in CI environment
   // describe('Integration tests', () => {
@@ -885,7 +873,7 @@ describe('Federated identity service', () => {
   //         expect(response.body).toHaveProperty('mappings')
   //         Object.values(
   //           response.body.mappings as Record<string, string>
-  //         ).forEach((address) => matrixAddresses.add(address))
+  //         ).forEach((address) => { matrixAddresses.add(address); })
   //       }
   //       expect(matrixAddresses.size).toEqual(1)
   //       expect(matrixAddresses.has('@chewbacca:example.com')).toEqual(true)
@@ -978,7 +966,7 @@ describe('Federated identity service', () => {
   //         expect(response.body).toHaveProperty('mappings')
   //         Object.values(
   //           response.body.mappings as Record<string, string>
-  //         ).forEach((address) => matrixAddresses.add(address))
+  //         ).forEach((address) => { matrixAddresses.add(address); })
   //         expect(response.body).toHaveProperty('third_party_mappings')
   //         Object.keys(response.body.third_party_mappings).forEach((host) => {
   //           ;(response.body.third_party_mappings[host] as string[]).forEach(
@@ -1008,349 +996,318 @@ describe('Federated identity service', () => {
   //   })
   // })
 
-  describe('Mock tests', () => {
-    let federatedIdentityService: FederatedIdentityService
-    let app: express.Application
-    let expressFederatedIdentityService: http.Server
-    const trustedIpAddress = '192.168.1.1'
-    const trustedIpv6Address = '2001:db8:3333:4444:5555:6666:7777:8888'
-    const trustedNetwork = '192.168.200.4/30'
+  describe("Mock tests", () => {
+    let federatedIdentityService: FederatedIdentityService;
+    let app: express.Application;
+    let expressFederatedIdentityService: http.Server;
+    const trustedIpAddress = "192.168.1.1";
+    const trustedIpv6Address = "2001:db8:3333:4444:5555:6666:7777:8888";
+    const trustedNetwork = "192.168.200.4/30";
     const testConfig = {
       ...(defaultConfig as Partial<Config>),
       additional_features: true,
       cron_service: true,
-      trusted_servers_addresses: [
-        trustedIpAddress,
-        trustedNetwork,
-        trustedIpv6Address
-      ]
-    }
+      trusted_servers_addresses: [trustedIpAddress, trustedNetwork, trustedIpv6Address],
+    };
 
     const stopFederatedIdentityService = (
       done: jest.DoneCallback,
       filesToDelete = [
-        path.join(pathToTestDataFolder, 'database.db'),
-        path.join(pathToTestDataFolder, 'matrix.db'),
-        path.join(pathToTestDataFolder, 'user.db')
-      ]
+        path.join(pathToTestDataFolder, "database.db"),
+        path.join(pathToTestDataFolder, "matrix.db"),
+        path.join(pathToTestDataFolder, "user.db"),
+      ],
     ): void => {
       filesToDelete.forEach((path: string) => {
-        if (fs.existsSync(path)) fs.unlinkSync(path)
-      })
-      if (federatedIdentityService != null) federatedIdentityService.cleanJobs()
-      if (expressFederatedIdentityService != null) {
+        if (fs.existsSync(path)) fs.unlinkSync(path);
+      });
+      if (federatedIdentityService !== undefined && federatedIdentityService !== null)
+        federatedIdentityService.cleanJobs();
+      if (expressFederatedIdentityService !== undefined && expressFederatedIdentityService !== null) {
         expressFederatedIdentityService.close((e) => {
-          if (e != null) {
-            done(e)
+          if (e !== undefined && e !== null) {
+            done(e);
           }
-          done()
-        })
+          done();
+        });
       } else {
-        done()
+        done();
       }
-    }
+    };
 
     beforeAll((done) => {
-      Promise.all([
-        buildUserDB(testConfig as Config),
-        buildMatrixDb(testConfig as Config)
-      ])
+      Promise.all([buildUserDB(testConfig as Config), buildMatrixDb(testConfig as Config)])
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         .then(() => {
-          done()
+          done();
         })
         .catch((e) => {
-          done(e)
-        })
-    })
+          done(e);
+        });
+    });
 
     afterAll((done) => {
-      stopFederatedIdentityService(done)
-    })
+      stopFederatedIdentityService(done);
+    });
 
     beforeEach(() => {
-      jest.restoreAllMocks()
-    })
+      jest.restoreAllMocks();
+    });
 
-    describe('Working cases', () => {
-      let hashDetails: IHashDetails
-      let allPeppers: string[]
-      let askywalkerHashes: string[]
-      let lskywalkerHashes: string[]
-      let okenobiHashes: string[]
-      let chewbaccaHashes: string[]
-      let qjinnHashes: string[]
+    describe("Working cases", () => {
+      let hashDetails: IHashDetails;
+      let allPeppers: string[];
+      let askywalkerHashes: string[];
+      let lskywalkerHashes: string[];
+      let okenobiHashes: string[];
+      let chewbaccaHashes: string[];
+      let qjinnHashes: string[];
 
-      const setFederatedIdentityServiceDataAndRoutes =
-        async (): Promise<void> => {
-          await new Promise<void>((resolve, _reject) =>
-            setTimeout(() => {
-              resolve()
-            }, 16000)
-          ) // wait to set previousPepper in db
-          await federatedIdentityService.db.insert('accessTokens', {
-            id: authToken,
-            data: '{"sub": "@test:example.com"}'
-          })
-          await new Promise<void>((resolve, _reject) => {
-            app.use(federatedIdentityService.routes)
-            expressFederatedIdentityService = app.listen(3000, () => {
-              resolve()
-            })
-          })
-        }
+      const setFederatedIdentityServiceDataAndRoutes = async (): Promise<void> => {
+        await new Promise<void>((resolve, _reject) =>
+          setTimeout(() => {
+            resolve();
+          }, 16000),
+        ); // wait to set previousPepper in db
+        await federatedIdentityService.db.insert("accessTokens", {
+          id: authToken,
+          data: '{"sub": "@test:example.com"}',
+        });
+        await new Promise<void>((resolve, _reject) => {
+          app.use(federatedIdentityService.routes);
+          expressFederatedIdentityService = app.listen(3000, () => {
+            resolve();
+          });
+        });
+      };
 
-      const pushHashesToFederatedIdentityService = async (
-        fedServerHashDetails?: IHashDetails
-      ): Promise<void> => {
+      const pushHashesToFederatedIdentityService = async (fedServerHashDetails?: IHashDetails): Promise<void> => {
         hashDetails =
           fedServerHashDetails ??
           ((
             await request(app)
-              .get('/_matrix/identity/v2/hash_details')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
-          ).body as IHashDetails)
+              .get("/_matrix/identity/v2/hash_details")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
+          ).body as IHashDetails);
 
-        allPeppers = [
-          hashDetails.lookup_pepper,
-          ...(hashDetails.alt_lookup_peppers ?? [])
-        ]
+        allPeppers = [hashDetails.lookup_pepper, ...(hashDetails.alt_lookup_peppers ?? [])];
 
-        askywalkerHashes = allPeppers.map((pepper) =>
-          hash.sha256(`askywalker@example.com email ${pepper}`)
-        )
-        lskywalkerHashes = allPeppers.map((pepper) =>
-          hash.sha256(`lskywalker@example.com email ${pepper}`)
-        )
-        okenobiHashes = allPeppers.map((pepper) =>
-          hash.sha256(`okenobi@example.com email ${pepper}`)
-        )
+        askywalkerHashes = allPeppers.map((pepper) => hash.sha256(`askywalker@example.com email ${pepper}`));
+        lskywalkerHashes = allPeppers.map((pepper) => hash.sha256(`lskywalker@example.com email ${pepper}`));
+        okenobiHashes = allPeppers.map((pepper) => hash.sha256(`okenobi@example.com email ${pepper}`));
 
-        chewbaccaHashes = allPeppers.map((pepper) =>
-          hash.sha256(`chewbacca@example.com email ${pepper}`)
-        )
+        chewbaccaHashes = allPeppers.map((pepper) => hash.sha256(`chewbacca@example.com email ${pepper}`));
 
-        qjinnHashes = allPeppers.map((pepper) =>
-          hash.sha256(`qjinn@example.com email ${pepper}`)
-        )
+        qjinnHashes = allPeppers.map((pepper) => hash.sha256(`qjinn@example.com email ${pepper}`));
 
         await Promise.all([
           // eslint-disable-next-line @typescript-eslint/promise-function-async
           ...askywalkerHashes.map((askywalkerHash, index) =>
             request(app)
-              .post('/_matrix/identity/v2/lookups')
-              .set('Accept', 'application/json')
-              .set('X-forwarded-for', trustedIpAddress)
+              .post("/_matrix/identity/v2/lookups")
+              .set("Accept", "application/json")
+              .set("X-forwarded-for", trustedIpAddress)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[index],
                 mappings: {
-                  'identity1.example.com:8448': [askywalkerHash]
-                }
-              })
+                  "identity1.example.com:8448": [askywalkerHash],
+                },
+              }),
           ),
           // eslint-disable-next-line @typescript-eslint/promise-function-async
           ...lskywalkerHashes.map((lskywalkerHash, index) =>
             request(app)
-              .post('/_matrix/identity/v2/lookups')
-              .set('Accept', 'application/json')
-              .set('X-forwarded-for', '192.168.200.5')
+              .post("/_matrix/identity/v2/lookups")
+              .set("Accept", "application/json")
+              .set("X-forwarded-for", "192.168.200.5")
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[index],
                 mappings: {
-                  'identity2.example.com:443': [lskywalkerHash]
-                }
-              })
+                  "identity2.example.com:443": [lskywalkerHash],
+                },
+              }),
           ),
           // eslint-disable-next-line @typescript-eslint/promise-function-async
           ...okenobiHashes.map((okenobiHash, index) =>
             request(app)
-              .post('/_matrix/identity/v2/lookups')
-              .set('Accept', 'application/json')
-              .set('X-forwarded-for', 'falsy_ip_address')
+              .post("/_matrix/identity/v2/lookups")
+              .set("Accept", "application/json")
+              .set("X-forwarded-for", "falsy_ip_address")
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[index],
                 mappings: {
-                  'identity4.example.com:443': [okenobiHash]
-                }
-              })
-          )
-        ])
-      }
+                  "identity4.example.com:443": [okenobiHash],
+                },
+              }),
+          ),
+        ]);
+      };
 
-      describe('Use environment variables', () => {
+      describe("Use environment variables", () => {
         const {
           trust_x_forwarded_for: trustXForwardedFor,
           trusted_servers_addresses: trustedServersAddresses,
           ...mIdentityServerConfig
-        } = testConfig
+        } = testConfig;
 
         beforeAll((done) => {
-          process.env.TRUSTED_SERVERS_ADDRESSES = trustedServersAddresses
-            .join(',')
-            .concat(',invalid_ip')
-          process.env.TRUST_X_FORWARDED_FOR = String(trustXForwardedFor)
-          federatedIdentityService = new FederatedIdentityService(
-            mIdentityServerConfig
-          )
-          app = express()
+          process.env.TRUSTED_SERVERS_ADDRESSES = trustedServersAddresses.join(",").concat(",invalid_ip");
+          process.env.TRUST_X_FORWARDED_FOR = String(trustXForwardedFor);
+          federatedIdentityService = new FederatedIdentityService(mIdentityServerConfig);
+          app = express();
           federatedIdentityService.ready
             // eslint-disable-next-line @typescript-eslint/promise-function-async
             .then(() => setFederatedIdentityServiceDataAndRoutes())
             // eslint-disable-next-line @typescript-eslint/promise-function-async
             .then(() => pushHashesToFederatedIdentityService())
             .then(() => {
-              done()
+              done();
             })
             .catch((e) => {
-              done(e)
-            })
-        })
+              done(e);
+            });
+        });
 
         afterAll((done) => {
-          delete process.env.TRUSTED_SERVERS_ADDRESSES
-          delete process.env.TRUST_X_FORWARDED_FOR
-          stopFederatedIdentityService(done, [
-            path.join(pathToTestDataFolder, 'database.db')
-          ])
-        })
+          delete process.env.TRUSTED_SERVERS_ADDRESSES;
+          delete process.env.TRUST_X_FORWARDED_FOR;
+          stopFederatedIdentityService(done, [path.join(pathToTestDataFolder, "database.db")]);
+        });
 
-        it('should get server in which third party user is registered on lookup', async () => {
-          const hosts = new Set<string>()
+        it("should get server in which third party user is registered on lookup", async () => {
+          const hosts = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [lskywalkerHashes[i]]
-              })
-            expect(response.body).toHaveProperty('mappings', {})
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings')
-            Object.keys(response.body.third_party_mappings).forEach((host) =>
-              hosts.add(host)
-            )
+                addresses: [lskywalkerHashes[i]],
+              });
+            expect(response.body).toHaveProperty("mappings", {});
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings");
+            Object.keys(response.body.third_party_mappings).forEach((host) => {
+              hosts.add(host);
+            });
           }
-          expect(hosts.size).toEqual(1)
-          expect(hosts.has('identity2.example.com:443')).toEqual(true)
-        })
+          expect(hosts.size).toEqual(1);
+          expect(hosts.has("identity2.example.com:443")).toEqual(true);
+        });
 
-        it('should get user of federated identity service environment on lookup', async () => {
-          const matrixAddresses = new Set<string>()
+        it("should get user of federated identity service environment on lookup", async () => {
+          const matrixAddresses = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [chewbaccaHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings')
-            Object.values(
-              response.body.mappings as Record<string, string>
-            ).forEach((address) => matrixAddresses.add(address))
+                addresses: [chewbaccaHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings");
+            Object.values(response.body.mappings as Record<string, string>).forEach((address) => {
+              matrixAddresses.add(address);
+            });
           }
-          expect(matrixAddresses.size).toEqual(1)
-          expect(matrixAddresses.has('@chewbacca:example.com')).toEqual(true)
-        })
+          expect(matrixAddresses.size).toEqual(1);
+          expect(matrixAddresses.has("@chewbacca:example.com")).toEqual(true);
+        });
 
-        it('should not find user from not trusted identity server on lookup', async () => {
+        it("should not find user from not trusted identity server on lookup", async () => {
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [okenobiHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings', {})
+                addresses: [okenobiHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings", {});
           }
-        })
+        });
 
-        it('should not find user not connected on any matrix server on lookup', async () => {
+        it("should not find user not connected on any matrix server on lookup", async () => {
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [qjinnHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings', {})
+                addresses: [qjinnHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings", {});
           }
-        })
+        });
 
-        it('should find all servers on which a third party user is connected on lookup', async () => {
+        it("should find all servers on which a third party user is connected on lookup", async () => {
           await Promise.all(
             allPeppers.map(async (pepper, i) => {
               await request(app)
-                .post('/_matrix/identity/v2/lookups')
-                .set('Accept', 'application/json')
-                .set('X-forwarded-for', trustedIpAddress)
+                .post("/_matrix/identity/v2/lookups")
+                .set("Accept", "application/json")
+                .set("X-forwarded-for", trustedIpAddress)
                 .send({
                   algorithm: hashDetails.algorithms[0],
                   pepper,
                   mappings: {
-                    'identity1.example.com:8448': [
-                      lskywalkerHashes[i],
-                      askywalkerHashes[i]
-                    ]
-                  }
-                })
-            })
-          )
+                    "identity1.example.com:8448": [lskywalkerHashes[i], askywalkerHashes[i]],
+                  },
+                });
+            }),
+          );
 
-          const hosts = new Set<string>()
+          const hosts = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [lskywalkerHashes[i]]
-              })
-            expect(response.body).toHaveProperty('mappings', {})
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings')
-            Object.keys(response.body.third_party_mappings).forEach((host) =>
-              hosts.add(host)
-            )
+                addresses: [lskywalkerHashes[i]],
+              });
+            expect(response.body).toHaveProperty("mappings", {});
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings");
+            Object.keys(response.body.third_party_mappings).forEach((host) => {
+              hosts.add(host);
+            });
           }
-          expect(hosts.size).toEqual(2)
-          expect(hosts.has('identity1.example.com:8448')).toEqual(true)
-          expect(hosts.has('identity2.example.com:443')).toEqual(true)
-        })
+          expect(hosts.size).toEqual(2);
+          expect(hosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(hosts.has("identity2.example.com:443")).toEqual(true);
+        });
 
-        it('should find all federated identity service users and servers address of third party users on lookup', async () => {
-          const matrixAddresses = new Set<string>()
-          const askywalkerHosts = new Set<string>()
-          const lskywalkerHosts = new Set<string>()
+        it("should find all federated identity service users and servers address of third party users on lookup", async () => {
+          const matrixAddresses = new Set<string>();
+          const askywalkerHosts = new Set<string>();
+          const lskywalkerHosts = new Set<string>();
 
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: hashDetails.lookup_pepper,
@@ -1359,196 +1316,187 @@ describe('Federated identity service', () => {
                   chewbaccaHashes[i],
                   qjinnHashes[i],
                   okenobiHashes[i],
-                  askywalkerHashes[i]
-                ]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('mappings')
-            Object.values(
-              response.body.mappings as Record<string, string>
-            ).forEach((address) => matrixAddresses.add(address))
-            expect(response.body).toHaveProperty('third_party_mappings')
+                  askywalkerHashes[i],
+                ],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("mappings");
+            Object.values(response.body.mappings as Record<string, string>).forEach((address) => {
+              matrixAddresses.add(address);
+            });
+            expect(response.body).toHaveProperty("third_party_mappings");
             Object.keys(response.body.third_party_mappings).forEach((host) => {
-              ;(response.body.third_party_mappings[host] as string[]).forEach(
-                (hash) => {
-                  switch (hash) {
-                    case lskywalkerHashes[i]:
-                      lskywalkerHosts.add(host)
-                      break
-                    case askywalkerHashes[i]:
-                      askywalkerHosts.add(host)
-                      break
-                    default:
-                      break
-                  }
+              (response.body.third_party_mappings[host] as string[]).forEach((hash) => {
+                switch (hash) {
+                  case lskywalkerHashes[i]:
+                    lskywalkerHosts.add(host);
+                    break;
+                  case askywalkerHashes[i]:
+                    askywalkerHosts.add(host);
+                    break;
+                  default:
+                    break;
                 }
-              )
-            })
+              });
+            });
           }
-          expect(askywalkerHosts.size).toEqual(1)
-          expect(askywalkerHosts.has('identity1.example.com:8448')).toEqual(
-            true
-          )
-          expect(lskywalkerHosts.size).toEqual(2)
-          expect(lskywalkerHosts.has('identity1.example.com:8448')).toEqual(
-            true
-          )
-          expect(lskywalkerHosts.has('identity2.example.com:443')).toEqual(true)
-          expect(matrixAddresses.size).toEqual(1)
-          expect(matrixAddresses.has('@chewbacca:example.com')).toEqual(true)
-        })
-      })
+          expect(askywalkerHosts.size).toEqual(1);
+          expect(askywalkerHosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(lskywalkerHosts.size).toEqual(2);
+          expect(lskywalkerHosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(lskywalkerHosts.has("identity2.example.com:443")).toEqual(true);
+          expect(matrixAddresses.size).toEqual(1);
+          expect(matrixAddresses.has("@chewbacca:example.com")).toEqual(true);
+        });
+      });
 
-      describe('Use JSON configuration object', () => {
+      describe("Use JSON configuration object", () => {
         beforeAll((done) => {
-          federatedIdentityService = new FederatedIdentityService(testConfig)
-          app = express()
+          federatedIdentityService = new FederatedIdentityService(testConfig);
+          app = express();
           federatedIdentityService.ready
             // eslint-disable-next-line @typescript-eslint/promise-function-async
             .then(() => setFederatedIdentityServiceDataAndRoutes())
             // eslint-disable-next-line @typescript-eslint/promise-function-async
             .then(() => pushHashesToFederatedIdentityService())
             .then(() => {
-              done()
+              done();
             })
             .catch((e) => {
-              done(e)
-            })
-        })
+              done(e);
+            });
+        });
 
-        it('should get server in which third party user is registered on lookup', async () => {
-          const hosts = new Set<string>()
+        it("should get server in which third party user is registered on lookup", async () => {
+          const hosts = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [lskywalkerHashes[i]]
-              })
-            expect(response.body).toHaveProperty('mappings', {})
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings')
-            Object.keys(response.body.third_party_mappings).forEach((host) =>
-              hosts.add(host)
-            )
+                addresses: [lskywalkerHashes[i]],
+              });
+            expect(response.body).toHaveProperty("mappings", {});
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings");
+            Object.keys(response.body.third_party_mappings).forEach((host) => {
+              hosts.add(host);
+            });
           }
-          expect(hosts.size).toEqual(1)
-          expect(hosts.has('identity2.example.com:443')).toEqual(true)
-        })
+          expect(hosts.size).toEqual(1);
+          expect(hosts.has("identity2.example.com:443")).toEqual(true);
+        });
 
-        it('should get user of federated identity service environment on lookup', async () => {
-          const matrixAddresses = new Set<string>()
+        it("should get user of federated identity service environment on lookup", async () => {
+          const matrixAddresses = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [chewbaccaHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings')
-            Object.values(
-              response.body.mappings as Record<string, string>
-            ).forEach((address) => matrixAddresses.add(address))
+                addresses: [chewbaccaHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings");
+            Object.values(response.body.mappings as Record<string, string>).forEach((address) => {
+              matrixAddresses.add(address);
+            });
           }
-          expect(matrixAddresses.size).toEqual(1)
-          expect(matrixAddresses.has('@chewbacca:example.com')).toEqual(true)
-        })
+          expect(matrixAddresses.size).toEqual(1);
+          expect(matrixAddresses.has("@chewbacca:example.com")).toEqual(true);
+        });
 
-        it('should not find user from not trusted identity server on lookup', async () => {
+        it("should not find user from not trusted identity server on lookup", async () => {
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [okenobiHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings', {})
+                addresses: [okenobiHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings", {});
           }
-        })
+        });
 
-        it('should not find user not connected on any matrix server on lookup', async () => {
+        it("should not find user not connected on any matrix server on lookup", async () => {
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [qjinnHashes[i]]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings', {})
-            expect(response.body).toHaveProperty('mappings', {})
+                addresses: [qjinnHashes[i]],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings", {});
+            expect(response.body).toHaveProperty("mappings", {});
           }
-        })
+        });
 
-        it('should find all servers on which a third party user is connected on lookup', async () => {
+        it("should find all servers on which a third party user is connected on lookup", async () => {
           await Promise.all(
             allPeppers.map(async (pepper, i) => {
               await request(app)
-                .post('/_matrix/identity/v2/lookups')
-                .set('Accept', 'application/json')
-                .set('X-forwarded-for', trustedIpAddress)
+                .post("/_matrix/identity/v2/lookups")
+                .set("Accept", "application/json")
+                .set("X-forwarded-for", trustedIpAddress)
                 .send({
                   algorithm: hashDetails.algorithms[0],
                   pepper,
                   mappings: {
-                    'identity1.example.com:8448': [
-                      lskywalkerHashes[i],
-                      askywalkerHashes[i]
-                    ]
-                  }
-                })
-            })
-          )
+                    "identity1.example.com:8448": [lskywalkerHashes[i], askywalkerHashes[i]],
+                  },
+                });
+            }),
+          );
 
-          const hosts = new Set<string>()
+          const hosts = new Set<string>();
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: allPeppers[i],
-                addresses: [lskywalkerHashes[i]]
-              })
-            expect(response.body).toHaveProperty('mappings', {})
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('third_party_mappings')
-            Object.keys(response.body.third_party_mappings).forEach((host) =>
-              hosts.add(host)
-            )
+                addresses: [lskywalkerHashes[i]],
+              });
+            expect(response.body).toHaveProperty("mappings", {});
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("third_party_mappings");
+            Object.keys(response.body.third_party_mappings).forEach((host) => {
+              hosts.add(host);
+            });
           }
-          expect(hosts.size).toEqual(2)
-          expect(hosts.has('identity1.example.com:8448')).toEqual(true)
-          expect(hosts.has('identity2.example.com:443')).toEqual(true)
-        })
+          expect(hosts.size).toEqual(2);
+          expect(hosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(hosts.has("identity2.example.com:443")).toEqual(true);
+        });
 
-        it('should find all federated identity service users and servers address of third party users on lookup', async () => {
-          const matrixAddresses = new Set<string>()
-          const askywalkerHosts = new Set<string>()
-          const lskywalkerHosts = new Set<string>()
+        it("should find all federated identity service users and servers address of third party users on lookup", async () => {
+          const matrixAddresses = new Set<string>();
+          const askywalkerHosts = new Set<string>();
+          const lskywalkerHosts = new Set<string>();
 
           for (let i = 0; i < allPeppers.length; i++) {
             const response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', `Bearer ${authToken}`)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", `Bearer ${authToken}`)
               .send({
                 algorithm: hashDetails.algorithms[0],
                 pepper: hashDetails.lookup_pepper,
@@ -1557,817 +1505,776 @@ describe('Federated identity service', () => {
                   chewbaccaHashes[i],
                   qjinnHashes[i],
                   okenobiHashes[i],
-                  askywalkerHashes[i]
-                ]
-              })
-            expect(response.body).toHaveProperty('inactive_mappings', {})
-            expect(response.body).toHaveProperty('mappings')
-            Object.values(
-              response.body.mappings as Record<string, string>
-            ).forEach((address) => matrixAddresses.add(address))
-            expect(response.body).toHaveProperty('third_party_mappings')
+                  askywalkerHashes[i],
+                ],
+              });
+            expect(response.body).toHaveProperty("inactive_mappings", {});
+            expect(response.body).toHaveProperty("mappings");
+            Object.values(response.body.mappings as Record<string, string>).forEach((address) => {
+              matrixAddresses.add(address);
+            });
+            expect(response.body).toHaveProperty("third_party_mappings");
             Object.keys(response.body.third_party_mappings).forEach((host) => {
-              ;(response.body.third_party_mappings[host] as string[]).forEach(
-                (hash) => {
-                  switch (hash) {
-                    case lskywalkerHashes[i]:
-                      lskywalkerHosts.add(host)
-                      break
-                    case askywalkerHashes[i]:
-                      askywalkerHosts.add(host)
-                      break
-                    default:
-                      break
-                  }
+              (response.body.third_party_mappings[host] as string[]).forEach((hash) => {
+                switch (hash) {
+                  case lskywalkerHashes[i]:
+                    lskywalkerHosts.add(host);
+                    break;
+                  case askywalkerHashes[i]:
+                    askywalkerHosts.add(host);
+                    break;
+                  default:
+                    break;
                 }
-              )
-            })
+              });
+            });
           }
-          expect(askywalkerHosts.size).toEqual(1)
-          expect(askywalkerHosts.has('identity1.example.com:8448')).toEqual(
-            true
-          )
-          expect(lskywalkerHosts.size).toEqual(2)
-          expect(lskywalkerHosts.has('identity1.example.com:8448')).toEqual(
-            true
-          )
-          expect(lskywalkerHosts.has('identity2.example.com:443')).toEqual(true)
-          expect(matrixAddresses.size).toEqual(1)
-          expect(matrixAddresses.has('@chewbacca:example.com')).toEqual(true)
-        })
+          expect(askywalkerHosts.size).toEqual(1);
+          expect(askywalkerHosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(lskywalkerHosts.size).toEqual(2);
+          expect(lskywalkerHosts.has("identity1.example.com:8448")).toEqual(true);
+          expect(lskywalkerHosts.has("identity2.example.com:443")).toEqual(true);
+          expect(matrixAddresses.size).toEqual(1);
+          expect(matrixAddresses.has("@chewbacca:example.com")).toEqual(true);
+        });
 
-        it('should store only hashes based on current peppers', async () => {
+        it("should store only hashes based on current peppers", async () => {
           let response = await request(app)
-            .get('/_matrix/identity/v2/hash_details')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .get("/_matrix/identity/v2/hash_details")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`);
 
-          const oldHashDetails = response.body as IHashDetails
+          const oldHashDetails = response.body as IHashDetails;
 
-          const oldPeppers = [
-            oldHashDetails.lookup_pepper,
-            ...(oldHashDetails.alt_lookup_peppers ?? [])
-          ]
+          const oldPeppers = [oldHashDetails.lookup_pepper, ...(oldHashDetails.alt_lookup_peppers ?? [])];
 
           let handledPeppers = [
             ...new Set<string>(
-              (
-                await federatedIdentityService.db.getAll(hashByServer, [
-                  'pepper'
-                ])
-              ).map((row) => row.pepper as string)
-            )
-          ]
+              (await federatedIdentityService.db.getAll(hashByServer, ["pepper"])).map((row) => row.pepper as string),
+            ),
+          ];
 
-          expect(oldPeppers.length).toEqual(2)
-          expect(handledPeppers.length).toEqual(2)
-          expect(handledPeppers).toEqual(expect.arrayContaining(oldPeppers))
+          expect(oldPeppers.length).toEqual(2);
+          expect(handledPeppers.length).toEqual(2);
+          expect(handledPeppers).toEqual(expect.arrayContaining(oldPeppers));
 
           await new Promise<void>((resolve) =>
             setTimeout(() => {
-              resolve()
-            }, 33000)
-          )
+              resolve();
+            }, 33000),
+          );
 
           response = await request(app)
-            .get('/_matrix/identity/v2/hash_details')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .get("/_matrix/identity/v2/hash_details")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`);
 
-          const newHashDetails = response.body as IHashDetails
+          const newHashDetails = response.body as IHashDetails;
 
-          const newPeppers = [
-            newHashDetails.lookup_pepper,
-            ...(newHashDetails.alt_lookup_peppers ?? [])
-          ]
+          const newPeppers = [newHashDetails.lookup_pepper, ...(newHashDetails.alt_lookup_peppers ?? [])];
 
-          await pushHashesToFederatedIdentityService(newHashDetails)
+          await pushHashesToFederatedIdentityService(newHashDetails);
 
           handledPeppers = [
             ...new Set<string>(
-              (
-                await federatedIdentityService.db.getAll(hashByServer, [
-                  'pepper'
-                ])
-              ).map((row) => row.pepper as string)
-            )
-          ]
+              (await federatedIdentityService.db.getAll(hashByServer, ["pepper"])).map((row) => row.pepper as string),
+            ),
+          ];
 
-          expect(newPeppers.length).toEqual(2)
-          expect(handledPeppers.length).toEqual(2)
-          expect(handledPeppers).toEqual(expect.arrayContaining(newPeppers))
-          expect(handledPeppers).toEqual(expect.not.arrayContaining(oldPeppers))
-        })
-      })
-    })
+          expect(newPeppers.length).toEqual(2);
+          expect(handledPeppers.length).toEqual(2);
+          expect(handledPeppers).toEqual(expect.arrayContaining(newPeppers));
+          expect(handledPeppers).toEqual(expect.not.arrayContaining(oldPeppers));
+        });
+      });
+    });
 
-    describe('Error cases', () => {
-      const errorMessage = 'error message'
+    describe("Error cases", () => {
+      const errorMessage = "error message";
 
-      it('reject unimplemented endpoint with 404', async () => {
-        const response = await request(app).get('/unkown')
-        expect(response.statusCode).toBe(404)
-        expect(JSON.stringify(response.body)).toEqual(
-          JSON.stringify({ errcode: 'M_NOT_FOUND', error: 'Not Found' })
-        )
-      })
+      it("reject unimplemented endpoint with 404", async () => {
+        const response = await request(app).get("/unkown");
+        expect(response.statusCode).toBe(404);
+        expect(JSON.stringify(response.body)).toEqual(JSON.stringify({ errcode: "M_NOT_FOUND", error: "Not Found" }));
+      });
 
-      describe('Lookup endpoint', () => {
-        it('reject not allowed method with 405 status code', async () => {
+      describe("Lookup endpoint", () => {
+        it("reject not allowed method with 405 status code", async () => {
           const response = await request(app)
-            .get('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .get("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`);
 
-          expect(response.statusCode).toBe(405)
+          expect(response.statusCode).toBe(405);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNRECOGNIZED',
-              error: 'Unrecognized'
-            })
-          )
-        })
+              errcode: "M_UNRECOGNIZED",
+              error: "Unrecognized",
+            }),
+          );
+        });
 
-        it('should reject if more than 100 requests are done in less than 10 seconds', async () => {
-          let response
-          let token
-          // eslint-disable-next-line @typescript-eslint/no-for-in-array, @typescript-eslint/no-unused-vars
-          for (const i in [...Array(101).keys()]) {
-            token = Number(i) % 2 === 0 ? `Bearer ${authToken}` : 'falsy_token'
+        it("should reject if more than 100 requests are done in less than 10 seconds", async () => {
+          let response: request.Response | undefined;
+          let token: string;
+
+          for (let i = 0; i < 101; i++) {
+            token = Number(i) % 2 === 0 ? `Bearer ${authToken}` : "falsy_token";
             response = await request(app)
-              .post('/_matrix/identity/v2/lookup')
-              .set('Accept', 'application/json')
-              .set('Authorization', token)
+              .post("/_matrix/identity/v2/lookup")
+              .set("Accept", "application/json")
+              .set("Authorization", token)
               .send({
                 addresse: [],
-                algorithm: 'sha256',
-                pepper: 'test_pepper'
-              })
+                algorithm: "sha256",
+                pepper: "test_pepper",
+              });
           }
-          expect((response as Response).statusCode).toEqual(429)
-          await new Promise((resolve) => setTimeout(resolve, 11000))
-        })
+          expect((response as Response).statusCode).toEqual(429);
+          await new Promise((resolve) => setTimeout(resolve, 11000));
+        });
 
-        it('should send an error if auth token is invalid', async () => {
+        it("should send an error if auth token is invalid", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', 'falsy_token')
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", "falsy_token")
             .send({
               addresse: [],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(401)
+          expect(response.statusCode).toEqual(401);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNAUTHORIZED',
-              error: 'Unauthorized'
-            })
-          )
-        })
+              errcode: "M_UNAUTHORIZED",
+              error: "Unauthorized",
+            }),
+          );
+        });
 
-        it('should send an error if auth token is not in accessTokens table', async () => {
+        it("should send an error if auth token is not in accessTokens table", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken.replace('a', 'f')}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken.replace("a", "f")}`)
             .send({
               addresse: [],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(401)
+          expect(response.statusCode).toEqual(401);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNAUTHORIZED',
-              error: 'Unauthorized'
-            })
-          )
-        })
+              errcode: "M_UNAUTHORIZED",
+              error: "Unauthorized",
+            }),
+          );
+        });
 
         it('should send an error if token data in accessTokens table does not contain "sub" field', async () => {
-          jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockResolvedValue([{ data: JSON.stringify({}) }])
+          jest.spyOn(federatedIdentityService.db, "get").mockResolvedValue([{ data: JSON.stringify({}) }]);
 
-          const jsonParseSpy = jest.spyOn(JSON, 'parse')
+          const jsonParseSpy = jest.spyOn(JSON, "parse");
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresse: [],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(jsonParseSpy).toHaveBeenNthCalledWith(2, '{}')
-          expect(response.statusCode).toEqual(401)
+          expect(jsonParseSpy).toHaveBeenNthCalledWith(2, "{}");
+          expect(response.statusCode).toEqual(401);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNAUTHORIZED',
-              error: 'Unauthorized'
-            })
-          )
-        })
+              errcode: "M_UNAUTHORIZED",
+              error: "Unauthorized",
+            }),
+          );
+        });
 
         it('should send an error if "algorithm" is not in body', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: [],
-              pepper: 'test_pepper'
-            })
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: algorithm)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: algorithm)",
+            }),
+          );
+        });
 
         it('should send an error if "algorithm" is not a string', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: [],
               algorithm: 2,
-              pepper: 'test_pepper'
-            })
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: algorithm)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: algorithm)",
+            }),
+          );
+        });
 
         it('should send an error if "pepper" is not in body', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: [],
-              algorithm: 'sha256'
-            })
+              algorithm: "sha256",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: pepper)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: pepper)",
+            }),
+          );
+        });
 
         it('should send an error if "pepper" is not a string', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: [],
-              algorithm: 'sha256',
-              pepper: 2
-            })
+              algorithm: "sha256",
+              pepper: 2,
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: pepper)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: pepper)",
+            }),
+          );
+        });
 
         it('should send an error if "addresses" is not in body', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: addresses)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: addresses)",
+            }),
+          );
+        });
 
         it('should send an error if "addresses" is not an array', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: 2,
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: addresses)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: addresses)",
+            }),
+          );
+        });
 
-        it('should send an error if one address is not a string', async () => {
+        it("should send an error if one address is not a string", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              addresses: ['hash1', 'hash2', 2, 'hash3'],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              addresses: ["hash1", "hash2", 2, "hash3"],
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error:
-                'Error field: One of the address is not a string (property: addresses)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: One of the address is not a string (property: addresses)",
+            }),
+          );
+        });
 
-        it('should send an error if exceeds hashes limit', async () => {
+        it("should send an error if exceeds hashes limit", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
               addresses: Array.from({ length: 101 }, (_, i) => `hash${i}`),
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error:
-                'Error field: Adresses limit of 100 exceeded (property: addresses)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Adresses limit of 100 exceeded (property: addresses)",
+            }),
+          );
+        });
 
-        it('should send an error if getting hashes from db fails', async () => {
+        it("should send an error if getting hashes from db fails", async () => {
           jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockResolvedValueOnce([
-              { data: JSON.stringify({ sub: '@test:example.com' }) }
-            ])
-            .mockRejectedValueOnce(new Error(errorMessage))
+            .spyOn(federatedIdentityService.db, "get")
+            .mockResolvedValueOnce([{ data: JSON.stringify({ sub: "@test:example.com" }) }])
+            .mockRejectedValueOnce(new Error(errorMessage));
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              addresses: ['hash1', 'hash2'],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              addresses: ["hash1", "hash2"],
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(500)
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
 
-        it('should send an error if getting hashes from hashes table fails', async () => {
+        it("should send an error if getting hashes from hashes table fails", async () => {
           const dbGetSpy = jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockResolvedValueOnce([
-              { data: JSON.stringify({ sub: '@test:example.com' }) }
-            ])
-            .mockRejectedValueOnce(new Error(errorMessage))
+            .spyOn(federatedIdentityService.db, "get")
+            .mockResolvedValueOnce([{ data: JSON.stringify({ sub: "@test:example.com" }) }])
+            .mockRejectedValueOnce(new Error(errorMessage));
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              addresses: ['hash1', 'hash2'],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              addresses: ["hash1", "hash2"],
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(dbGetSpy).toHaveBeenCalledTimes(2)
-          expect(response.statusCode).toEqual(500)
+          expect(dbGetSpy).toHaveBeenCalledTimes(2);
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
 
-        it('should send an error if getting hashes from hashbyserver table fails', async () => {
+        it("should send an error if getting hashes from hashbyserver table fails", async () => {
           const dbGetSpy = jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockResolvedValueOnce([
-              { data: JSON.stringify({ sub: '@test:example.com' }) }
-            ])
+            .spyOn(federatedIdentityService.db, "get")
+            .mockResolvedValueOnce([{ data: JSON.stringify({ sub: "@test:example.com" }) }])
             .mockResolvedValueOnce([])
-            .mockRejectedValueOnce(new Error(errorMessage))
+            .mockRejectedValueOnce(new Error(errorMessage));
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookup')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookup")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              addresses: ['hash1', 'hash2'],
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              addresses: ["hash1", "hash2"],
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(dbGetSpy).toHaveBeenCalledTimes(3)
-          expect(response.statusCode).toEqual(500)
+          expect(dbGetSpy).toHaveBeenCalledTimes(3);
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
-      })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
+      });
 
-      describe('Lookups endpoint', () => {
-        it('reject not allowed method with 405 status code', async () => {
+      describe("Lookups endpoint", () => {
+        it("reject not allowed method with 405 status code", async () => {
           const response = await request(app)
-            .get('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .get("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress);
 
-          expect(response.statusCode).toBe(405)
+          expect(response.statusCode).toBe(405);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNRECOGNIZED',
-              error: 'Unrecognized'
-            })
-          )
-        })
+              errcode: "M_UNRECOGNIZED",
+              error: "Unrecognized",
+            }),
+          );
+        });
 
-        it('should reject if more than 100 requests are done in less than 10 seconds', async () => {
-          let response
-          let ipAddress
-          // eslint-disable-next-line @typescript-eslint/no-for-in-array, @typescript-eslint/no-unused-vars
-          for (const i in [...Array(101).keys()]) {
-            ipAddress = Number(i) % 2 === 0 ? trustedIpAddress : '192.168.1.25'
+        it("should reject if more than 100 requests are done in less than 10 seconds", async () => {
+          let response: request.Response | undefined;
+          let ipAddress: string;
+
+          for (let i = 0; i < 101; i++) {
+            ipAddress = Number(i) % 2 === 0 ? trustedIpAddress : "192.168.1.25";
             response = await request(app)
-              .post('/_matrix/identity/v2/lookups')
-              .set('Accept', 'application/json')
-              .set('X-forwarded-for', ipAddress)
+              .post("/_matrix/identity/v2/lookups")
+              .set("Accept", "application/json")
+              .set("X-forwarded-for", ipAddress)
               .send({
                 mappings: {},
-                algorithm: 'sha256',
-                pepper: 'test_pepper'
-              })
+                algorithm: "sha256",
+                pepper: "test_pepper",
+              });
           }
-          expect((response as Response).statusCode).toEqual(429)
-          await new Promise((resolve) => setTimeout(resolve, 11000))
-        })
+          expect((response as Response).statusCode).toEqual(429);
+          await new Promise((resolve) => setTimeout(resolve, 11000));
+        });
 
-        it('should send an error if requester ip does not belong to trusted ip addresses', async () => {
+        it("should send an error if requester ip does not belong to trusted ip addresses", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', '192.168.1.25')
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", "192.168.1.25")
             .send({
               mappings: {},
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(401)
+          expect(response.statusCode).toEqual(401);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNAUTHORIZED',
-              error: 'Unauthorized'
-            })
-          )
-        })
+              errcode: "M_UNAUTHORIZED",
+              error: "Unauthorized",
+            }),
+          );
+        });
 
-        it('should send an error if requester ip is not a valid address', async () => {
+        it("should send an error if requester ip is not a valid address", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', 'falsy_ip_address')
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", "falsy_ip_address")
             .send({
               mappings: {},
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(401)
+          expect(response.statusCode).toEqual(401);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNAUTHORIZED',
-              error: 'Unauthorized'
-            })
-          )
-        })
+              errcode: "M_UNAUTHORIZED",
+              error: "Unauthorized",
+            }),
+          );
+        });
 
         it('should send an error if "pepper" is not in body', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              mappings: { 'test.example.com': [] },
-              algorithm: 'sha256'
-            })
+              mappings: { "test.example.com": [] },
+              algorithm: "sha256",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: pepper)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: pepper)",
+            }),
+          );
+        });
 
         it('should send an error if "pepper" is not a string', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              mappings: { 'test.example.com': [] },
-              algorithm: 'sha256',
-              pepper: 2
-            })
+              mappings: { "test.example.com": [] },
+              algorithm: "sha256",
+              pepper: 2,
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: pepper)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: pepper)",
+            }),
+          );
+        });
 
         it('should send an error if "mappings" is not in body', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: mappings)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: mappings)",
+            }),
+          );
+        });
 
         it('should send an error if "mappings" is not an object', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
               mappings: 2,
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error: 'Error field: Invalid value (property: mappings)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Invalid value (property: mappings)",
+            }),
+          );
+        });
 
         it('should send an error if "mappings" contains more than one server hostname', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              mappings: { 'test.example.com': [], 'test2.example.com': [] },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              mappings: { "test.example.com": [], "test2.example.com": [] },
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error:
-                'Error field: Only one server address is allowed (property: mappings)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Only one server address is allowed (property: mappings)",
+            }),
+          );
+        });
 
         it('should send an error if "mappings" values is not an array', async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              mappings: { 'test.example.com': 2 },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              mappings: { "test.example.com": 2 },
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error:
-                'Error field: Mappings object values are not string arrays (property: mappings)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Mappings object values are not string arrays (property: mappings)",
+            }),
+          );
+        });
 
-        it('should send an error if one address is not a string', async () => {
+        it("should send an error if one address is not a string", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`)
             .send({
-              mappings: { 'test.example.com': ['hash1', 'hash2', 2, 'hash3'] },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              mappings: { "test.example.com": ["hash1", "hash2", 2, "hash3"] },
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(400)
+          expect(response.statusCode).toEqual(400);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_INVALID_PARAM',
-              error:
-                'Error field: Mappings object values are not string arrays (property: mappings)'
-            })
-          )
-        })
+              errcode: "M_INVALID_PARAM",
+              error: "Error field: Mappings object values are not string arrays (property: mappings)",
+            }),
+          );
+        });
 
-        it('should send an error if getting pepper in keys table fails', async () => {
-          jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockRejectedValueOnce(new Error(errorMessage))
+        it("should send an error if getting pepper in keys table fails", async () => {
+          jest.spyOn(federatedIdentityService.db, "get").mockRejectedValueOnce(new Error(errorMessage));
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              mappings: { 'test.example.com': [] },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              mappings: { "test.example.com": [] },
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(500)
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
 
-        it('should send an error if deleting hashes in hashbyserver table fails', async () => {
-          jest
-            .spyOn(federatedIdentityService.db, 'deleteWhere')
-            .mockRejectedValue(new Error(errorMessage))
+        it("should send an error if deleting hashes in hashbyserver table fails", async () => {
+          jest.spyOn(federatedIdentityService.db, "deleteWhere").mockRejectedValue(new Error(errorMessage));
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
-              mappings: { 'test.example.com': [] },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              mappings: { "test.example.com": [] },
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(response.statusCode).toEqual(500)
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
 
-        it('should send an error if inserting hashes in hashbyserver table fails', async () => {
+        it("should send an error if inserting hashes in hashbyserver table fails", async () => {
           const insertSpyOn = jest
-            .spyOn(federatedIdentityService.db, 'insert')
+            .spyOn(federatedIdentityService.db, "insert")
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([])
             .mockRejectedValueOnce(new Error(errorMessage))
-            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([]);
 
           const response = await request(app)
-            .post('/_matrix/identity/v2/lookups')
-            .set('Accept', 'application/json')
-            .set('X-forwarded-for', trustedIpAddress)
+            .post("/_matrix/identity/v2/lookups")
+            .set("Accept", "application/json")
+            .set("X-forwarded-for", trustedIpAddress)
             .send({
               mappings: {
-                'test.example.com': ['test1', 'test2', 'test3', 'test4']
+                "test.example.com": ["test1", "test2", "test3", "test4"],
               },
-              algorithm: 'sha256',
-              pepper: 'test_pepper'
-            })
+              algorithm: "sha256",
+              pepper: "test_pepper",
+            });
 
-          expect(insertSpyOn).toHaveBeenCalledTimes(4)
-          expect(response.statusCode).toEqual(500)
+          expect(insertSpyOn).toHaveBeenCalledTimes(4);
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
-      })
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
+      });
 
-      describe('Hash_details endpoint', () => {
-        it('reject not allowed method with 405 status code', async () => {
+      describe("Hash_details endpoint", () => {
+        it("reject not allowed method with 405 status code", async () => {
           const response = await request(app)
-            .post('/_matrix/identity/v2/hash_details')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .post("/_matrix/identity/v2/hash_details")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`);
 
-          expect(response.statusCode).toBe(405)
+          expect(response.statusCode).toBe(405);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNRECOGNIZED',
-              error: 'Unrecognized'
-            })
-          )
-        })
+              errcode: "M_UNRECOGNIZED",
+              error: "Unrecognized",
+            }),
+          );
+        });
 
-        it('should reject if more than 100 requests are done in less than 10 seconds', async () => {
-          let response
-          let token
-          // eslint-disable-next-line @typescript-eslint/no-for-in-array, @typescript-eslint/no-unused-vars
-          for (const i in [...Array(101).keys()]) {
-            token = Number(i) % 2 === 0 ? `Bearer ${authToken}` : 'falsy_token'
+        it("should reject if more than 100 requests are done in less than 10 seconds", async () => {
+          let response: request.Response | undefined;
+          let token: string;
+
+          for (let i = 0; i < 101; i++) {
+            token = Number(i) % 2 === 0 ? `Bearer ${authToken}` : "falsy_token";
             response = await request(app)
-              .get('/_matrix/identity/v2/hash_details')
-              .set('Accept', 'application/json')
-              .set('Authorization', token)
+              .get("/_matrix/identity/v2/hash_details")
+              .set("Accept", "application/json")
+              .set("Authorization", token);
           }
-          expect((response as Response).statusCode).toEqual(429)
-          await new Promise((resolve) => setTimeout(resolve, 11000))
-        })
+          expect((response as Response).statusCode).toEqual(429);
+          await new Promise((resolve) => setTimeout(resolve, 11000));
+        });
 
-        it('should send an error if deleting hashes in hashbyserver table fails', async () => {
+        it("should send an error if deleting hashes in hashbyserver table fails", async () => {
           jest
-            .spyOn(federatedIdentityService.db, 'get')
-            .mockResolvedValueOnce([
-              { data: JSON.stringify({ sub: '@test:example.com' }) }
-            ])
-            .mockRejectedValueOnce(new Error(errorMessage))
+            .spyOn(federatedIdentityService.db, "get")
+            .mockResolvedValueOnce([{ data: JSON.stringify({ sub: "@test:example.com" }) }])
+            .mockRejectedValueOnce(new Error(errorMessage));
 
           const response = await request(app)
-            .get('/_matrix/identity/v2/hash_details')
-            .set('Accept', 'application/json')
-            .set('Authorization', `Bearer ${authToken}`)
+            .get("/_matrix/identity/v2/hash_details")
+            .set("Accept", "application/json")
+            .set("Authorization", `Bearer ${authToken}`);
 
-          expect(response.statusCode).toEqual(500)
+          expect(response.statusCode).toEqual(500);
           expect(JSON.stringify(response.body)).toEqual(
             JSON.stringify({
-              errcode: 'M_UNKNOWN',
-              error: `Error: ${errorMessage}`
-            })
-          )
-        })
-      })
-    })
-  })
-})
+              errcode: "M_UNKNOWN",
+              error: `Error: ${errorMessage}`,
+            }),
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/federated-identity-service/src/index.ts
+++ b/packages/federated-identity-service/src/index.ts
@@ -1,79 +1,68 @@
-import configParser, { type ConfigDescription } from '@twake/config-parser'
-import { type TwakeLogger } from '@twake/logger'
-import MatrixIdentityServer from '@twake/matrix-identity-server'
-import { Router } from 'express'
-import fs from 'fs'
-import defaultConfig from './config.json'
-import { Authenticate } from './middlewares/auth'
-import Routes from './routes/routes'
-import { type Config, type FdServerDb, type fdDbCollections } from './types'
-import { isIpLiteral, isNetwork } from './utils/ip-address'
+import fs from "fs";
+
+import { Router } from "express";
+
+import configParser, { type ConfigDescription } from "@twake/config-parser";
+import type { TwakeLogger } from "@twake/logger";
+
+import MatrixIdentityServer from "@twake/matrix-identity-server";
+
+import defaultConfig from "./config.json";
+import { Authenticate } from "./middlewares/auth";
+import Routes from "./routes/routes";
+import type { Config, FdServerDb, fdDbCollections } from "./types";
+import { isIpLiteral, isNetwork } from "./utils/ip-address";
 
 const tables = {
-  hashByServer:
-    'hash varchar(48), server text, pepper text, PRIMARY KEY (hash, server, pepper)'
-}
+  hashByServer: "hash varchar(48), server text, pepper text, PRIMARY KEY (hash, server, pepper)",
+};
 
 export default class FederatedIdentityService extends MatrixIdentityServer<fdDbCollections> {
-  routes = Router()
-  declare conf: Config
-  declare db: FdServerDb
-  constructor(
-    conf?: Partial<Config>,
-    confDesc?: ConfigDescription,
-    logger?: TwakeLogger
-  ) {
-    if (confDesc == null) confDesc = defaultConfig
+  routes = Router();
+  declare conf: Config;
+  declare db: FdServerDb;
+  constructor(conf?: Partial<Config>, confDesc?: ConfigDescription, logger?: TwakeLogger) {
+    if (confDesc === undefined || confDesc === null) confDesc = defaultConfig;
     const serverConf = configParser(
       confDesc,
       /* istanbul ignore next */
-      fs.existsSync('/etc/twake/federated-identity-service.conf')
-        ? '/etc/twake/federated-identity-service.conf'
-        : process.env.TWAKE_FEDERATED_IDENTITY_SERVICE_CONF != null
-        ? process.env.TWAKE_FEDERATED_IDENTITY_SERVICE_CONF
-        : conf != null
-        ? conf
-        : undefined
-    ) as Config
-    super(serverConf, confDesc, logger, tables)
+      fs.existsSync("/etc/twake/federated-identity-service.conf")
+        ? "/etc/twake/federated-identity-service.conf"
+        : process.env.TWAKE_FEDERATED_IDENTITY_SERVICE_CONF !== undefined &&
+            process.env.TWAKE_FEDERATED_IDENTITY_SERVICE_CONF !== null
+          ? process.env.TWAKE_FEDERATED_IDENTITY_SERVICE_CONF
+          : conf !== undefined && conf !== null
+            ? conf
+            : undefined,
+    ) as Config;
+    super(serverConf, confDesc, logger, tables);
     this.conf.trusted_servers_addresses =
-      typeof this.conf.trusted_servers_addresses === 'string'
-        ? (this.conf.trusted_servers_addresses as string)
-            .split(/[,\s]+/)
-            .filter((addr) => {
-              // istanbul ignore next
-              if ((addr.match(isIpLiteral) ?? addr.match(isNetwork)) != null) {
-                return true
-              } else {
-                this.logger.warn(`${addr} rejected`)
-                return false
-              }
-            })
-        : this.conf.trusted_servers_addresses
-    this.logger.debug(
-      `Trusted servers: ${this.conf.trusted_servers_addresses.join(', ')}`
-    )
+      typeof this.conf.trusted_servers_addresses === "string"
+        ? (this.conf.trusted_servers_addresses as string).split(/[,\s]+/).filter((addr) => {
+            // istanbul ignore next
+            if ((addr.match(isIpLiteral) ?? addr.match(isNetwork)) !== null) {
+              return true;
+            }
+            this.logger.warn(`${addr} rejected`);
+            return false;
+          })
+        : this.conf.trusted_servers_addresses;
+    this.logger.debug(`Trusted servers: ${this.conf.trusted_servers_addresses.join(", ")}`);
     this.authenticate = Authenticate(
       this.db,
       this.conf.trusted_servers_addresses,
       this.conf.trust_x_forwarded_for as boolean,
-      this.logger
-    )
-    const superReady = this.ready
+      this.logger,
+    );
+    const superReady = this.ready;
     this.ready = new Promise((resolve, reject) => {
       superReady
         .then(() => {
-          this.routes = Routes(
-            this.api,
-            this.db,
-            this.authenticate,
-            this.conf,
-            this.logger
-          )
-          resolve(true)
+          this.routes = Routes(this.api, this.db, this.authenticate, this.conf, this.logger);
+          resolve(true);
         })
         /* istanbul ignore next */
-        .catch(reject)
-    })
+        .catch(reject);
+    });
   }
 }

--- a/packages/federated-identity-service/src/middlewares/auth.ts
+++ b/packages/federated-identity-service/src/middlewares/auth.ts
@@ -1,110 +1,109 @@
-import { type TwakeLogger } from '@twake/logger'
-import { errMsg, send } from '@twake/utils'
-import { Utils, type tokenContent } from '@twake/matrix-identity-server'
-import { type NextFunction, type Response } from 'express'
-import { type AuthRequest, type FdServerDb } from '../types'
-import { convertToIPv6 } from '../utils/ip-address'
+import type { NextFunction, Response } from "express";
 
-const tokenTrustedServer = 'TOKEN_TRUSTED_SERVER'
+import type { TwakeLogger } from "@twake/logger";
+import { errMsg, send } from "@twake/utils";
+
+import type { tokenContent, Utils } from "@twake/matrix-identity-server";
+
+import type { AuthRequest, FdServerDb } from "../types";
+import { convertToIPv6 } from "../utils/ip-address";
+
+const tokenTrustedServer = "TOKEN_TRUSTED_SERVER";
 
 export const Authenticate = (
   db: FdServerDb,
   trustedServersList: string[],
   trustXForwardedForHeader: boolean,
-  logger: TwakeLogger
+  logger: TwakeLogger,
 ): Utils.AuthenticationFunction => {
-  const trustedServersListAsIPv6 = trustedServersList.map((ip) =>
-    convertToIPv6(ip)
-  )
-  const tokenRe = /^Bearer (\S+)$/
+  const trustedServersListAsIPv6 = trustedServersList.map((ip) => convertToIPv6(ip));
+  const tokenRe = /^Bearer (\S+)$/;
   return (req, res, callbackMethod) => {
-    const request = req as AuthRequest
+    const request = req as AuthRequest;
     const remoteAddress = trustXForwardedForHeader
       ? // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        (request.headers['x-forwarded-for'] as string) ||
-        (request.socket.remoteAddress as string)
-      : (request.socket.remoteAddress as string)
+        (request.headers["x-forwarded-for"] as string) || (request.socket.remoteAddress as string)
+      : (request.socket.remoteAddress as string);
 
-    const parsedAdressArray = remoteAddress.split(':')
-    const originalRequesterIPAddress =
-      parsedAdressArray[parsedAdressArray.length - 1]
+    const parsedAdressArray = remoteAddress.split(":");
+    const originalRequesterIPAddress = parsedAdressArray[parsedAdressArray.length - 1];
 
-    logger.info('', {
+    logger.info("", {
       ip: originalRequesterIPAddress,
       httpMethod: request.method,
-      endpointPath: request.originalUrl
-    })
+      endpointPath: request.originalUrl,
+    });
     try {
-      const requesterIPAddress = convertToIPv6(originalRequesterIPAddress)
-      logger.debug(`Authenticated request from ${originalRequesterIPAddress}`)
+      const requesterIPAddress = convertToIPv6(originalRequesterIPAddress);
+      logger.debug(`Authenticated request from ${originalRequesterIPAddress}`);
       // istanbul ignore if
       if (trustedServersListAsIPv6.includes(requesterIPAddress)) {
-        logger.debug('IP is in list')
-        callbackMethod({ sub: '', epoch: 0 }, tokenTrustedServer)
+        logger.debug("IP is in list");
+        callbackMethod({ sub: "", epoch: 0 }, tokenTrustedServer);
       } else if (
         trustedServersListAsIPv6.some((ip) => {
-          const res = requesterIPAddress.isInSubnet(ip)
-          if (res) logger.debug(`IP is in ${ip.address}`)
-          return res
+          const res = requesterIPAddress.isInSubnet(ip);
+          if (res) logger.debug(`IP is in ${ip.address}`);
+          return res;
         })
       ) {
-        callbackMethod({ sub: '', epoch: 0 }, tokenTrustedServer)
+        callbackMethod({ sub: "", epoch: 0 }, tokenTrustedServer);
       } else {
-        logger.debug(`${originalRequesterIPAddress} isn't in white list`)
-        let token: string | null = null
-        if (req.headers.authorization != null) {
-          const re = req.headers.authorization.match(tokenRe)
-          if (re != null) {
-            token = re[1]
+        logger.debug(`${originalRequesterIPAddress} isn't in white list`);
+        let token: string | null = null;
+        if (req.headers.authorization !== undefined && req.headers.authorization !== null) {
+          const re = req.headers.authorization.match(tokenRe);
+          if (re !== undefined && re !== null) {
+            token = re[1];
           }
           // @ts-expect-error req.query exists
         } else if (req.query && Object.keys(req.query).length > 0) {
           // @ts-expect-error req.query.access_token may be null
-          token = req.query.access_token
+          token = req.query.access_token;
         }
-        if (token != null) {
-          db.get('accessTokens', ['data'], { id: token })
+        if (token !== undefined && token !== null) {
+          db.get("accessTokens", ["data"], { id: token })
             .then((rows) => {
-              callbackMethod(JSON.parse(rows[0].data as string), token)
+              callbackMethod(JSON.parse(rows[0].data as string), token);
             })
             .catch((e) => {
-              send(res, 401, errMsg('unAuthorized'))
-            })
+              send(res, 401, errMsg("unAuthorized"));
+            });
         } else {
-          send(res, 401, errMsg('unAuthorized'))
+          send(res, 401, errMsg("unAuthorized"));
         }
       }
     } catch (error) {
       logger.debug(
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `Real error: ${error instanceof Error ? error.message : error}`
-      )
+        `Real error: ${error instanceof Error ? error.message : error}`,
+      );
       logger.error(`Unauthorized`, {
         ip: originalRequesterIPAddress,
         httpMethod: request.method,
-        endpointPath: request.originalUrl
-      })
-      send(res, 401, errMsg('unAuthorized'))
+        endpointPath: request.originalUrl,
+      });
+      send(res, 401, errMsg("unAuthorized"));
     }
-  }
-}
+  };
+};
 
 export const auth = (authenticator: Utils.AuthenticationFunction) => {
   return (req: AuthRequest, res: Response, next: NextFunction): void => {
     authenticator(req, res, (data: tokenContent, token: string | null) => {
       if (token === tokenTrustedServer) {
-        next()
-        return
+        next();
+        return;
       }
       /* istanbul ignore if */
       if (data.sub === undefined) {
-        throw new Error('Invalid data')
+        throw new Error("Invalid data");
       }
-      req.userId = data.sub
-      if (token != null) {
-        req.accessToken = token
+      req.userId = data.sub;
+      if (token !== undefined && token !== null) {
+        req.accessToken = token;
       }
-      next()
-    })
-  }
-}
+      next();
+    });
+  };
+};

--- a/packages/federated-identity-service/src/middlewares/errors.ts
+++ b/packages/federated-identity-service/src/middlewares/errors.ts
@@ -1,79 +1,70 @@
-import { defaultMsg, errCodes } from '@twake/utils'
-import { type Request } from 'express'
-import { validationResult, type ValidationError } from 'express-validator'
-import {
-  type ErrorResponseBody,
-  type expressAppHandlerError,
-  type federatedIdentityServiceErrorCode
-} from '../types'
+import type { Request } from "express";
+import { type ValidationError, validationResult } from "express-validator";
 
-export const defaultErrorMsg = 'Internal server error'
+import { defaultMsg, errCodes } from "@twake/utils";
+
+import type { ErrorResponseBody, expressAppHandlerError, federatedIdentityServiceErrorCode } from "../types";
+
+export const defaultErrorMsg = "Internal server error";
 
 export class FederatedIdentityServiceError extends Error {
-  statusCode: number
-  errcode?: federatedIdentityServiceErrorCode
+  statusCode: number;
+  errcode?: federatedIdentityServiceErrorCode;
 
   constructor(
     error: {
-      status?: number
-      message?: string
-      code?: federatedIdentityServiceErrorCode
-    } = {}
+      status?: number;
+      message?: string;
+      code?: federatedIdentityServiceErrorCode;
+    } = {},
   ) {
-    let errorMessage = defaultErrorMsg
-    if (error.message != null) {
-      errorMessage = error.message
-    } else if (error.code != null) {
-      errorMessage = defaultMsg(error.code)
+    let errorMessage = defaultErrorMsg;
+    if (error.message !== undefined && error.message !== null) {
+      errorMessage = error.message;
+    } else if (error.code !== undefined && error.code !== null) {
+      errorMessage = defaultMsg(error.code);
     }
-    super(errorMessage)
-    if (error.code != null) {
-      this.errcode = error.code
+    super(errorMessage);
+    if (error.code !== undefined && error.code !== null) {
+      this.errcode = error.code;
     }
-    this.statusCode = error.status ?? 500
+    this.statusCode = error.status ?? 500;
   }
 }
 
-export const errorMiddleware: expressAppHandlerError = (
-  error,
-  req,
-  res,
-  next
-) => {
+export const errorMiddleware: expressAppHandlerError = (error, req, res, next) => {
   const federatedIdentityServiceError: FederatedIdentityServiceError =
     error instanceof FederatedIdentityServiceError
       ? error
-      : new FederatedIdentityServiceError({ message: error.message })
-  res.status(federatedIdentityServiceError.statusCode)
+      : new FederatedIdentityServiceError({ message: error.message });
+  res.status(federatedIdentityServiceError.statusCode);
   let bodyResponse: ErrorResponseBody = {
-    error: federatedIdentityServiceError.message
-  }
-  if (federatedIdentityServiceError.errcode != null) {
+    error: federatedIdentityServiceError.message,
+  };
+  if (federatedIdentityServiceError.errcode !== undefined && federatedIdentityServiceError.errcode !== null) {
     bodyResponse = {
       errcode: federatedIdentityServiceError.errcode,
-      ...bodyResponse
-    }
+      ...bodyResponse,
+    };
   }
-  res.statusMessage = federatedIdentityServiceError.message
-  res.json(bodyResponse)
-}
+  res.statusMessage = federatedIdentityServiceError.message;
+  res.json(bodyResponse);
+};
 
 export const validationErrorHandler = (req: Request): void => {
-  const errors = validationResult(req)
+  const errors = validationResult(req);
   if (!errors.isEmpty()) {
     const errorMessage = errors
       .array({ onlyFirstError: true })
       .map(
         (error: ValidationError) =>
-          `Error ${error.type}: ${String(error.msg)}${
-            'path' in error ? ` (property: ${error.path})` : ''
-          }`
+          `Error ${error.type}: ${String(error.msg)}${"path" in error ? ` (property: ${error.path})` : ""}`,
       )
-      .join(', ')
+      .join(", ");
     throw new FederatedIdentityServiceError({
       status: 400,
       message: errorMessage,
-      code: errCodes.invalidParam
-    })
+      code: errCodes.invalidParam,
+    });
   }
-}
+};

--- a/packages/federated-identity-service/src/middlewares/utils.ts
+++ b/packages/federated-identity-service/src/middlewares/utils.ts
@@ -1,30 +1,25 @@
-import { errCodes } from '@twake/utils'
-import { type expressAppHandler } from '../types'
-import { FederatedIdentityServiceError } from './errors'
+import { errCodes } from "@twake/utils";
+
+import type { expressAppHandler } from "../types";
+import { FederatedIdentityServiceError } from "./errors";
 
 export const allowCors: expressAppHandler = (req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    'GET, POST, PUT, DELETE, OPTIONS'
-  )
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, Authorization'
-  )
-  next()
-}
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
+  next();
+};
 
 export const methodNotAllowed: expressAppHandler = (req, res, next) => {
   throw new FederatedIdentityServiceError({
     status: 405,
-    code: errCodes.unrecognized
-  })
-}
+    code: errCodes.unrecognized,
+  });
+};
 
 export const methodNotFound: expressAppHandler = (req, res, next) => {
   throw new FederatedIdentityServiceError({
     status: 404,
-    code: errCodes.notFound
-  })
-}
+    code: errCodes.notFound,
+  });
+};

--- a/packages/federated-identity-service/src/middlewares/validation.ts
+++ b/packages/federated-identity-service/src/middlewares/validation.ts
@@ -1,43 +1,39 @@
-import { body, type ValidationChain } from 'express-validator'
+import { body, type ValidationChain } from "express-validator";
 
-export const commonValidators = [
-  body('algorithm').exists().isString(),
-  body('pepper').exists().isString()
-]
+export const commonValidators = [body("algorithm").exists().isString(), body("pepper").exists().isString()];
 
 export const lookupValidator = (hashesLimit: number): ValidationChain =>
-  body('addresses')
+  body("addresses")
     .exists()
     .isArray()
     .custom((value, { req }) => {
-      if ((value as any[]).some((address) => typeof address !== 'string')) {
-        throw new Error('One of the address is not a string')
-      } else if ((value as string[]).length > hashesLimit) {
-        throw new Error(`Adresses limit of ${hashesLimit} exceeded`)
+      if ((value as unknown[]).some((address) => typeof address !== "string")) {
+        throw new Error("One of the address is not a string");
       }
-      return true
-    })
+      if ((value as string[]).length > hashesLimit) {
+        throw new Error(`Adresses limit of ${hashesLimit} exceeded`);
+      }
+      return true;
+    });
 
 export const lookupsValidator = [
-  body('pepper').exists().isString(),
-  body('mappings')
+  body("pepper").exists().isString(),
+  body("mappings")
     .exists()
     .isObject()
     .custom((value, { req }) => {
       if (Object.keys(value).length > 1) {
-        throw new Error('Only one server address is allowed')
+        throw new Error("Only one server address is allowed");
       }
       if (
         Object.keys(value).length === 1 &&
         !(
           Array.isArray(Object.values(value)[0]) &&
-          (Object.values(value)[0] as any[]).every(
-            (hash) => typeof hash === 'string'
-          )
+          (Object.values(value)[0] as unknown[]).every((hash) => typeof hash === "string")
         )
       ) {
-        throw new Error('Mappings object values are not string arrays')
+        throw new Error("Mappings object values are not string arrays");
       }
-      return true
-    })
-]
+      return true;
+    }),
+];

--- a/packages/federated-identity-service/src/routes/routes.ts
+++ b/packages/federated-identity-service/src/routes/routes.ts
@@ -1,44 +1,30 @@
-import { type TwakeLogger } from '@twake/logger'
-import { type IdServerAPI, type Utils } from '@twake/matrix-identity-server'
-import { Router, json, urlencoded } from 'express'
-import { hashDetails, lookup, lookups } from '../controllers/controllers'
-import { auth } from '../middlewares/auth'
-import { errorMiddleware } from '../middlewares/errors'
-import {
-  allowCors,
-  methodNotAllowed,
-  methodNotFound
-} from '../middlewares/utils'
-import {
-  commonValidators,
-  lookupValidator,
-  lookupsValidator
-} from '../middlewares/validation'
-import {
-  type FdServerDb,
-  type Config,
-  type expressAppHandler,
-  type middlewaresList
-} from '../types'
+import { json, Router, urlencoded } from "express";
 
-const errorMiddlewares = (middleware: expressAppHandler): middlewaresList => [
-  allowCors,
-  middleware,
-  errorMiddleware
-]
+import type { TwakeLogger } from "@twake/logger";
+
+import type { IdServerAPI, Utils } from "@twake/matrix-identity-server";
+
+import { hashDetails, lookup, lookups } from "../controllers/controllers";
+import { auth } from "../middlewares/auth";
+import { errorMiddleware } from "../middlewares/errors";
+import { allowCors, methodNotAllowed, methodNotFound } from "../middlewares/utils";
+import { commonValidators, lookupsValidator, lookupValidator } from "../middlewares/validation";
+import type { Config, expressAppHandler, FdServerDb, middlewaresList } from "../types";
+
+const errorMiddlewares = (middleware: expressAppHandler): middlewaresList => [allowCors, middleware, errorMiddleware];
 
 export default (
   api: {
-    get: IdServerAPI
-    post: IdServerAPI
-    put?: IdServerAPI
+    get: IdServerAPI;
+    post: IdServerAPI;
+    put?: IdServerAPI;
   },
   db: FdServerDb,
   authenticate: Utils.AuthenticationFunction,
   conf: Config,
-  logger: TwakeLogger
+  logger: TwakeLogger,
 ): Router => {
-  const routes = Router()
+  const routes = Router();
   /**
    * @openapi
    * '/_matrix/identity/v2/lookup':
@@ -127,7 +113,7 @@ export default (
    *        $ref: '#/components/responses/InternalServerError'
    */
   routes
-    .route('/_matrix/identity/v2/lookup')
+    .route("/_matrix/identity/v2/lookup")
     .post(
       allowCors,
       json(),
@@ -136,9 +122,9 @@ export default (
       ...commonValidators,
       lookupValidator(conf.hashes_rate_limit as number),
       lookup(conf, db),
-      errorMiddleware
+      errorMiddleware,
     )
-    .all(...errorMiddlewares(methodNotAllowed))
+    .all(...errorMiddlewares(methodNotAllowed));
 
   /**
    * @openapi
@@ -149,34 +135,32 @@ export default (
    *    description: Implements https://spec.matrix.org/v1.6/identity-service-api/#get_matrixidentityv2hash_details
    */
   routes
-    .route('/_matrix/identity/v2/hash_details')
+    .route("/_matrix/identity/v2/hash_details")
     .get(
       allowCors,
       json(),
       urlencoded({ extended: false }),
       auth(authenticate),
       hashDetails(db, logger),
-      errorMiddleware
+      errorMiddleware,
     )
-    .all(...errorMiddlewares(methodNotAllowed))
+    .all(...errorMiddlewares(methodNotAllowed));
 
-  const defaultGetEndpoints = Object.keys(api.get)
-  const defaultPostEndpoints = Object.keys(api.post)
+  const defaultGetEndpoints = Object.keys(api.get);
+  const defaultPostEndpoints = Object.keys(api.post);
 
   defaultGetEndpoints.forEach((k) => {
-    routes.route(k).get(api.get[k])
-  })
+    routes.route(k).get(api.get[k]);
+  });
   defaultPostEndpoints.forEach((k) => {
-    routes.route(k).post(api.post[k])
-  })
+    routes.route(k).post(api.post[k]);
+  });
 
-  const allDefaultEndpoints = [
-    ...new Set([...defaultGetEndpoints, ...defaultPostEndpoints])
-  ]
+  const allDefaultEndpoints = [...new Set([...defaultGetEndpoints, ...defaultPostEndpoints])];
 
   allDefaultEndpoints.forEach((k) => {
-    routes.route(k).all(...errorMiddlewares(methodNotAllowed))
-  })
+    routes.route(k).all(...errorMiddlewares(methodNotAllowed));
+  });
 
   /**
    * @openapi
@@ -236,7 +220,7 @@ export default (
    *        $ref: '#/components/responses/InternalServerError'
    */
   routes
-    .route('/_matrix/identity/v2/lookups')
+    .route("/_matrix/identity/v2/lookups")
     .post(
       allowCors,
       json(),
@@ -245,11 +229,11 @@ export default (
       ...commonValidators,
       lookupsValidator,
       lookups(db),
-      errorMiddleware
+      errorMiddleware,
     )
-    .all(...errorMiddlewares(methodNotAllowed))
+    .all(...errorMiddlewares(methodNotAllowed));
 
-  routes.use(...errorMiddlewares(methodNotFound))
+  routes.use(...errorMiddlewares(methodNotFound));
 
-  return routes
-}
+  return routes;
+};

--- a/packages/federated-identity-service/src/types.ts
+++ b/packages/federated-identity-service/src/types.ts
@@ -1,42 +1,31 @@
-import {
-  type IdentityServerDb,
-  type Config as MConfig
-} from '@twake/matrix-identity-server'
-import { type errCodes } from '@twake/utils'
-import { type NextFunction, type Request, type Response } from 'express'
+import type { NextFunction, Request, Response } from "express";
 
-export type expressAppHandler = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => void
+import type { errCodes } from "@twake/utils";
 
-export type expressAppHandlerError = (
-  error: Error,
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => void
+import type { IdentityServerDb, Config as MConfig } from "@twake/matrix-identity-server";
+
+export type expressAppHandler = (req: Request, res: Response, next: NextFunction) => void;
+
+export type expressAppHandlerError = (error: Error, req: Request, res: Response, next: NextFunction) => void;
 
 export interface AuthRequest extends Request {
-  userId?: string
-  accessToken?: string
+  userId?: string;
+  accessToken?: string;
 }
 
-export type federatedIdentityServiceErrorCode =
-  (typeof errCodes)[keyof typeof errCodes]
+export type federatedIdentityServiceErrorCode = (typeof errCodes)[keyof typeof errCodes];
 
 export interface ErrorResponseBody {
-  error: string
-  errcode?: federatedIdentityServiceErrorCode
+  error: string;
+  errcode?: federatedIdentityServiceErrorCode;
 }
 
-export type middlewaresList = Array<expressAppHandler | expressAppHandlerError>
+export type middlewaresList = Array<expressAppHandler | expressAppHandlerError>;
 
 export type Config = MConfig & {
-  trusted_servers_addresses: string[]
-}
+  trusted_servers_addresses: string[];
+};
 
-export type fdDbCollections = 'hashByServer'
+export type fdDbCollections = "hashByServer";
 
-export type FdServerDb = IdentityServerDb<fdDbCollections>
+export type FdServerDb = IdentityServerDb<fdDbCollections>;

--- a/packages/federated-identity-service/src/utils/ip-address.ts
+++ b/packages/federated-identity-service/src/utils/ip-address.ts
@@ -1,24 +1,24 @@
-import { Address4, Address6 } from 'ip-address'
+import { Address4, Address6 } from "ip-address";
 
 // Imported form Perl modules (Regex::Common::*)
 const ipv4 =
-  '(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))'
+  "(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))";
 // Imported from is-ipv6-node
 const ipv6 =
-  '(?:(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?:(?::[0-9a-fA-F]{1,4}){1,6})|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(?::[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(?:ffff(?::0{1,4}){0,1}:){0,1}(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])|(?:[0-9a-fA-F]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9]))'
-export const isIpLiteral = new RegExp(`^(${ipv4}|${ipv6})(?:(?<!:):(\\d+))?$`)
-export const isNetwork = new RegExp(`^(${ipv4}|${ipv6})/\\d+`)
+  "(?:(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?:(?::[0-9a-fA-F]{1,4}){1,6})|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(?::[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(?:ffff(?::0{1,4}){0,1}:){0,1}(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])|(?:[0-9a-fA-F]{1,4}:){1,4}:(?:(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+export const isIpLiteral = new RegExp(`^(${ipv4}|${ipv6})(?:(?<!:):(\\d+))?$`);
+export const isNetwork = new RegExp(`^(${ipv4}|${ipv6})/\\d+`);
 
 export const convertToIPv6 = (ipAddress: string): Address6 => {
   // istanbul ignore if
-  if (typeof ipAddress !== 'string') {
-    throw new Error('An IP address must be of string type')
+  if (typeof ipAddress !== "string") {
+    throw new Error("An IP address must be of string type");
   }
   if (Address6.isValid(ipAddress)) {
-    return new Address6(ipAddress)
-  } else if (Address4.isValid(ipAddress)) {
-    return Address6.fromAddress4(ipAddress)
-  } else {
-    throw new Error(`The IP address ${ipAddress} is not valid`)
+    return new Address6(ipAddress);
   }
-}
+  if (Address4.isValid(ipAddress)) {
+    return Address6.fromAddress4(ipAddress);
+  }
+  throw new Error(`The IP address ${ipAddress} is not valid`);
+};


### PR DESCRIPTION
## Summary

Replaces `x != null` / `x == null` nullish checks with `x !== undefined && x !== null` (and the `==` variant) to satisfy `noDoubleEquals` with `ignoreNull: false`; converts `for (const i in [...Array(101).keys()])` rate-limit test loops to plain numeric `for` loops with typed `let` bindings; wraps single-expression `.forEach((x) => set.add(x))` callbacks in braces so `useIterableCallbackReturn` no longer fires; swaps `as any[]` for `as unknown[]` in the validation middleware; drops unused imports and dead variables; adds a `biome-ignore` for the example script's intentional `console.log`. Most of the diff is the formatter's single-to-double-quote and import-reorganisation pass.