### PR TITLE
Hotfix(ToM Server ): Corrects Typo in LDAP Properties

### DIFF
--- a/packages/tom-server/src/user-info-api/services/index.ts
+++ b/packages/tom-server/src/user-info-api/services/index.ts
@@ -163,7 +163,7 @@ class UserInfoService implements IUserInfoService {
             'givenName',
             'mail',
             'mobile',
-            'workplaceFqdn',
+            'workspaceurl',
             'twakeWorkplaceUrl'
           ],
           { uid: localParts }
@@ -393,19 +393,20 @@ class UserInfoService implements IUserInfoService {
             )
             userInfo.phones = [directoryRow.mobile as string]
           }
-          // The Twake Workplace user LDAP schema has changed to favor twakeWorkplaceUrl instead of previously choosen workplaceFqdn
+          // The Twake Workplace user LDAP schema has changed to favor twakeWorkspaceUrl instead of previously choosen workspaceurl or workplaceFqdn
           // https://github.com/linagora/twake-on-matrix/pull/2787
-          // To reflect that change gracefully, ToM returns both deprectaed workplaceFqdn and newly adopted twakeWorkplaceUrl
+          // To reflect that change gracefully, ToM searches both deprecated workspaceurl and newly adopted twakeWorkplaceUrl
           // To also support legacy LDAP users not yet / unsuccessfully migrated we keep looking for both LDAP properties
-          if (directoryRow.twakeWorkplaceUrl || directoryRow.workplaceFqdn) {
-            const workplaceUrl: string = getFirstString(directoryRow.twakeWorkplaceUrl || directoryRow.workplaceFqdn)
+          // And returns deprecated workplaceFqdn along new twakeWorkplaceUrl allowing older TC clients to still understand the info
+          if (directoryRow.twakeWorkplaceUrl || directoryRow.workspaceurl) {
+            const workplaceUrl: string = getFirstString(directoryRow.twakeWorkplaceUrl || directoryRow.workspaceurl)
             this.logger.debug(
-              `[UserInfoService].getBatch: mxid=${id} workplaceFqdn source=directory value="${directoryRow.workplaceFqdn}"`
+              `[UserInfoService].getBatch: mxid=${id} workspaceurl source=directory value="${directoryRow.workspaceurl}"`
             )
             this.logger.debug(
               `[UserInfoService].getBatch: mxid=${id} twakeWorkplaceUrl source=directory value="${directoryRow.twakeWorkplaceUrl}"`
             )
-            this.logger.debug(`[UserInfoService].getBatch: returned workplaceFqdn: ${workplaceUrl}`)
+            this.logger.debug(`[UserInfoService].getBatch: returned workspaceurl: ${workplaceUrl}`)
             userInfo.workplaceFqdn = workplaceUrl
             userInfo.twakeWorkplaceUrl = workplaceUrl
           }

--- a/packages/tom-server/src/user-info-api/services/index.ts
+++ b/packages/tom-server/src/user-info-api/services/index.ts
@@ -164,7 +164,7 @@ class UserInfoService implements IUserInfoService {
             'mail',
             'mobile',
             'workspaceurl',
-            'twakeWorkplaceUrl'
+            'twakeWorkspaceUrl'
           ],
           { uid: localParts }
         )) as unknown as Array<Record<string, string | string[]>>
@@ -395,20 +395,20 @@ class UserInfoService implements IUserInfoService {
           }
           // The Twake Workplace user LDAP schema has changed to favor twakeWorkspaceUrl instead of previously choosen workspaceurl or workplaceFqdn
           // https://github.com/linagora/twake-on-matrix/pull/2787
-          // To reflect that change gracefully, ToM searches both deprecated workspaceurl and newly adopted twakeWorkplaceUrl
+          // To reflect that change gracefully, ToM searches both deprecated workspaceurl and newly adopted twakeWorkspaceUrl
           // To also support legacy LDAP users not yet / unsuccessfully migrated we keep looking for both LDAP properties
-          // And returns deprecated workplaceFqdn along new twakeWorkplaceUrl allowing older TC clients to still understand the info
-          if (directoryRow.twakeWorkplaceUrl || directoryRow.workspaceurl) {
-            const workplaceUrl: string = getFirstString(directoryRow.twakeWorkplaceUrl || directoryRow.workspaceurl)
+          // And returns deprecated workplaceFqdn along new twakeWorkspaceUrl allowing older TC clients to still understand the info
+          if (directoryRow.twakeWorkspaceUrl || directoryRow.workspaceurl) {
+            const workplaceUrl: string = getFirstString(directoryRow.twakeWorkspaceUrl || directoryRow.workspaceurl)
             this.logger.debug(
               `[UserInfoService].getBatch: mxid=${id} workspaceurl source=directory value="${directoryRow.workspaceurl}"`
             )
             this.logger.debug(
-              `[UserInfoService].getBatch: mxid=${id} twakeWorkplaceUrl source=directory value="${directoryRow.twakeWorkplaceUrl}"`
+              `[UserInfoService].getBatch: mxid=${id} twakeWorkspaceUrl source=directory value="${directoryRow.twakeWorkspaceUrl}"`
             )
             this.logger.debug(`[UserInfoService].getBatch: returned workspaceurl: ${workplaceUrl}`)
             userInfo.workplaceFqdn = workplaceUrl
-            userInfo.twakeWorkplaceUrl = workplaceUrl
+            userInfo.twakeWorkspaceUrl = workplaceUrl
           }
         }
 

--- a/packages/tom-server/src/user-info-api/tests/service.test.ts
+++ b/packages/tom-server/src/user-info-api/tests/service.test.ts
@@ -41,7 +41,7 @@ const MOCK_DATA = {
     givenName: 'LDAP First Name',
     mail: 'ldap@example.org',
     mobile: '+1 555 123 4567',
-    twakeWorkplaceUrl: 'workplace.example.com'
+    twakeWorkspaceUrl: 'workplace.example.com'
   },
   COMMON_SETTINGS: {
     display_name: 'CS Display Name',
@@ -77,7 +77,7 @@ type useProfileTwake = {
   givenName: boolean
   mail: boolean
   phone: boolean
-  twakeWorkplaceUrl: boolean
+  twakeWorkspaceUrl: boolean
 }
 const useProfileTwakeDefaults: useProfileTwake = {
   displayName: false,
@@ -85,7 +85,7 @@ const useProfileTwakeDefaults: useProfileTwake = {
   givenName: false,
   mail: false,
   phone: false,
-  twakeWorkplaceUrl: false
+  twakeWorkspaceUrl: false
 }
 /**
  * Configure Matrix mock response.
@@ -104,7 +104,7 @@ const mockUserDB = (
     if (Object.values(useProfileDefaults).every((v) => !v)) {
       userDBMock.get.mockResolvedValue([])
     } else {
-      const { displayName, lastName, givenName, mail, phone, twakeWorkplaceUrl } =
+      const { displayName, lastName, givenName, mail, phone, twakeWorkspaceUrl } =
         useProfileDefaults
       // Extract local part from MATRIX_MXID (e.g., '@dwho:docker.localhost' -> 'dwho')
       const localPart = MATRIX_MXID.replace(/^@([^:]+):.*$/, '$1')
@@ -132,8 +132,8 @@ const mockUserDB = (
       if (phone) {
         profile.mobile = MOCK_DATA.LDAP.mobile
       }
-      if (twakeWorkplaceUrl) {
-        profile.twakeWorkplaceUrl = MOCK_DATA.LDAP.twakeWorkplaceUrl
+      if (twakeWorkspaceUrl) {
+        profile.twakeWorkspaceUrl = MOCK_DATA.LDAP.twakeWorkspaceUrl
       }
 
       userDBMock.get.mockResolvedValue([profile])
@@ -511,13 +511,13 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).not.toHaveProperty('timezone')
     })
 
-    it('Should add twakeWorkplaceUrl from UserDB when available', async () => {
+    it('Should add twakeWorkspaceUrl from UserDB when available', async () => {
       mockMatrix({ displayName: true, avatar: true })
       mockUserDB({
         displayName: true,
         lastName: true,
         givenName: true,
-        twakeWorkplaceUrl: true
+        twakeWorkspaceUrl: true
       })
 
       const user = await svc.get(MATRIX_MXID)
@@ -527,7 +527,7 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).toHaveProperty('avatar_url', MOCK_DATA.MATRIX.avatar_url)
       expect(user).toHaveProperty('sn', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('givenName', MOCK_DATA.LDAP.givenName)
-      expect(user).toHaveProperty('twakeWorkplaceUrl', MOCK_DATA.LDAP.twakeWorkplaceUrl)
+      expect(user).toHaveProperty('twakeWorkspaceUrl', MOCK_DATA.LDAP.twakeWorkspaceUrl)
       expect(user).toHaveProperty('last_name', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('first_name', MOCK_DATA.LDAP.givenName)
       expect(user).not.toHaveProperty('emails')
@@ -536,13 +536,13 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).not.toHaveProperty('timezone')
     })
 
-    it('Should not add twakeWorkplaceUrl when not available in UserDB', async () => {
+    it('Should not add twakeWorkspaceUrl when not available in UserDB', async () => {
       mockMatrix({ displayName: true, avatar: true })
       mockUserDB({
         displayName: true,
         lastName: true,
         givenName: true,
-        twakeWorkplaceUrl: false
+        twakeWorkspaceUrl: false
       })
 
       const user = await svc.get(MATRIX_MXID)
@@ -552,7 +552,7 @@ describe('User Info Service GET with: No feature flags ON', () => {
       expect(user).toHaveProperty('avatar_url', MOCK_DATA.MATRIX.avatar_url)
       expect(user).toHaveProperty('sn', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('givenName', MOCK_DATA.LDAP.givenName)
-      expect(user).not.toHaveProperty('twakeWorkplaceUrl')
+      expect(user).not.toHaveProperty('twakeWorkspaceUrl')
       expect(user).toHaveProperty('last_name', MOCK_DATA.LDAP.sn)
       expect(user).toHaveProperty('first_name', MOCK_DATA.LDAP.givenName)
       expect(user).not.toHaveProperty('emails')

--- a/packages/tom-server/src/user-info-api/types.ts
+++ b/packages/tom-server/src/user-info-api/types.ts
@@ -28,7 +28,7 @@ export interface UserEnrichmentFields {
   language?: string
   timezone?: string
   workplaceFqdn?: string
-  twakeWorkplaceUrl?: string
+  twakeWorkspaceUrl?: string
 }
 
 export interface UserInformation extends UserEnrichmentFields {


### PR DESCRIPTION
## What

A typo fixing change.

## Why

During the different troubleshooting and LDAP reviewing discussions, some typos were made. After a final review we found the correct values and apply them here.