### PR TITLE
HotFix: `workplaceFqdn` has been renamed to `twakeWorkplaceUrl`

### DIFF
--- a/packages/tom-server/src/user-info-api/services/index.ts
+++ b/packages/tom-server/src/user-info-api/services/index.ts
@@ -15,6 +15,8 @@ import type { TwakeLogger } from '@twake/logger'
 import { type IAddressbookService } from '../../addressbook-api/types'
 import { AddressbookService } from '../../addressbook-api/services'
 
+const getFirstString = (input: string | string[]): string => Array.isArray(input) ? input[0] : input;
+
 class UserInfoService implements IUserInfoService {
   private readonly addressBookService: IAddressbookService
   private readonly enableAdditionalFeatures: boolean
@@ -46,9 +48,9 @@ class UserInfoService implements IUserInfoService {
           .visibility === 'public'
           ? ProfileVisibility.Public
           : this.config.features.user_profile.default_visibility_settings
-              .visibility === 'contacts'
-          ? ProfileVisibility.Contacts
-          : ProfileVisibility.Private,
+            .visibility === 'contacts'
+            ? ProfileVisibility.Contacts
+            : ProfileVisibility.Private,
       visible_fields: []
     }
 
@@ -102,8 +104,7 @@ class UserInfoService implements IUserInfoService {
     viewer?: string
   ): Promise<Map<string, UserInformation>> => {
     this.logger.debug(
-      `[UserInfoService].getBatch: Gathering information on ${ids.length} user${
-        ids.length > 1 ? 's' : ''
+      `[UserInfoService].getBatch: Gathering information on ${ids.length} user${ids.length > 1 ? 's' : ''
       }`
     )
 
@@ -162,7 +163,8 @@ class UserInfoService implements IUserInfoService {
             'givenName',
             'mail',
             'mobile',
-            'workplaceFqdn'
+            'workplaceFqdn',
+            'twakeWorkplaceUrl'
           ],
           { uid: localParts }
         )) as unknown as Array<Record<string, string | string[]>>
@@ -391,11 +393,21 @@ class UserInfoService implements IUserInfoService {
             )
             userInfo.phones = [directoryRow.mobile as string]
           }
-          if (directoryRow.workplaceFqdn) {
+          // The Twake Workplace user LDAP schema has changed to favor twakeWorkplaceUrl instead of previously choosen workplaceFqdn
+          // https://github.com/linagora/twake-on-matrix/pull/2787
+          // To reflect that change gracefully, ToM returns both deprectaed workplaceFqdn and newly adopted twakeWorkplaceUrl
+          // To also support legacy LDAP users not yet / unsuccessfully migrated we keep looking for both LDAP properties
+          if (directoryRow.twakeWorkplaceUrl || directoryRow.workplaceFqdn) {
+            const workplaceUrl: string = getFirstString(directoryRow.twakeWorkplaceUrl || directoryRow.workplaceFqdn)
             this.logger.debug(
               `[UserInfoService].getBatch: mxid=${id} workplaceFqdn source=directory value="${directoryRow.workplaceFqdn}"`
             )
-            userInfo.workplaceFqdn = directoryRow.workplaceFqdn as string
+            this.logger.debug(
+              `[UserInfoService].getBatch: mxid=${id} twakeWorkplaceUrl source=directory value="${directoryRow.twakeWorkplaceUrl}"`
+            )
+            this.logger.debug(`[UserInfoService].getBatch: returned workplaceFqdn: ${workplaceUrl}`)
+            userInfo.workplaceFqdn = workplaceUrl
+            userInfo.twakeWorkplaceUrl = workplaceUrl
           }
         }
 

--- a/packages/tom-server/src/user-info-api/tests/service.test.ts
+++ b/packages/tom-server/src/user-info-api/tests/service.test.ts
@@ -41,7 +41,7 @@ const MOCK_DATA = {
     givenName: 'LDAP First Name',
     mail: 'ldap@example.org',
     mobile: '+1 555 123 4567',
-    workplaceFqdn: 'workplace.example.com'
+    twakeWorkplaceUrl: 'workplace.example.com'
   },
   COMMON_SETTINGS: {
     display_name: 'CS Display Name',
@@ -77,7 +77,7 @@ type useProfileTwake = {
   givenName: boolean
   mail: boolean
   phone: boolean
-  workplaceFqdn: boolean
+  twakeWorkplaceUrl: boolean
 }
 const useProfileTwakeDefaults: useProfileTwake = {
   displayName: false,
@@ -85,7 +85,7 @@ const useProfileTwakeDefaults: useProfileTwake = {
   givenName: false,
   mail: false,
   phone: false,
-  workplaceFqdn: false
+  twakeWorkplaceUrl: false
 }
 /**
  * Configure Matrix mock response.
@@ -104,7 +104,7 @@ const mockUserDB = (
     if (Object.values(useProfileDefaults).every((v) => !v)) {
       userDBMock.get.mockResolvedValue([])
     } else {
-      const { displayName, lastName, givenName, mail, phone, workplaceFqdn } =
+      const { displayName, lastName, givenName, mail, phone, twakeWorkplaceUrl } =
         useProfileDefaults
       // Extract local part from MATRIX_MXID (e.g., '@dwho:docker.localhost' -> 'dwho')
       const localPart = MATRIX_MXID.replace(/^@([^:]+):.*$/, '$1')
@@ -132,8 +132,8 @@ const mockUserDB = (
       if (phone) {
         profile.mobile = MOCK_DATA.LDAP.mobile
       }
-      if (workplaceFqdn) {
-        profile.workplaceFqdn = MOCK_DATA.LDAP.workplaceFqdn
+      if (twakeWorkplaceUrl) {
+        profile.twakeWorkplaceUrl = MOCK_DATA.LDAP.twakeWorkplaceUrl
       }
 
       userDBMock.get.mockResolvedValue([profile])
@@ -511,13 +511,13 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).not.toHaveProperty('timezone')
     })
 
-    it('Should add workplaceFqdn from UserDB when available', async () => {
+    it('Should add twakeWorkplaceUrl from UserDB when available', async () => {
       mockMatrix({ displayName: true, avatar: true })
       mockUserDB({
         displayName: true,
         lastName: true,
         givenName: true,
-        workplaceFqdn: true
+        twakeWorkplaceUrl: true
       })
 
       const user = await svc.get(MATRIX_MXID)
@@ -527,7 +527,7 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).toHaveProperty('avatar_url', MOCK_DATA.MATRIX.avatar_url)
       expect(user).toHaveProperty('sn', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('givenName', MOCK_DATA.LDAP.givenName)
-      expect(user).toHaveProperty('workplaceFqdn', MOCK_DATA.LDAP.workplaceFqdn)
+      expect(user).toHaveProperty('twakeWorkplaceUrl', MOCK_DATA.LDAP.twakeWorkplaceUrl)
       expect(user).toHaveProperty('last_name', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('first_name', MOCK_DATA.LDAP.givenName)
       expect(user).not.toHaveProperty('emails')
@@ -536,13 +536,13 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).not.toHaveProperty('timezone')
     })
 
-    it('Should not add workplaceFqdn when not available in UserDB', async () => {
+    it('Should not add twakeWorkplaceUrl when not available in UserDB', async () => {
       mockMatrix({ displayName: true, avatar: true })
       mockUserDB({
         displayName: true,
         lastName: true,
         givenName: true,
-        workplaceFqdn: false
+        twakeWorkplaceUrl: false
       })
 
       const user = await svc.get(MATRIX_MXID)
@@ -552,7 +552,7 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).toHaveProperty('avatar_url', MOCK_DATA.MATRIX.avatar_url)
       expect(user).toHaveProperty('sn', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('givenName', MOCK_DATA.LDAP.givenName)
-      expect(user).not.toHaveProperty('workplaceFqdn')
+      expect(user).not.toHaveProperty('twakeWorkplaceUrl')
       expect(user).toHaveProperty('last_name', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('first_name', MOCK_DATA.LDAP.givenName)
       expect(user).not.toHaveProperty('emails')

--- a/packages/tom-server/src/user-info-api/types.ts
+++ b/packages/tom-server/src/user-info-api/types.ts
@@ -28,6 +28,7 @@ export interface UserEnrichmentFields {
   language?: string
   timezone?: string
   workplaceFqdn?: string
+  twakeWorkplaceUrl?: string
 }
 
 export interface UserInformation extends UserEnrichmentFields {


### PR DESCRIPTION
## What

This PR updates the user_info HTTP response to include a newly adopted LDAP property `twakeWorkplaceUrl`. It keeps `workplaceFqdn` property for backward compatibility.

## Why

When updating the common-settings redirection support inside the twake chat client: https://github.com/linagora/twake-on-matrix/pull/2787
@nqhhdev noticed that the `workplaceFqdn` field was missing in the ToM user_info HTTP response.

## How

The new LDAP `twakeWorkplaceUrl` is present inside Twake LDAP servers that were migrated to the new OpenLDAP schema: https://twake-docs.stg.lin-saas.com/b2b-deployment/openldap-schema

To support both the new and the legacy properties ToM LDAP ORM is looking for both values and coalesces to a string value the first one found using the following precedence:

1. `twakeWorkplaceUrl`
2. `workplaceUrl`

Hence,
- if both are empty in LDAP: nothing is returned
- if `twakeWorkplaceUrl` **only** is set in LDAP: user_info HTTP response contains both `twakeWorkplaceUrl` and `workplaceUrl` set with LDAP `twakeWorkplaceUrl` value
- if `workplaceUrl` **only** is set in LDAP: user_info HTTP response contains both `twakeWorkplaceUrl` and `workplaceUrl` set with LDAP `workplaceUrl` value]
- if both LDAP properties are set: user_info HTTP response contains both `twakeWorkplaceUrl` and `workplaceUrl` set with LDAP `twakeWorkplaceUrl` value