### PR TITLE
Chore(cs bridge): Updates RabbitMQ Client Lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3695,13 +3695,12 @@
       "license": "MIT"
     },
     "node_modules/@linagora/rabbitmq-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@linagora/rabbitmq-client/-/rabbitmq-client-0.1.2.tgz",
-      "integrity": "sha512-ZjL2PP3fbSz5tKhgBRl4G9arQTJj+qqeZFFQMMM+7VWceZ1+GXHqqvBACkwle0YEjOcKbPBGog2cQe21ovKHxw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@linagora/rabbitmq-client/-/rabbitmq-client-0.2.0.tgz",
+      "integrity": "sha512-ZHDHyPsaGSrGZPQMdvHp5bDgyVid9Difhm9ozwy+J4IT8QB/EVYTM60nHEo8oKGyb4HBYutFFoJCFEXXRtDCkg==",
       "license": "MIT",
       "dependencies": {
-        "amqplib": "^0.10.7",
-        "pino": "^9.6.0"
+        "amqplib": "^0.10.7"
       },
       "engines": {
         "node": ">=18"
@@ -10181,12 +10180,6 @@
         "typescript": "^3 || ^4 || ^5"
       }
     },
-    "node_modules/@pinojs/redact": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
-      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
-      "license": "MIT"
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -13189,15 +13182,6 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
-    },
-    "node_modules/atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -21838,15 +21822,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/on-exit-leak-free": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -22582,52 +22557,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/pino": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
-      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
-      "license": "MIT",
-      "dependencies": {
-        "@pinojs/redact": "^0.4.0",
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/pino-abstract-transport/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/pino-std-serializers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
-      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
-      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -23476,22 +23405,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/proggy": {
       "version": "3.0.0",
       "dev": true,
@@ -23780,12 +23693,6 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "license": "MIT"
-    },
-    "node_modules/quick-format-unescaped": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/quick-lru": {
@@ -24083,15 +23990,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/real-require": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -25688,15 +25586,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/sonic-boom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
-      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
@@ -27065,15 +26954,6 @@
       },
       "peerDependencies": {
         "tslib": "^2"
-      }
-    },
-    "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
       }
     },
     "node_modules/through": {
@@ -28624,7 +28504,7 @@
       "version": "0.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@linagora/rabbitmq-client": "^0.1.2",
+        "@linagora/rabbitmq-client": "^0.2.0",
         "@twake/db": "*",
         "@twake/logger": "*",
         "matrix-appservice-bridge": "^11.2.0"

--- a/packages/common-settings-bridge/package.json
+++ b/packages/common-settings-bridge/package.json
@@ -17,7 +17,7 @@
   },
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@linagora/rabbitmq-client": "^0.1.2",
+    "@linagora/rabbitmq-client": "^0.2.0",
     "@twake/db": "*",
     "@twake/logger": "*",
     "matrix-appservice-bridge": "^11.2.0"

--- a/packages/common-settings-bridge/src/bridge.test.ts
+++ b/packages/common-settings-bridge/src/bridge.test.ts
@@ -150,9 +150,11 @@ describe("CommonSettingsBridge", () => {
     it("should initialize RabbitMQ client with URL built from config", () => {
       bridge = new CommonSettingsBridge(mockConfig);
 
-      expect(RabbitMQClient).toHaveBeenCalledWith({
-        url: "amqp://guest:guest@localhost:5672//",
-      });
+      expect(RabbitMQClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "amqp://guest:guest@localhost:5672//",
+        })
+      );
     });
   });
 

--- a/packages/common-settings-bridge/src/bridge.ts
+++ b/packages/common-settings-bridge/src/bridge.ts
@@ -186,6 +186,7 @@ export class CommonSettingsBridge {
       prefetch: rabbitConfig.prefetch,
       maxRetries: rabbitConfig.maxRetries,
       retryDelay: rabbitConfig.retryDelay,
+      logger: this.#log,
     });
 
     this.#log.debug("RabbitMQ client configured");


### PR DESCRIPTION
## What

Just updating the RabbitMQ Client lib from LINAGORA to fix a minor logger discrepancy issue

## Why

The RabbitMQ Client was previously relying on a Pino only compatible logger option. The Common Settings Bridge is using Twake/Logger it self relying on WinstonJS. Therefore it was impossible to pass the CS Bridge logger to the RabbitMQ Client and causing logs to mixed Pino and Winston config/outputs.